### PR TITLE
Add default pull request template to the right position that Github requires

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+---
+name: Pull request
+about: Push a change to this project
+---
+
+### Motivate of the pull request
+- [ ] To address an existing issue. If so, please provide a link to the issue.
+- [ ] Breaking new feature. If so, please decribe details in the description part.
+
+### Describe the technical details
+- What is currently done? (Provide issue link if applicable)
+- What does this pull request change?
+
+### Which part of the code base require a change
+**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
+- [ ] VPR
+- [ ] OpenFPGA libraries
+- [ ] FPGA-Verilog
+- [ ] FPGA-Bitstream
+- [ ] FPGA-SDC
+- [ ] FPGA-SPICE
+- [ ] Flow scripts
+- [ ] Architecture library
+- [ ] Cell library
+
+### Checklist of the pull request
+- [ ] Require code changes. 
+- [ ] Require new tests to be added
+- [ ] Require an update on documentation
+
+### Impact of the pull request
+- [ ] Require a change on Quality of Results (QoR)
+- [ ] Break back-compatibility. If so, please list who may be influenced.


### PR DESCRIPTION
Previously the pull request template placed in `.github` directory is not considered by Github as a default template. 
This PR aims to fix the problem by placing the pull request template file in the right place as Github requests. 