### PR TITLE
Support Multiple Clock Definition in Testbench and SDC Generators

### DIFF
--- a/docs/source/manual/arch_lang/annotate_vpr_arch.rst
+++ b/docs/source/manual/arch_lang/annotate_vpr_arch.rst
@@ -49,6 +49,8 @@ Similar to the Switch Boxes and Connection Blocks, the channel wire segments in 
 
 - ``circuit_model_name="<string>"`` should match a circuit model whose type is ``chan_wire`` defined in :ref:`circuit_library`.
 
+.. _annotate_vpr_arch_physical_tile_annotation:
+
 Physical Tile Annotation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/manual/arch_lang/circuit_library.rst
+++ b/docs/source/manual/arch_lang/circuit_library.rst
@@ -136,6 +136,8 @@ Pass Gate Logic
 .. note:: pass-gate logic are used in building multiplexers and LUTs.
 
 
+.. _circuit_library_circuit_port:
+
 Circuit Port
 ^^^^^^^^^^^^
 

--- a/docs/source/manual/arch_lang/simulation_setting.rst
+++ b/docs/source/manual/arch_lang/simulation_setting.rst
@@ -10,7 +10,10 @@ General organization is as follows
 
     <openfpga_simulation_setting>
       <clock_setting>
-        <operating frequency="<int>|<string>" num_cycles="<int>|<string>" slack="<float>"/>
+        <operating frequency="<int>|<string>" num_cycles="<int>|<string>" slack="<float>">
+          <clock name="<string>" port="<string>" frequency="<float>"/>
+          ...
+        </operating>
         <programming frequency="<int>"/>
       </clock_setting>
       <simulator_option>
@@ -54,13 +57,17 @@ We should the full syntax in the code block below and then provide details on ea
 .. code-block:: xml
 
   <clock_setting>
-    <operating frequency="<float>|<string>" num_cycles="<int>|<string>" slack="<float>"/>
+    <operating frequency="<float>|<string>" num_cycles="<int>|<string>" slack="<float>">
+      <clock name="<string>" port="<string>" frequency="<float>"/>
+      ...
+    </operating>
     <programming frequency="<float>"/>
   </clock_setting>
 
 Operating clock setting
 ^^^^^^^^^^^^^^^^^^^^^^^
 Operating clocks are defined under the XML node ``<operating>``
+To support FPGA fabrics with multiple clocks, OpenFPGA allows users to define a default operating clock frequency as well as a set of clock ports using different frequencies.
 
 .. option:: <operating frequency="<float>|<string>" num_cycles="<int>|<string>" slack="<float>"/>
 
@@ -69,6 +76,8 @@ Operating clocks are defined under the XML node ``<operating>``
   Alternatively, users can bind the frequency to the maximum clock frequency analyzed by VPR STA engine.
   This is very useful to validate the maximum operating frequency for users' implementations
   In such case, the value of this attribute should be a reserved word ``auto``.
+
+.. note:: The frequency is considered as a default operating clock frequency, which will be used when a clock pin of a multi-clock FPGA fabric lacks explicit clock definition.
 
 - ``num_cycles="<int>|<string>"``
   can be either ``auto`` or an integer. When set to ``auto``, OpenFPGA will infer the number of clock cycles from the average/median of all the signal activities.
@@ -85,6 +94,22 @@ Operating clocks are defined under the XML node ``<operating>``
 .. note:: Only valid when option ``frequency`` is set to ``auto``
 
 .. warning:: Avoid to use a negative slack! This may cause your simulation to fail!
+
+.. option:: <clock name="<string>" port="<string>" frequency="<float>"/>
+
+- ``name="<string>``
+  Specify a unique name for a clock signal. The name will be used in generating clock stimulus in testbenches.
+
+- ``port="<string>``
+  Specify the clock port which the clock signal should be applied to. The clock port must be a valid clock port defined in OpenFPGA architecture description. Explicit index is required, e.g., ``clk[1:1]``. Otherwise, default index ``0`` will be considered, e.g., ``clk`` will be translated as ``clk[0:0]``.
+
+.. note:: You can define clock ports either through the tile annotation in :ref:`annotate_vpr_arch_physical_tile_annotation` or :ref:`circuit_library_circuit_port`.
+
+- ``frequency="<float>``
+  Specify frequency of a clock signal in the unit of ``[Hz]`` 
+
+.. warning:: Currently, we only allow operating clocks to be overwritten!!!
+
 
 Programming clock setting
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/libopenfpga/libarchopenfpga/src/simulation_setting.cpp
+++ b/libopenfpga/libarchopenfpga/src/simulation_setting.cpp
@@ -43,6 +43,11 @@ std::string SimulationSetting::clock_name(const SimulationClockId& clock_id) con
   return clock_names_[clock_id];
 }
 
+BasicPort SimulationSetting::clock_port(const SimulationClockId& clock_id) const {
+  VTR_ASSERT(valid_clock_id(clock_id));
+  return clock_ports_[clock_id];
+}
+
 float SimulationSetting::clock_frequency(const SimulationClockId& clock_id) const {
   VTR_ASSERT(valid_clock_id(clock_id));
   return clock_frequencies_[clock_id];
@@ -139,17 +144,34 @@ void SimulationSetting::set_programming_clock_frequency(const float& clock_freq)
   default_clock_frequencies_.set_y(clock_freq);
 }
 
-SimulationClockId SimulationSetting::create_simulation_clock(const std::string& name) {
+SimulationClockId SimulationSetting::create_clock(const std::string& name) {
+  /* Ensure a unique name for the clock definition */
+  std::map<std::string, SimulationClockId>::iterator it = clock_name2ids_.find(name);
+  if (it != clock_name2ids_.end()) {
+    return SimulationClockId::INVALID();
+  }
+
+  /* This is a legal name. we can create a new id */
   SimulationClockId clock_id = SimulationClockId(clock_ids_.size());
   clock_ids_.push_back(clock_id);
   clock_names_.push_back(name);
+  clock_ports_.emplace_back();
   clock_frequencies_.push_back(0.);
+
+  /* Register in the name-to-id map */
+  clock_name2ids_[name] = clock_id;
 
   return clock_id;
 }
 
-void SimulationSetting::set_simulation_clock_frequency(const SimulationClockId& clock_id,
-                                                       const float& frequency) {
+void SimulationSetting::set_clock_port(const SimulationClockId& clock_id,
+                                       const BasicPort& port) {
+  VTR_ASSERT(valid_clock_id(clock_id));
+  clock_ports_[clock_id] = port;
+}
+
+void SimulationSetting::set_clock_frequency(const SimulationClockId& clock_id,
+                                            const float& frequency) {
   VTR_ASSERT(valid_clock_id(clock_id));
   clock_frequencies_[clock_id] = frequency;
 }

--- a/libopenfpga/libarchopenfpga/src/simulation_setting.h
+++ b/libopenfpga/libarchopenfpga/src/simulation_setting.h
@@ -8,7 +8,10 @@
 #include <string>
 #include <array>
 
+#include "vtr_vector.h" 
 #include "vtr_geometry.h" 
+
+#include "simulation_setting_fwd.h" 
 
 /********************************************************************
  * Types of signal type in measurement and stimuli
@@ -48,11 +51,20 @@ namespace openfpga {
  *
  *******************************************************************/
 class SimulationSetting {
+  public: /* Types */
+    typedef vtr::vector<SimulationClockId, SimulationClockId>::const_iterator simulation_clock_iterator;
+    /* Create range */
+    typedef vtr::Range<simulation_clock_iterator> simulation_clock_range;
   public:  /* Constructors */
     SimulationSetting();
+  public: /* Accessors: aggregates */
+    simulation_clock_range clocks() const;
   public: /* Public Accessors */
-    float operating_clock_frequency() const;
+    float default_operating_clock_frequency() const;
     float programming_clock_frequency() const;
+    size_t num_simulation_clock_cycles() const;
+    std::string clock_name(const SimulationClockId& clock_id) const;
+    float clock_frequency(const SimulationClockId& clock_id) const;
     bool auto_select_num_clock_cycles() const;
     size_t num_clock_cycles() const;
     float operating_clock_frequency_slack() const;
@@ -73,8 +85,16 @@ class SimulationSetting {
     e_sim_accuracy_type stimuli_input_slew_type(const e_sim_signal_type& signal_type) const;
     float stimuli_input_slew(const e_sim_signal_type& signal_type) const;
   public: /* Public Mutators */
-    void set_operating_clock_frequency(const float& clock_freq);
+    void set_default_operating_clock_frequency(const float& clock_freq);
     void set_programming_clock_frequency(const float& clock_freq);
+    /* Add a new simulation clock with 
+     * - a given name
+     * - a default zero frequency which can be overwritten by 
+     *   the operating_clock_frequency()
+     */
+    SimulationClockId create_simulation_clock(const std::string& name);
+    void set_simulation_clock_frequency(const SimulationClockId& clock_id,
+                                        const float& frequency);
     void set_num_clock_cycles(const size_t& num_clk_cycles);
     void set_operating_clock_frequency_slack(const float& op_clk_freq_slack);
     void set_simulation_temperature(const float& sim_temp);
@@ -102,13 +122,25 @@ class SimulationSetting {
                                 const float& input_slew);
   public: /* Public Validators */
     bool valid_signal_threshold(const float& threshold) const;
+    bool valid_clock_id(const SimulationClockId& clock_id) const;
   private: /* Internal data */
-    /* Operating clock frequency: the clock frequency to be applied to users' implemetation on FPGA 
+    /* Operating clock frequency: the default clock frequency to be applied to users' implemetation on FPGA 
      *                            This will be stored in the x() part of vtr::Point
      * Programming clock frequency: the clock frequency to be applied to configuration protocol of FPGA 
      *                            This will be stored in the y() part of vtr::Point
      */
-    vtr::Point<float> clock_frequencies_;
+    vtr::Point<float> default_clock_frequencies_;
+
+    /* Multiple simulation clocks with detailed information
+     * Each clock has 
+     * - a unique id
+     * - a unique name which is supposed 
+     *   to match the clock port definition in OpenFPGA documentation
+     * - a frequency which is only applicable to this clock name
+     */
+    vtr::vector<SimulationClockId, SimulationClockId> clock_ids_;
+    vtr::vector<SimulationClockId, std::string> clock_names_;
+    vtr::vector<SimulationClockId, float> clock_frequencies_;
 
     /* Number of clock cycles to be used in simulation
      * If the value is 0, the clock cycles can be automatically 

--- a/libopenfpga/libarchopenfpga/src/simulation_setting.h
+++ b/libopenfpga/libarchopenfpga/src/simulation_setting.h
@@ -7,9 +7,12 @@
  *******************************************************************/
 #include <string>
 #include <array>
+#include <map>
 
 #include "vtr_vector.h" 
 #include "vtr_geometry.h" 
+
+#include "openfpga_port.h" 
 
 #include "simulation_setting_fwd.h" 
 
@@ -64,6 +67,7 @@ class SimulationSetting {
     float programming_clock_frequency() const;
     size_t num_simulation_clock_cycles() const;
     std::string clock_name(const SimulationClockId& clock_id) const;
+    BasicPort clock_port(const SimulationClockId& clock_id) const;
     float clock_frequency(const SimulationClockId& clock_id) const;
     bool auto_select_num_clock_cycles() const;
     size_t num_clock_cycles() const;
@@ -89,12 +93,15 @@ class SimulationSetting {
     void set_programming_clock_frequency(const float& clock_freq);
     /* Add a new simulation clock with 
      * - a given name
+     * - a given port description
      * - a default zero frequency which can be overwritten by 
      *   the operating_clock_frequency()
      */
-    SimulationClockId create_simulation_clock(const std::string& name);
-    void set_simulation_clock_frequency(const SimulationClockId& clock_id,
-                                        const float& frequency);
+    SimulationClockId create_clock(const std::string& name);
+    void set_clock_port(const SimulationClockId& clock_id,
+                        const BasicPort& port);
+    void set_clock_frequency(const SimulationClockId& clock_id,
+                             const float& frequency);
     void set_num_clock_cycles(const size_t& num_clk_cycles);
     void set_operating_clock_frequency_slack(const float& op_clk_freq_slack);
     void set_simulation_temperature(const float& sim_temp);
@@ -134,13 +141,18 @@ class SimulationSetting {
     /* Multiple simulation clocks with detailed information
      * Each clock has 
      * - a unique id
-     * - a unique name which is supposed 
+     * - a unique name
+     * - a unique port definition which is supposed 
      *   to match the clock port definition in OpenFPGA documentation
      * - a frequency which is only applicable to this clock name
      */
     vtr::vector<SimulationClockId, SimulationClockId> clock_ids_;
     vtr::vector<SimulationClockId, std::string> clock_names_;
+    vtr::vector<SimulationClockId, BasicPort> clock_ports_;
     vtr::vector<SimulationClockId, float> clock_frequencies_;
+
+    /* Fast name-to-id lookup */
+    std::map<std::string, SimulationClockId> clock_name2ids_;
 
     /* Number of clock cycles to be used in simulation
      * If the value is 0, the clock cycles can be automatically 

--- a/libopenfpga/libarchopenfpga/src/simulation_setting_fwd.h
+++ b/libopenfpga/libarchopenfpga/src/simulation_setting_fwd.h
@@ -1,0 +1,22 @@
+/************************************************************************
+ * A header file for SimulationSetting class, including critical data declaration
+ * Please include this file only for using any SimulationSetting data structure
+ * Refer to simulation_setting.h for more details 
+ ***********************************************************************/
+
+/************************************************************************
+ * Create strong id for Simulation Clock to avoid illegal type casting 
+ ***********************************************************************/
+#ifndef SIMULATION_SETTING_FWD_H
+#define SIMULATION_SETTING_FWD_H
+
+#include "vtr_strong_id.h"
+
+struct simulation_clock_id_tag;
+
+typedef vtr::StrongId<simulation_clock_id_tag> SimulationClockId;
+
+/* Short declaration of class */
+class SimulationSetting;
+
+#endif

--- a/libopenfpga/libarchopenfpga/src/write_xml_simulation_setting.cpp
+++ b/libopenfpga/libarchopenfpga/src/write_xml_simulation_setting.cpp
@@ -44,6 +44,7 @@ void write_xml_clock_setting(std::fstream& fp,
   for (const SimulationClockId& clock_id : sim_setting.clocks()) {
     fp << "\t\t\t" << "<clock";
     write_xml_attribute(fp, "name", sim_setting.clock_name(clock_id).c_str());
+    write_xml_attribute(fp, "port", generate_xml_port_name(sim_setting.clock_port(clock_id)).c_str());
     write_xml_attribute(fp, "frequency", std::to_string(sim_setting.clock_frequency(clock_id)).c_str());
     fp << ">" << "\n";
   }

--- a/libopenfpga/libarchopenfpga/src/write_xml_simulation_setting.cpp
+++ b/libopenfpga/libarchopenfpga/src/write_xml_simulation_setting.cpp
@@ -27,7 +27,7 @@ void write_xml_clock_setting(std::fstream& fp,
   fp << "\t" << "<clock_setting>" << "\n";
 
   fp << "\t\t" << "<operating";
-  write_xml_attribute(fp, "frequency", sim_setting.operating_clock_frequency());
+  write_xml_attribute(fp, "frequency", sim_setting.default_operating_clock_frequency());
 
   if (true == sim_setting.auto_select_num_clock_cycles()) {
     write_xml_attribute(fp, "num_cycles", "auto");
@@ -37,8 +37,19 @@ void write_xml_clock_setting(std::fstream& fp,
   }
 
   write_xml_attribute(fp, "slack", std::to_string(sim_setting.operating_clock_frequency_slack()).c_str());
+
+  fp << ">" << "\n";
   
-  fp << "/>" << "\n";
+  /* Output clock information one by one */
+  for (const SimulationClockId& clock_id : sim_setting.clocks()) {
+    fp << "\t\t\t" << "<clock";
+    write_xml_attribute(fp, "name", sim_setting.clock_name(clock_id).c_str());
+    write_xml_attribute(fp, "frequency", std::to_string(sim_setting.clock_frequency(clock_id)).c_str());
+    fp << ">" << "\n";
+  }
+  
+  fp << "\t\t" << "</operating";
+  fp << ">" << "\n";
 
   fp << "\t\t" << "<operating";
   write_xml_attribute(fp, "frequency", sim_setting.programming_clock_frequency());
@@ -219,7 +230,7 @@ void write_xml_simulation_setting(std::fstream& fp,
                                   const openfpga::SimulationSetting& sim_setting) {
   /* Validate the file stream */
   openfpga::check_file_stream(fname, fp);
-  
+
   /* Write the root node <openfpga_simulation_setting>
    */
   fp << "<openfpga_simulation_setting>" << "\n";

--- a/libopenfpga/libarchopenfpga/src/write_xml_tile_annotation.cpp
+++ b/libopenfpga/libarchopenfpga/src/write_xml_tile_annotation.cpp
@@ -18,25 +18,6 @@
 namespace openfpga {
 
 /********************************************************************
- * FIXME: Use a common function to output ports
- * Generate the full hierarchy name for a operating pb_type
- *******************************************************************/
-static 
-std::string generate_tile_port_name(const BasicPort& pb_port) {
-  std::string port_name;
-
-  /* Output format: <port_name>[<LSB>:<MSB>] */
-  port_name += pb_port.get_name();
-  port_name += std::string("[");
-  port_name += std::to_string(pb_port.get_lsb());
-  port_name += std::string(":");
-  port_name += std::to_string(pb_port.get_msb());
-  port_name += std::string("]");
-
-  return port_name;
-}
-
-/********************************************************************
  * A writer to output a device variation in a technology library to XML format
  *******************************************************************/
 static 
@@ -64,7 +45,7 @@ void write_xml_tile_annotation_global_port(std::fstream& fp,
   for (size_t tile_info_id = 0; tile_info_id < tile_annotation.global_port_tile_names(global_port_id).size(); ++tile_info_id) {
     fp << "\t\t\t" << "<tile ";
     write_xml_attribute(fp, "name", tile_annotation.global_port_tile_names(global_port_id)[tile_info_id].c_str());
-    write_xml_attribute(fp, "port", generate_tile_port_name(tile_annotation.global_port_tile_ports(global_port_id)[tile_info_id]).c_str());
+    write_xml_attribute(fp, "port", generate_xml_port_name(tile_annotation.global_port_tile_ports(global_port_id)[tile_info_id]).c_str());
     write_xml_attribute(fp, "x", tile_annotation.global_port_tile_coordinates(global_port_id)[tile_info_id].x());
     write_xml_attribute(fp, "y", tile_annotation.global_port_tile_coordinates(global_port_id)[tile_info_id].y());
     fp << "/>";

--- a/libopenfpga/libarchopenfpga/src/write_xml_utils.cpp
+++ b/libopenfpga/libarchopenfpga/src/write_xml_utils.cpp
@@ -90,3 +90,21 @@ void write_xml_attribute(std::fstream& fp,
   fp << std::scientific << value;
   fp << "\""; 
 }
+
+/********************************************************************
+ * FIXME: Use a common function to output ports
+ * Generate the full hierarchy name for a operating pb_type
+ *******************************************************************/
+std::string generate_xml_port_name(const openfpga::BasicPort& pb_port) {
+  std::string port_name;
+
+  /* Output format: <port_name>[<LSB>:<MSB>] */
+  port_name += pb_port.get_name();
+  port_name += std::string("[");
+  port_name += std::to_string(pb_port.get_lsb());
+  port_name += std::string(":");
+  port_name += std::to_string(pb_port.get_msb());
+  port_name += std::string("]");
+
+  return port_name;
+}

--- a/libopenfpga/libarchopenfpga/src/write_xml_utils.h
+++ b/libopenfpga/libarchopenfpga/src/write_xml_utils.h
@@ -6,6 +6,7 @@
  *******************************************************************/
 #include <fstream>
 #include "circuit_library.h"
+#include "openfpga_port.h" 
 
 /********************************************************************
  * Function declaration
@@ -29,5 +30,7 @@ void write_xml_attribute(std::fstream& fp,
 void write_xml_attribute(std::fstream& fp, 
                          const char* attr,
                          const size_t& value);
+
+std::string generate_xml_port_name(const openfpga::BasicPort& pb_port);
 
 #endif

--- a/openfpga/src/annotation/annotate_simulation_setting.cpp
+++ b/openfpga/src/annotation/annotate_simulation_setting.cpp
@@ -191,7 +191,7 @@ int annotate_simulation_setting(const AtomContext& atom_ctx,
                                 SimulationSetting& sim_setting) {
 
   /* Find if the operating frequency is binded to vpr results */
-  if (0. == sim_setting.operating_clock_frequency()) {
+  if (0. == sim_setting.default_operating_clock_frequency()) {
     VTR_LOG("User specified the operating clock frequency to use VPR results\n");
     /* Run timing analysis and collect critical path delay
      * This code is copied from function vpr_analysis() in vpr_api.h 
@@ -212,12 +212,12 @@ int annotate_simulation_setting(const AtomContext& atom_ctx,
 
     /* Get critical path delay. Update simulation settings */
     float T_crit = timing_info->least_slack_critical_path().delay() * (1. + sim_setting.operating_clock_frequency_slack());
-    sim_setting.set_operating_clock_frequency(1 / T_crit); 
+    sim_setting.set_default_operating_clock_frequency(1 / T_crit); 
     VTR_LOG("Use VPR critical path delay %g [ns] with a %g [%] slack in OpenFPGA.\n",
             T_crit / 1e9, sim_setting.operating_clock_frequency_slack() * 100);
   }
   VTR_LOG("Will apply operating clock frequency %g [MHz] to simulations\n",
-          sim_setting.operating_clock_frequency() / 1e6);
+          sim_setting.default_operating_clock_frequency() / 1e6);
 
   if (0. == sim_setting.num_clock_cycles()) {
     /* Find the number of clock cycles to be used in simulation 

--- a/openfpga/src/annotation/annotate_simulation_setting.cpp
+++ b/openfpga/src/annotation/annotate_simulation_setting.cpp
@@ -219,6 +219,18 @@ int annotate_simulation_setting(const AtomContext& atom_ctx,
   VTR_LOG("Will apply operating clock frequency %g [MHz] to simulations\n",
           sim_setting.default_operating_clock_frequency() / 1e6);
 
+  /* Walk through all the clock information */
+  for (const SimulationClockId& clock_id : sim_setting.clocks()) {
+    if (0. == sim_setting.clock_frequency(clock_id)) {
+      sim_setting.set_clock_frequency(clock_id, sim_setting.default_operating_clock_frequency());
+    }
+    VTR_LOG("Will apply clock frequency %g [MHz] to clock '%s[%d:%d]' in simulations\n",
+            sim_setting.clock_frequency(clock_id) / 1e6,
+            sim_setting.clock_port(clock_id).get_name().c_str(),
+            sim_setting.clock_port(clock_id).get_lsb(),
+            sim_setting.clock_port(clock_id).get_msb());
+  }
+
   if (0. == sim_setting.num_clock_cycles()) {
     /* Find the number of clock cycles to be used in simulation 
      * by average over the signal activity 

--- a/openfpga/src/base/openfpga_sdc.cpp
+++ b/openfpga/src/base/openfpga_sdc.cpp
@@ -84,7 +84,7 @@ int write_pnr_sdc(const OpenfpgaContext& openfpga_ctx,
   if (true == options.generate_sdc_pnr()) { 
     print_pnr_sdc(options,
                   1./openfpga_ctx.simulation_setting().programming_clock_frequency(),
-                  1./openfpga_ctx.simulation_setting().operating_clock_frequency(),
+                  1./openfpga_ctx.simulation_setting().default_operating_clock_frequency(),
                   g_vpr_ctx.device(),
                   openfpga_ctx.vpr_device_annotation(),
                   openfpga_ctx.device_rr_gsb(),
@@ -190,7 +190,7 @@ int write_analysis_sdc(const OpenfpgaContext& openfpga_ctx,
 
   if (true == options.generate_sdc_analysis()) {
     print_analysis_sdc(options,
-                       1./openfpga_ctx.simulation_setting().operating_clock_frequency(),
+                       1./openfpga_ctx.simulation_setting().default_operating_clock_frequency(),
                        g_vpr_ctx, 
                        openfpga_ctx,
                        openfpga_ctx.flow_manager().compress_routing());

--- a/openfpga/src/base/openfpga_sdc.cpp
+++ b/openfpga/src/base/openfpga_sdc.cpp
@@ -83,8 +83,6 @@ int write_pnr_sdc(const OpenfpgaContext& openfpga_ctx,
   /* Execute only when sdc is enabled */
   if (true == options.generate_sdc_pnr()) { 
     print_pnr_sdc(options,
-                  1./openfpga_ctx.simulation_setting().programming_clock_frequency(),
-                  1./openfpga_ctx.simulation_setting().default_operating_clock_frequency(),
                   g_vpr_ctx.device(),
                   openfpga_ctx.vpr_device_annotation(),
                   openfpga_ctx.device_rr_gsb(),
@@ -92,6 +90,7 @@ int write_pnr_sdc(const OpenfpgaContext& openfpga_ctx,
                   openfpga_ctx.mux_lib(),
                   openfpga_ctx.arch().circuit_lib,
                   openfpga_ctx.fabric_global_port_info(),
+                  openfpga_ctx.simulation_setting(),
                   openfpga_ctx.flow_manager().compress_routing());
   }
 

--- a/openfpga/src/fpga_sdc/analysis_sdc_writer.cpp
+++ b/openfpga/src/fpga_sdc/analysis_sdc_writer.cpp
@@ -241,7 +241,10 @@ void print_analysis_sdc(const AnalysisSdcOption& option,
   ModuleId top_module = openfpga_ctx.module_graph().find_module(generate_fpga_top_module_name());
   VTR_ASSERT(true == openfpga_ctx.module_graph().valid_module_id(top_module));
 
-  /* Create clock and set I/O ports with input/output delays */
+  /* Create clock and set I/O ports with input/output delays
+   * FIXME: Now different I/Os have different delays due to multiple clock frequency
+   *        We need to consider these impacts and constrain different I/Os with different delays!!!
+   */
   print_analysis_sdc_io_delays(fp, option.time_unit(),
                                vpr_ctx.atom(), vpr_ctx.placement(),
                                openfpga_ctx.vpr_netlist_annotation(), openfpga_ctx.io_location_map(),

--- a/openfpga/src/fpga_sdc/pnr_sdc_global_port.h
+++ b/openfpga/src/fpga_sdc/pnr_sdc_global_port.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include "module_manager.h"
 #include "fabric_global_port_info.h"
+#include "simulation_setting.h"
 
 /********************************************************************
  * Function declaration
@@ -17,11 +18,10 @@
 namespace openfpga {
 
 void print_pnr_sdc_global_ports(const std::string& sdc_dir, 
-                                const float& programming_critical_path_delay,
-                                const float& operating_critical_path_delay,
                                 const ModuleManager& module_manager,
                                 const ModuleId& top_module,
                                 const FabricGlobalPortInfo& global_ports,
+                                const SimulationSetting& sim_setting,
                                 const bool& constrain_non_clock_port);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
+++ b/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
@@ -319,8 +319,6 @@ void print_pnr_sdc_compact_routing_disable_switch_block_outputs(const std::strin
  * 4. Design constraints for breaking the combinational loops in FPGA fabric
  *******************************************************************/
 void print_pnr_sdc(const PnrSdcOption& sdc_options,
-                   const float& programming_critical_path_delay,
-                   const float& operating_critical_path_delay,
                    const DeviceContext& device_ctx,
                    const VprDeviceAnnotation& device_annotation,
                    const DeviceRRGSB& device_rr_gsb,
@@ -328,6 +326,7 @@ void print_pnr_sdc(const PnrSdcOption& sdc_options,
                    const MuxLibrary& mux_lib,
                    const CircuitLibrary& circuit_lib,
                    const FabricGlobalPortInfo& global_ports,
+                   const SimulationSetting& sim_setting,
                    const bool& compact_routing_hierarchy) {
 
   std::string top_module_name = generate_fpga_top_module_name();
@@ -337,9 +336,8 @@ void print_pnr_sdc(const PnrSdcOption& sdc_options,
   /* Constrain global ports */
   if (true == sdc_options.constrain_global_port()) {
     print_pnr_sdc_global_ports(sdc_options.sdc_dir(),
-                               programming_critical_path_delay,
-                               operating_critical_path_delay,
                                module_manager, top_module, global_ports,
+                               sim_setting,
                                sdc_options.constrain_non_clock_global_port());
   }
 

--- a/openfpga/src/fpga_sdc/pnr_sdc_writer.h
+++ b/openfpga/src/fpga_sdc/pnr_sdc_writer.h
@@ -12,6 +12,7 @@
 #include "module_manager.h"
 #include "mux_library.h"
 #include "circuit_library.h"
+#include "simulation_setting.h"
 #include "fabric_global_port_info.h"
 #include "pnr_sdc_option.h"
 
@@ -23,8 +24,6 @@
 namespace openfpga {
 
 void print_pnr_sdc(const PnrSdcOption& sdc_options,
-                   const float& programming_critical_path_delay,
-                   const float& operating_critical_path_delay,
                    const DeviceContext& device_ctx,
                    const VprDeviceAnnotation& device_annotation,
                    const DeviceRRGSB& device_rr_gsb,
@@ -32,6 +31,7 @@ void print_pnr_sdc(const PnrSdcOption& sdc_options,
                    const MuxLibrary& mux_lib,
                    const CircuitLibrary& circuit_lib,
                    const FabricGlobalPortInfo& global_ports,
+                   const SimulationSetting& sim_setting,
                    const bool& compact_routing_hierarchy);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -226,7 +226,7 @@ void fpga_verilog_testbench(const ModuleManager &module_manager,
                                   bitstream_manager.num_bits(),
                                   simulation_setting.num_clock_cycles(),
                                   simulation_setting.programming_clock_frequency(),
-                                  simulation_setting.operating_clock_frequency());
+                                  simulation_setting.default_operating_clock_frequency());
   }
 
   /* Generate a Verilog file including all the netlists that have been generated */

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -254,7 +254,7 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
 
   float simulation_time = find_operating_phase_simulation_time(MAGIC_NUMBER_FOR_SIMULATION_TIME,
                                                                simulation_parameters.num_clock_cycles(),
-                                                               1./simulation_parameters.operating_clock_frequency(),
+                                                               1./simulation_parameters.default_operating_clock_frequency(),
                                                                VERILOG_SIM_TIMESCALE);
 
   /* Add Icarus requirement */

--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
@@ -488,7 +488,7 @@ void print_verilog_testbench_clock_stimuli(std::fstream& fp,
     /* Create clock stimuli */
     fp << "\t\t" << generate_verilog_port(VERILOG_PORT_CONKT, clock_port) << " <= 1'b0;" << std::endl;
     fp << "\t\twhile(1) begin" << std::endl;
-    fp << "\t\t\t#" << std::setprecision(10) << ((0.5/simulation_parameters.operating_clock_frequency())/VERILOG_SIM_TIMESCALE) << std::endl;
+    fp << "\t\t\t#" << std::setprecision(10) << ((0.5/simulation_parameters.default_operating_clock_frequency())/VERILOG_SIM_TIMESCALE) << std::endl;
     fp << "\t\t\t" << generate_verilog_port(VERILOG_PORT_CONKT, clock_port);
     fp << " <= !";
     fp << generate_verilog_port(VERILOG_PORT_CONKT, clock_port);

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1839,7 +1839,7 @@ void print_verilog_top_testbench(const ModuleManager& module_manager,
 
   /* Find the clock period */
   float prog_clock_period = (1./simulation_parameters.programming_clock_frequency());
-  float op_clock_period = (1./simulation_parameters.operating_clock_frequency());
+  float op_clock_period = (1./simulation_parameters.default_operating_clock_frequency());
   /* Estimate the number of configuration clock cycles */
   size_t num_config_clock_cycles = calculate_num_config_clock_cycles(config_protocol.type(),
                                                                      apply_fast_configuration,
@@ -1968,7 +1968,7 @@ void print_verilog_top_testbench(const ModuleManager& module_manager,
                                                       num_config_clock_cycles,
 										              1./simulation_parameters.programming_clock_frequency(),
                                                       simulation_parameters.num_clock_cycles(),
-                                                      1./simulation_parameters.operating_clock_frequency());
+                                                      1./simulation_parameters.default_operating_clock_frequency());
 
 
   /* Add Icarus requirement: 

--- a/openfpga_flow/openfpga_simulation_settings/fixed_4clock_sim_openfpga.xml
+++ b/openfpga_flow/openfpga_simulation_settings/fixed_4clock_sim_openfpga.xml
@@ -1,0 +1,49 @@
+<!-- Simulation Setting for OpenFPGA framework
+     This file will use automatic inference for any settings
+     including:
+     - auto select the number of simulation cycles
+     - auto select the simulation clock frequency from VPR results
+  -->
+<openfpga_simulation_setting>
+  <clock_setting>
+    <!-- The frequency defined in the operating line will be 
+         the default operating clock frequency for all the clocks
+         define specific frequency using <clock> line will overwrite the default value
+         Note that the clock name must match clock port definition in OpenFPGA architecture XML!!!
+      -->
+    <operating frequency="50e6" num_cycles="100" slack="0.2">
+      <clock name="clk[0:0]" frequency="10e6"/>
+      <clock name="clk[1:1]" frequency="20e6"/>
+      <clock name="clk[2:2]" frequency="30e6"/>
+      <clock name="clk[3:3]" frequency="40e6"/>
+    </operating>
+    <programming frequency="100e6"/>
+  </clock_setting>
+  <simulator_option>
+    <operating_condition temperature="25"/>
+    <output_log verbose="false" captab="false"/>
+    <accuracy type="abs" value="1e-13"/>
+    <runtime fast_simulation="true"/>
+  </simulator_option>
+  <monte_carlo num_simulation_points="2"/>
+  <measurement_setting>
+    <slew>
+      <rise upper_thres_pct="0.95" lower_thres_pct="0.05"/>
+      <fall upper_thres_pct="0.05" lower_thres_pct="0.95"/>
+    </slew>
+    <delay>
+      <rise input_thres_pct="0.5" output_thres_pct="0.5"/>
+      <fall input_thres_pct="0.5" output_thres_pct="0.5"/>
+    </delay>
+  </measurement_setting>
+  <stimulus>
+    <clock>
+      <rise slew_type="abs" slew_time="20e-12" />
+      <fall slew_type="abs" slew_time="20e-12" />
+    </clock>
+    <input>
+      <rise slew_type="abs" slew_time="25e-12" />
+      <fall slew_type="abs" slew_time="25e-12" />
+    </input>
+  </stimulus>
+</openfpga_simulation_setting>

--- a/openfpga_flow/openfpga_simulation_settings/fixed_4clock_sim_openfpga.xml
+++ b/openfpga_flow/openfpga_simulation_settings/fixed_4clock_sim_openfpga.xml
@@ -9,13 +9,15 @@
     <!-- The frequency defined in the operating line will be 
          the default operating clock frequency for all the clocks
          define specific frequency using <clock> line will overwrite the default value
-         Note that the clock name must match clock port definition in OpenFPGA architecture XML!!!
+         Note that 
+         - clock name must be unique as it is used in testbench genertion
+         - the clock port must match clock port definition in OpenFPGA architecture XML!!!
       -->
     <operating frequency="50e6" num_cycles="20" slack="0.2">
-      <clock name="clk[0:0]" frequency="10e6"/>
-      <clock name="clk[1:1]" frequency="20e6"/>
-      <clock name="clk[2:2]" frequency="30e6"/>
-      <clock name="clk[3:3]" frequency="40e6"/>
+      <clock name="clk_10MHz" port="clk[0:0]" frequency="10e6"/>
+      <clock name="clk_20MHz" port="clk[1:1]" frequency="20e6"/>
+      <clock name="clk_30MHz" port="clk[2:2]" frequency="30e6"/>
+      <clock name="clk_40MHz" port="clk[3:3]" frequency="40e6"/>
     </operating>
     <programming frequency="100e6"/>
   </clock_setting>

--- a/openfpga_flow/openfpga_simulation_settings/fixed_4clock_sim_openfpga.xml
+++ b/openfpga_flow/openfpga_simulation_settings/fixed_4clock_sim_openfpga.xml
@@ -11,7 +11,7 @@
          define specific frequency using <clock> line will overwrite the default value
          Note that the clock name must match clock port definition in OpenFPGA architecture XML!!!
       -->
-    <operating frequency="50e6" num_cycles="100" slack="0.2">
+    <operating frequency="50e6" num_cycles="20" slack="0.2">
       <clock name="clk[0:0]" frequency="10e6"/>
       <clock name="clk[1:1]" frequency="20e6"/>
       <clock name="clk[2:2]" frequency="30e6"/>

--- a/openfpga_flow/tasks/basic_tests/global_tile_ports/global_tile_4clock/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/global_tile_ports/global_tile_4clock/config/task.conf
@@ -24,7 +24,7 @@ fpga_flow=vpr_blif
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/global_tile_clock_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTile4Clk_cc_openfpga.xml
-openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_4clock_sim_openfpga.xml
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile4Clk_40nm.xml


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [X] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
OpenFPGA only accepts a single operating clock frequency to be considered in the testbench and SDC generators.
This has become a critical barrier when implementing multi-clock FPGA fabrics and verification.

- What does this pull request change?
This PR introduces new XML syntax to the simulation setting description.
Now users are allowed to define multiple clock names and frequency.
The clock names should be validated to match a clock port in the FPGA fabric.
The clock frequencies are used in the generating testbenches and timing constraints in SDC format.

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [X] OpenFPGA libraries
- [X] FPGA-Verilog
- [ ] FPGA-Bitstream
- [X] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [X] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [X] Require code changes. 
- [ ] Require new tests to be added
- [X] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
