### PR TITLE
Avoid to output initial signal for general-purpose output ports of FPGA fabrics in Verilog testbenches

### DIFF
--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
@@ -273,6 +273,11 @@ void print_verilog_testbench_connect_fpga_ios(std::fstream& fp,
         continue;
       }
 
+      /* Bypass unused output pads */
+      if (ModuleManager::MODULE_GPOUT_PORT == module_manager.port_type(top_module, module_io_port_id)) {
+        continue;
+      }
+
       /* Wire to a contant */
       BasicPort module_unused_io_port = module_manager.module_port(top_module, module_io_port_id);
       /* Set the port pin index */ 


### PR DESCRIPTION
### Motivate of the pull request
- [X] To address an existing issue. If so, please provide a link to the issue.
- [ ] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
To address issue #178 

- What does this pull request change?
This PR patched testbench generator of FPGA-Verilog by removing the signal initialization for unused general-purpose output ports of FPGA fabrics.
Attached an example testbench outputted by OpenFPGA after this patch.
You can see all the signal assignment for `SOC_OUT` is now removed from generator (as shown in #178)

[and2_autocheck_top_tb.zip](https://github.com/lnis-uofu/OpenFPGA/files/5859203/and2_autocheck_top_tb.zip)



### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [X] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [X] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
