### PR TITLE
Bug fix on the incompatible sphinx bibtex version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@
 #recommonmark
 
 #Handle references in bibtex format
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2.0.0
 
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:


### PR DESCRIPTION
Documentation build is currently failing due to a new released major version of `sphnix bibitex` which is not incompatible. This PR aims to the solve the build errors by pinning `sphinxcontrib-bibtex` to a compatible version.