### PR TITLE
Critical Bug fix in the XML Syntax when Defining Default Values for A Global Tile Port

### DIFF
--- a/docs/source/manual/arch_lang/annotate_vpr_arch.rst
+++ b/docs/source/manual/arch_lang/annotate_vpr_arch.rst
@@ -60,7 +60,7 @@ Here is an example:
 .. code-block:: xml
 
   <tile_annotations>
-    <global_port name="<string>" tile_port="<string>" is_clock="<bool>" is_reset="<bool>" is_set="<bool>"/>
+    <global_port name="<string>" tile_port="<string>" is_clock="<bool>" is_reset="<bool>" is_set="<bool>" default_val="<int>"/>
   </tile_annotations>
 
 - ``name="<string>"`` is the port name to appear in the top-level FPGA fabric.
@@ -84,6 +84,8 @@ Here is an example:
 .. note:: A port can only be defined as ``clock`` or ``set`` or ``reset``.
 
 .. note:: All the global port from a physical tile port is only used in operating phase. Any ports for programmable use are not allowed!
+
+- ``default_val="<int>"`` define if the default value for the global port when initialized in testbenches. Valid values are either ``0`` or ``1``. For example, the default value of an active-high reset pin is ``0``, while an active-low reset pin is ``1``.
 
 A more illustrative example:
 

--- a/libopenfpga/libarchopenfpga/src/read_xml_tile_annotation.cpp
+++ b/libopenfpga/libarchopenfpga/src/read_xml_tile_annotation.cpp
@@ -67,7 +67,7 @@ void read_xml_tile_global_port_annotation(pugi::xml_node& xml_tile,
   tile_annotation.set_global_port_is_reset(tile_global_port_id, get_attribute(xml_tile, "is_reset", loc_data, pugiutil::ReqOpt::OPTIONAL).as_bool(false));
 
   /* Get default_value attributes */
-  tile_annotation.set_global_port_default_value(tile_global_port_id, get_attribute(xml_tile, "default_value", loc_data, pugiutil::ReqOpt::OPTIONAL).as_int(0));
+  tile_annotation.set_global_port_default_value(tile_global_port_id, get_attribute(xml_tile, "default_val", loc_data, pugiutil::ReqOpt::OPTIONAL).as_int(0));
 
   /* Ensure valid port attributes */
   if (false == tile_annotation.valid_global_port_attributes(tile_global_port_id)) {

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -218,7 +218,7 @@
   </direct_connection>
   <tile_annotations>
     <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
-    <global_port name="reset" tile_port="clb.reset" is_reset="true" default_val="1"/>
+    <global_port name="reset" tile_port="clb.reset" is_reset="true" default_val="0"/>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->


### PR DESCRIPTION
The XML syntax to define a default value for a global tile port was ``default_value="<int>"`` while in architecture example ``default_val="<int>"`` was used.
This has caused the default value definition in these examples to be dropped by parser.
This PR aims to fix this critical bug by setting the expected syntax as ``default_val="<int>"``, being consistent with circuit model port definition.