### PR TITLE
Bug fix in LUT circuit model documentation

### DIFF
--- a/docs/source/manual/arch_lang/circuit_model_examples.rst
+++ b/docs/source/manual/arch_lang/circuit_model_examples.rst
@@ -825,7 +825,7 @@ The code describing this LUT is:
     <port type="output" prefix="lut2_out" size="1" lut_frac_level="3" lut_output_mask="0"/>
     <port type="output" prefix="lut3_out" size="1" lut_output_mask="0"/>
     <port type="sram" prefix="sram" size="8"/>
-    <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="ccff" default_val="1"/>
+    <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="ccff" default_val="0"/>
   </circuit_model>
 
 This example shows:
@@ -833,9 +833,9 @@ This example shows:
   - There is a SRAM cell to switch the operating mode of this LUT, configured by a configuration-chain flip-flop ``ccff``
   - The last input ``in[2]`` of LUT will be tri-stated in dual-LUT2 mode.
   - An 2-input OR gate will be wired to the last input ``in[2]`` to tri-state the input. The mode-select SRAM will be wired to an input of the OR gate. 
-    It means that when the mode-selection bit is '1', the LUT will operate in dual-LUT5 mode.
+    It means that when the mode-selection bit is '0', the LUT will operate in dual-LUT2 mode.
   - There will be two outputs wired to the 5th stage of routing multiplexer (the outputs of dual 5-input LUTs) 
-  - By default, the mode-selection configuration bit will be '1', indicating that by default the LUT will operate in dual-LUT2 mode.
+  - By default, the mode-selection configuration bit will be '0', indicating that by default the LUT will operate in dual-LUT2 mode.
 
 :numref:`fig_std_frac_lut` illustrates the detailed schematic of a standard fracturable 6-input LUT, where the 5th and 6th inputs can be pull up/down to a fixed logic value to enable LUT4 and LUT5 outputs.
 

--- a/docs/source/manual/arch_lang/circuit_model_examples.rst
+++ b/docs/source/manual/arch_lang/circuit_model_examples.rst
@@ -833,8 +833,8 @@ This example shows:
   - There is a SRAM cell to switch the operating mode of this LUT, configured by a configuration-chain flip-flop ``ccff``
   - The last input ``in[2]`` of LUT will be tri-stated in dual-LUT2 mode.
   - An 2-input OR gate will be wired to the last input ``in[2]`` to tri-state the input. The mode-select SRAM will be wired to an input of the OR gate. 
-    It means that when the mode-selection bit is '0', the LUT will operate in dual-LUT2 mode.
-  - There will be two outputs wired to the 5th stage of routing multiplexer (the outputs of dual 5-input LUTs) 
+    It means that when the mode-selection bit is '0', the LUT will operate in dual-LUT3 mode.
+  - There will be two outputs wired to the 2th stage of routing multiplexer (the outputs of dual 2-input LUTs) 
   - By default, the mode-selection configuration bit will be '0', indicating that by default the LUT will operate in dual-LUT2 mode.
 
 :numref:`fig_std_frac_lut` illustrates the detailed schematic of a standard fracturable 6-input LUT, where the 5th and 6th inputs can be pull up/down to a fixed logic value to enable LUT4 and LUT5 outputs.

--- a/docs/source/manual/arch_lang/figures/native_frac_lut.svg
+++ b/docs/source/manual/arch_lang/figures/native_frac_lut.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="156.96 201.47352 710.0226 352.01553" width="710.0226" height="352.01553">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" viewBox="156.96 201.47352 710.0226 352.01553" width="710.0226" height="352.01553">
   <defs>
     <font-face font-family="Times New Roman" font-size="15" panose-1="2 2 8 3 7 5 5 2 3 4" units-per-em="1000" underline-position="-108.88672" underline-thickness="95.21484" slope="0" x-height="456.54297" cap-height="662.1094" ascent="891.1133" descent="-216.3086" font-weight="700">
       <font-face-src>
@@ -28,8 +28,8 @@
       </font-face-src>
     </font-face>
   </defs>
-  <metadata> Produced by OmniGraffle 7.18\n2020-11-26 19:31:38 +0000</metadata>
-  <g id="native_frac_lut" fill="none" stroke="none" stroke-opacity="1" stroke-dasharray="none" fill-opacity="1">
+  <metadata> Produced by OmniGraffle 7.18\n2020-12-04 21:35:09 +0000</metadata>
+  <g id="native_frac_lut" stroke-dasharray="none" stroke="none" fill="none" fill-opacity="1" stroke-opacity="1">
     <title>native_frac_lut</title>
     <g id="native_frac_lut_Schematic">
       <title>Schematic</title>
@@ -210,32 +210,32 @@
       </g>
       <g id="Graphic_56">
         <text transform="translate(159.95758 219.6969)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in0</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in5</tspan>
         </text>
       </g>
       <g id="Graphic_55">
         <text transform="translate(160.95758 244.97972)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in1</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in4</tspan>
         </text>
       </g>
       <g id="Graphic_54">
         <text transform="translate(160.95758 273.70744)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in2</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in3</tspan>
         </text>
       </g>
       <g id="Graphic_53">
         <text transform="translate(159.95758 284.87993)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in3</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in2</tspan>
         </text>
       </g>
       <g id="Graphic_52">
         <text transform="translate(158.9574 297.61358)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in4</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in1</tspan>
         </text>
       </g>
       <g id="Graphic_51">
         <text transform="translate(158.9574 309.19286)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in5</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in0</tspan>
         </text>
       </g>
       <g id="Line_33">

--- a/docs/source/manual/arch_lang/figures/std_frac_lut.svg
+++ b/docs/source/manual/arch_lang/figures/std_frac_lut.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="156.96 182.62277 710.0226 370.8663" width="710.0226" height="370.8663">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" viewBox="156.96 182.62277 710.0226 370.8663" width="710.0226" height="370.8663">
   <defs>
     <font-face font-family="Times New Roman" font-size="15" panose-1="2 2 8 3 7 5 5 2 3 4" units-per-em="1000" underline-position="-108.88672" underline-thickness="95.21484" slope="0" x-height="456.54297" cap-height="662.1094" ascent="891.1133" descent="-216.3086" font-weight="700">
       <font-face-src>
@@ -33,8 +33,8 @@
       </font-face-src>
     </font-face>
   </defs>
-  <metadata> Produced by OmniGraffle 7.18\n2020-11-26 19:31:38 +0000</metadata>
-  <g id="std_frac_lut" fill="none" stroke="none" stroke-opacity="1" stroke-dasharray="none" fill-opacity="1">
+  <metadata> Produced by OmniGraffle 7.18\n2020-12-04 21:35:09 +0000</metadata>
+  <g id="std_frac_lut" stroke-dasharray="none" stroke="none" fill="none" fill-opacity="1" stroke-opacity="1">
     <title>std_frac_lut</title>
     <g id="std_frac_lut_Schematic">
       <title>Schematic</title>
@@ -203,33 +203,33 @@
         <line x1="457.1989" y1="435.57314" x2="478.98" y2="435.3829" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
       </g>
       <g id="Graphic_56">
-        <text transform="translate(159.95758 219.6969)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in0</tspan>
+        <text transform="translate(161.95758 219.6969)" fill="black">
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in5</tspan>
         </text>
       </g>
       <g id="Graphic_55">
         <text transform="translate(161.22984 239.87654)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in1</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in4</tspan>
         </text>
       </g>
       <g id="Graphic_54">
         <text transform="translate(160.95758 273.70744)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in2</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in3</tspan>
         </text>
       </g>
       <g id="Graphic_53">
         <text transform="translate(159.95758 284.87993)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in3</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in2</tspan>
         </text>
       </g>
       <g id="Graphic_52">
         <text transform="translate(158.9574 297.61358)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in4</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in1</tspan>
         </text>
       </g>
       <g id="Graphic_51">
         <text transform="translate(158.9574 309.19286)" fill="black">
-          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in5</tspan>
+          <tspan font-family="Times New Roman" font-size="15" font-style="italic" font-weight="700" fill="black" x="0" y="13">in0</tspan>
         </text>
       </g>
       <g id="Group_43">


### PR DESCRIPTION
- Correct the input port names for fracturable LUT schematic examples.
- Correct mode-select bits for dual-LUT2 modes