### PR TITLE
Support I/O tiles in the center part of FPGA grid layout

### DIFF
--- a/.github/workflows/basic_reg_test.sh
+++ b/.github/workflows/basic_reg_test.sh
@@ -102,6 +102,8 @@ echo -e "Testing tiles with pins only on top and right sides";
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/tile_organization/top_right_custom_pins --debug --show_thread_logs
 echo -e "Testing tiles with pins only on bottom and right sides";
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/tile_organization/bottom_right_custom_pins --debug --show_thread_logs
+echo -e "Testing tiles with I/O in center grid";
+python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/tile_organization/tileable_io --debug --show_thread_logs
 
 echo -e "Testing global port definition from tiles";
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/global_tile_ports/global_tile_clock --debug --show_thread_logs

--- a/openfpga/src/base/openfpga_naming.cpp
+++ b/openfpga/src/base/openfpga_naming.cpp
@@ -1003,7 +1003,7 @@ std::string generate_grid_block_netlist_name(const std::string& block_name,
   /* Add the name of physical block */
   std::string module_name(block_name);
 
-  if (true == is_block_io) {
+  if ((true == is_block_io) && (NUM_SIDES != io_side)) {
     SideManager side_manager(io_side);
     module_name += std::string("_");
     module_name += std::string(side_manager.to_string());

--- a/openfpga/src/base/openfpga_pb_pin_fixup.cpp
+++ b/openfpga/src/base/openfpga_pb_pin_fixup.cpp
@@ -157,8 +157,6 @@ void update_pb_pin_with_post_routing_results(const DeviceContext& device_ctx,
       if (true == is_empty_type(device_ctx.grid[x][y].type)) {
         continue;
       }
-      /* We must have an regular (non-I/O) type here */
-      VTR_ASSERT(false == is_io_type(device_ctx.grid[x][y].type));
       /* Get the mapped blocks to this grid */
       for (const ClusterBlockId& cluster_blk_id : placement_ctx.grid_blocks[x][y].blocks) {
         /* Skip invalid ids */ 

--- a/openfpga/src/fabric/build_grid_module_duplicated_pins.cpp
+++ b/openfpga/src/fabric/build_grid_module_duplicated_pins.cpp
@@ -66,7 +66,7 @@ void add_grid_module_duplicated_pb_type_ports(ModuleManager& module_manager,
    * Otherwise, we will iterate all the 4 sides  
    */
   if (true == is_io_type(grid_type_descriptor)) {
-    grid_pin_sides.push_back(find_grid_module_pin_side(grid_type_descriptor, border_side));
+    grid_pin_sides = find_grid_module_pin_sides(grid_type_descriptor, border_side);
   } else {
     grid_pin_sides = {TOP, RIGHT, BOTTOM, LEFT}; 
   }
@@ -147,12 +147,9 @@ void add_grid_module_net_connect_duplicated_pb_graph_pin(ModuleManager& module_m
    * Otherwise, we will iterate all the 4 sides  
    */
   if (true == is_io_type(grid_type_descriptor)) {
-    grid_pin_sides.push_back(find_grid_module_pin_side(grid_type_descriptor, border_side));
+    grid_pin_sides = find_grid_module_pin_sides(grid_type_descriptor, border_side);
   } else {
-    grid_pin_sides.push_back(TOP); 
-    grid_pin_sides.push_back(RIGHT); 
-    grid_pin_sides.push_back(BOTTOM); 
-    grid_pin_sides.push_back(LEFT); 
+    grid_pin_sides = {TOP, RIGHT, BOTTOM, LEFT}; 
   }
 
   /* num_pins/capacity = the number of pins that each type_descriptor has.

--- a/openfpga/src/fabric/build_grid_module_utils.h
+++ b/openfpga/src/fabric/build_grid_module_utils.h
@@ -17,8 +17,8 @@
 /* begin namespace openfpga */
 namespace openfpga {
 
-e_side find_grid_module_pin_side(t_physical_tile_type_ptr grid_type_descriptor,
-                                 const e_side& border_side);
+std::vector<e_side> find_grid_module_pin_sides(t_physical_tile_type_ptr grid_type_descriptor,
+                                               const e_side& border_side);
 
 void add_grid_module_net_connect_pb_graph_pin(ModuleManager& module_manager,
                                               const ModuleId& grid_module,

--- a/openfpga/src/fabric/build_grid_modules.cpp
+++ b/openfpga/src/fabric/build_grid_modules.cpp
@@ -52,7 +52,7 @@ void add_grid_module_pb_type_ports(ModuleManager& module_manager,
    * Otherwise, we will iterate all the 4 sides  
    */
   if (true == is_io_type(grid_type_descriptor)) {
-    grid_pin_sides.push_back(find_grid_module_pin_side(grid_type_descriptor, border_side));
+    grid_pin_sides = find_grid_module_pin_sides(grid_type_descriptor, border_side);
   } else {
     grid_pin_sides = {TOP, RIGHT, BOTTOM, LEFT}; 
   }
@@ -981,11 +981,6 @@ void build_physical_tile_module(ModuleManager& module_manager,
                                 const e_side& border_side,
                                 const bool& duplicate_grid_pin,
                                 const bool& verbose) {
-  /* Check code: if this is an IO block, the border side MUST be valid */
-  if (true == is_io_type(phy_block_type)) {
-    VTR_ASSERT(NUM_SIDES != border_side);
-  }
-
   /* Create a Module for the top-level physical block, and add to module manager */
   std::string grid_module_name = generate_grid_block_module_name(std::string(GRID_MODULE_NAME_PREFIX), 
                                                                  std::string(phy_block_type->name),

--- a/openfpga/src/fabric/build_top_module.cpp
+++ b/openfpga/src/fabric/build_top_module.cpp
@@ -120,8 +120,6 @@ vtr::Matrix<size_t> add_top_module_grid_instances(ModuleManager& module_manager,
         grid_instance_ids[ix][iy] = grid_instance_ids[root_grid_coord.x()][root_grid_coord.y()];
         continue;
       }
-      /* We should not meet any I/O grid */
-      VTR_ASSERT(false == is_io_type(grids[ix][iy].type));
       /* Add a grid module to top_module*/
       vtr::Point<size_t> grid_coord(ix, iy);
       grid_instance_ids[ix][iy] = add_top_module_grid_instance(module_manager, top_module,

--- a/openfpga/src/fpga_bitstream/build_grid_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_grid_bitstream.cpp
@@ -710,8 +710,6 @@ void build_grid_bitstream(BitstreamManager& bitstream_manager,
         || (0 < grids[ix][iy].height_offset) ) {
         continue;
       }
-      /* We should not meet any I/O grid */
-      VTR_ASSERT(true != is_io_type(grids[ix][iy].type));
       /* Add a grid module to top_module*/
       vtr::Point<size_t> grid_coord(ix, iy);
       build_physical_block_bitstream(bitstream_manager, top_block, module_manager,

--- a/openfpga/src/fpga_bitstream/build_routing_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_routing_bitstream.cpp
@@ -463,6 +463,11 @@ void build_connection_block_bitstreams(BitstreamManager& bitstream_manager,
       ModuleId cb_module = module_manager.find_module(cb_module_name);
       VTR_ASSERT(true == module_manager.valid_module_id(cb_module));
 
+      /* Bypass empty blocks which have none configurable children */
+      if (0 == count_module_manager_module_configurable_children(module_manager, cb_module)) {
+        continue;
+      } 
+
       /* Create a block for the bitstream which corresponds to the Switch block */
       ConfigBlockId cb_configurable_block = bitstream_manager.add_block(generate_connection_block_module_name(cb_type, cb_coord));
       /* Set switch block as a child of top block */
@@ -529,6 +534,11 @@ void build_routing_bitstream(BitstreamManager& bitstream_manager,
       } 
       ModuleId sb_module = module_manager.find_module(sb_module_name);
       VTR_ASSERT(true == module_manager.valid_module_id(sb_module));
+
+      /* Bypass empty blocks which have none configurable children */
+      if (0 == count_module_manager_module_configurable_children(module_manager, sb_module)) {
+        continue;
+      } 
 
       /* Create a block for the bitstream which corresponds to the Switch block */
       ConfigBlockId sb_configurable_block = bitstream_manager.add_block(generate_switch_block_module_name(sb_coord));

--- a/openfpga/src/fpga_sdc/analysis_sdc_grid_writer.cpp
+++ b/openfpga/src/fpga_sdc/analysis_sdc_grid_writer.cpp
@@ -618,9 +618,6 @@ void print_analysis_sdc_disable_unused_grids(std::fstream& fp,
   /* Process unused core grids */
   for (size_t ix = 1; ix < grids.width() - 1; ++ix) {
     for (size_t iy = 1; iy < grids.height() - 1; ++iy) {
-      /* We should not meet any I/O grid */
-      VTR_ASSERT(false == is_io_type(grids[ix][iy].type));
-
       print_analysis_sdc_disable_unused_grid(fp, vtr::Point<size_t>(ix, iy),
                                              grids, device_annotation, cluster_annotation, place_annotation,
                                              module_manager, NUM_SIDES);

--- a/openfpga/src/fpga_verilog/verilog_grid.cpp
+++ b/openfpga/src/fpga_verilog/verilog_grid.cpp
@@ -286,11 +286,6 @@ void print_verilog_physical_tile_netlist(NetlistManager& netlist_manager,
                                          t_physical_tile_type_ptr phy_block_type,
                                          const e_side& border_side,
                                          const bool& use_explicit_mapping) {
-  /* Check code: if this is an IO block, the border side MUST be valid */
-  if (true == is_io_type(phy_block_type)) {
-    VTR_ASSERT(NUM_SIDES != border_side);
-  }
-  
   /* Give a name to the Verilog netlist */
   /* Create the file name for Verilog */
   std::string verilog_fname(subckt_dir 

--- a/openfpga_flow/tasks/basic_tests/tile_organization/tileable_io/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/tileable_io/config/task.conf
@@ -1,0 +1,36 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=2x2
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/or2/or2.v
+
+[SYNTHESIS_PARAM]
+bench0_top = or2
+bench0_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/vpr_arch/README.md
+++ b/openfpga_flow/vpr_arch/README.md
@@ -5,7 +5,8 @@ Please reveal the following architecture features in the names to help quickly s
   * The keyword 'frac' is to specify if fracturable LUT is used or not.
   * The keyword 'Native' is to specify if fracturable LUT design is a native one (without mode switch) or a standard one (with mode switch).
 - N<le\_size>: Number of logic elements for a CLB. If you have multiple CLB architectures, this should be largest number.
-- tileable: If the routing architecture is tileable or not.
+- tileable<IO>: If the routing architecture is tileable or not. 
+  * The keyword 'IO' specifies if the I/O tile is tileable or not
 - adder\_chain: If hard adder/carry chain is used inside CLBs
 - register\_chain: If shift register chain is used inside CLBs
 - scan\_chain: If scan chain testing infrastructure is used inside CLBs

--- a/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
@@ -43,8 +43,8 @@
       <output name="inpad" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="top">io.outpad io.inpad</loc>
-        <loc side="right">io.outpad io.inpad</loc>
+        <loc side="top">io.outpad</loc>
+        <loc side="right">io.inpad</loc>
       </pinlocations>
     </tile>
     <tile name="clb" area="53894">

--- a/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
@@ -62,44 +62,20 @@
   <!-- Physical descriptions begin -->
   <layout tileable="true">
     <auto_layout aspect_ratio="1.0">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <perimeter type="io" priority="100"/>
-      <!-- The top row should be empty -->
-      <row type="EMPTY" starty="H-1" priority="101"/>
-      <!-- The rightmost column should be empty -->
-      <col type="EMPTY" startx="W-1" priority="101"/>
-      <!-- A row of I/O in the H-2 row -->
-      <row type="io" starty="H-2" priority="100"/>
-      <!-- A column of I/O in the W-2 column -->
-      <col type="io" startx="W-2" priority="100"/>
-      <!-- Bottom-left corner should be empty -->
-      <single type="EMPTY" x="0" y="0" priority="101"/>
-      <!-- Top-left corner should be empty -->
-      <single type="EMPTY" x="0" y="H-2" priority="101"/>
-      <!-- Bottom-right corner should be empty -->
-      <single type="EMPTY" x="W-2" y="0" priority="101"/>
-      <!--Fill with 'clb'-->
-      <fill type="clb" priority="10"/>
+      <!-- Perimeter of 'EMPTY' blocks -->
+      <perimeter type="EMPTY" priority="100"/>
+      <!--Fill with 'io'-->
+      <fill type="io" priority="10"/>
+      <!-- Build an inner region of clbs -->
+      <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/> 
     </auto_layout>
-    <fixed_layout name="2x2" width="5" height="5">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <perimeter type="io" priority="100"/>
-      <!-- The top row should be empty -->
-      <row type="EMPTY" starty="H-1" priority="101"/>
-      <!-- The rightmost column should be empty -->
-      <col type="EMPTY" startx="W-1" priority="101"/>
-      <!-- A row of I/O in the H-2 row -->
-      <row type="io" starty="H-2" priority="100"/>
-      <!-- A column of I/O in the W-2 column -->
-      <col type="io" startx="W-2" priority="100"/>
-      <!-- Bottom-left corner should be empty -->
-      <single type="EMPTY" x="0" y="0" priority="101"/>
-      <!-- Top-left corner should be empty -->
-      <single type="EMPTY" x="0" y="H-2" priority="101"/>
-      <!-- Bottom-right corner should be empty -->
-      <single type="EMPTY" x="W-2" y="0" priority="101"/>
-      <!--Fill with 'clb'-->
-      <fill type="clb" priority="10"/>
+    <fixed_layout name="2x2" width="6" height="6">
+      <!-- Perimeter of 'EMPTY' blocks -->
+      <perimeter type="EMPTY" priority="100"/>
+      <!--Fill with 'io'-->
+      <fill type="io" priority="10"/>
+      <!-- Build an inner region of clbs -->
+      <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/> 
     </fixed_layout>
   </layout>
   <device>

--- a/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
@@ -72,6 +72,12 @@
       <row type="io" starty="H-2" priority="100"/>
       <!-- A column of I/O in the W-2 column -->
       <col type="io" startx="W-2" priority="100"/>
+      <!-- Bottom-left corner should be empty -->
+      <single type="EMPTY" x="0" y="0" priority="101"/>
+      <!-- Top-left corner should be empty -->
+      <single type="EMPTY" x="0" y="H-2" priority="101"/>
+      <!-- Bottom-right corner should be empty -->
+      <single type="EMPTY" x="W-2" y="0" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </auto_layout>
@@ -86,6 +92,12 @@
       <row type="io" starty="H-2" priority="100"/>
       <!-- A column of I/O in the W-2 column -->
       <col type="io" startx="W-2" priority="100"/>
+      <!-- Bottom-left corner should be empty -->
+      <single type="EMPTY" x="0" y="0" priority="101"/>
+      <!-- Top-left corner should be empty -->
+      <single type="EMPTY" x="0" y="H-2" priority="101"/>
+      <!-- Bottom-right corner should be empty -->
+      <single type="EMPTY" x="W-2" y="0" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </fixed_layout>

--- a/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
@@ -1,0 +1,305 @@
+<!-- 
+  Architecture with no fracturable LUTs
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 4, N = 4
+  - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
+
+  Details on Modelling:
+
+  Based on flagship k6_frac_N10_mem32K_40nm.xml architecture.  This architecture has no fracturable LUTs nor any heterogeneous blocks.
+
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" capacity="8" area="0">
+      <equivalent_sites>
+        <site pb_type="io"/>
+      </equivalent_sites>
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="custom">
+        <loc side="top">io.outpad io.inpad</loc>
+        <loc side="right">io.outpad io.inpad</loc>
+      </pinlocations>
+    </tile>
+    <tile name="clb" area="53894">
+      <equivalent_sites>
+        <site pb_type="clb"/>
+      </equivalent_sites>
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="spread"/>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <!-- The top row should be empty -->
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <!-- The rightmost column should be empty -->
+      <col type="EMPTY" startx="W-1" priority="101"/>
+      <!-- A row of I/O in the H-2 row -->
+      <row type="io" starty="H-2" priority="100"/>
+      <!-- A column of I/O in the W-2 column -->
+      <col type="io" startx="W-2" priority="100"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="5" height="5">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <!-- The top row should be empty -->
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <!-- The rightmost column should be empty -->
+      <col type="EMPTY" startx="W-1" priority="101"/>
+      <!-- A row of I/O in the H-2 row -->
+      <row type="io" starty="H-2" priority="100"/>
+      <!-- A column of I/O in the W-2 column -->
+      <col type="io" startx="W-2" priority="100"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	       book area formula. This means the mux transistors are about 5x minimum drive strength.
+	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+	       2.5x when looking up in Jeff's tables.
+	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" packable="false">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
+             Each basic logic element has a 4-LUT that can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                261e-12
+                261e-12
+                261e-12
+                261e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+		     The delays below come from Stratix IV. the delay through a connection block
+		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+		     delay within the crossbar is 95 ps. 
+		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+               naive specification).
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
+</architecture>

--- a/vpr/src/tileable_rr_graph/rr_graph_builder_utils.cpp
+++ b/vpr/src/tileable_rr_graph/rr_graph_builder_utils.cpp
@@ -52,11 +52,15 @@ e_side determine_io_grid_pin_side(const vtr::Point<size_t>& device_size,
     return TOP; /* Such I/O has only Top side pins */
   } else if (0 == grid_coordinate.x()) { /* LEFT side IO of FPGA */
     return RIGHT; /* Such I/O has only Right side pins */
-  } else {
-    VTR_LOGF_ERROR(__FILE__, __LINE__,
-                   "I/O Grid is in the center part of FPGA! Currently unsupported!\n");
-    exit(1);
+  } else if ((grid_coordinate.x() < device_size.x()) && (grid_coordinate.y() < device_size.y())) {
+    /* I/O grid in the center grid */
+    return NUM_SIDES;
   }
+  VTR_LOGF_ERROR(__FILE__, __LINE__,
+                 "Invalid coordinate (%lu, %lu) for I/O Grid whose size is (%lu, %lu)!\n",
+                grid_coordinate.x(), grid_coordinate.y(),
+                device_size.x(), device_size.y());
+  exit(1);
 }
 
 /* Deteremine the side of a pin of a grid */

--- a/vpr/src/tileable_rr_graph/rr_graph_builder_utils.cpp
+++ b/vpr/src/tileable_rr_graph/rr_graph_builder_utils.cpp
@@ -115,7 +115,7 @@ size_t get_grid_num_pins(const t_grid_tile& cur_grid,
   for (const e_side& side : {TOP, RIGHT, BOTTOM, LEFT}) {
     /* skip unwanted sides */
     if ( (true == is_io_type(cur_grid.type))
-      && (side != io_side) ) { 
+      && (side != io_side) && (NUM_SIDES != io_side)) { 
       continue;
     }
     /* Get pin list */

--- a/vpr/src/tileable_rr_graph/tileable_rr_graph_node_builder.cpp
+++ b/vpr/src/tileable_rr_graph/tileable_rr_graph_node_builder.cpp
@@ -379,7 +379,7 @@ void load_one_grid_opin_nodes_basic_info(RRGraph& rr_graph,
         SideManager side_manager(side);
         /* skip unwanted sides */
         if ( (true == is_io_type(cur_grid.type))
-          && (side != io_side_manager.to_size_t()) ) { 
+          && (side != io_side_manager.to_size_t()) && (NUM_SIDES != io_side) ) { 
           continue;
         }
         /* Find OPINs */
@@ -442,7 +442,7 @@ void load_one_grid_ipin_nodes_basic_info(RRGraph& rr_graph,
         SideManager side_manager(side);
         /* skip unwanted sides */
         if ( (true == is_io_type(cur_grid.type))
-          && (side != io_side_manager.to_size_t()) ) { 
+          && (side != io_side_manager.to_size_t()) && (NUM_SIDES != io_side) ) { 
           continue;
         }
 


### PR DESCRIPTION
- Add a new example architecture where I/O tiles sit in the center part of FPGA grids.
- Relax I/O restrictions in FPGA tools to unlock this feature

  Example grid layout (from VPR GUI):

![image](https://user-images.githubusercontent.com/11499826/101230356-1875cb80-3662-11eb-8709-e1d7411e8291.png)

  
![image](https://user-images.githubusercontent.com/11499826/101230367-2e838c00-3662-11eb-909e-3ef2fd255d34.png)
