### PR TITLE
Organize Routing Multiplexer Verilog Netlist

### DIFF
--- a/openfpga/src/fpga_verilog/verilog_constants.h
+++ b/openfpga/src/fpga_verilog/verilog_constants.h
@@ -32,6 +32,7 @@ constexpr char* SUBMODULE_VERILOG_FILE_NAME = "sub_module.v";
 constexpr char* LOGIC_BLOCK_VERILOG_FILE_NAME = "logic_blocks.v";
 constexpr char* LUTS_VERILOG_FILE_NAME = "luts.v";
 constexpr char* ROUTING_VERILOG_FILE_NAME = "routing.v";
+constexpr char* MUX_PRIMITIVES_VERILOG_FILE_NAME = "mux_primitives.v";
 constexpr char* MUXES_VERILOG_FILE_NAME = "muxes.v";
 constexpr char* LOCAL_ENCODER_VERILOG_FILE_NAME = "local_encoder.v";
 constexpr char* ARCH_ENCODER_VERILOG_FILE_NAME = "arch_encoder.v";


### PR DESCRIPTION
Currently, all the Verilog modules of routing multiplexers are outputted into an unique netlist.
This leads to a large Verilog netlists, which is hard to users to review and modify even using scripts.

This PR Split MUX Verilog netlist into two separated files: 
- one contains only primitive module, such as `mux_size12_basis_size4`, which are used to build large routing multiplexers, are placed in the same netlist. Users can freely modify this netlist to replace with custom cells.
- the other contains the top-level modules