### PR TITLE
Add OpenFPGA version display

### DIFF
--- a/libopenfpga/libopenfpgautil/CMakeLists.txt
+++ b/libopenfpga/libopenfpgautil/CMakeLists.txt
@@ -2,10 +2,66 @@ cmake_minimum_required(VERSION 3.9)
 
 project("libopenfpgautil")
 
+#Version info
+set(OPENFPGA_VERSION_FILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/src/openfpga_version.cpp.in)
+set(OPENFPGA_VERSION_FILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/openfpga_version.cpp)
+
+#Compiler info
+set(OPENFPGA_COMPILER_INFO "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} on ${CMAKE_SYSTEM} ${CMAKE_SYSTEM_PROCESSOR}")
+
+set(OPENFPGA_BUILD_INFO "${CMAKE_BUILD_TYPE}")
+
+#Set default version numbers in case not specified
+if(NOT DEFINED OPENFPGA_VERSION_MAJOR)
+    set(OPENFPGA_VERSION_MAJOR 0)
+endif()
+
+if(NOT DEFINED OPENFPGA_VERSION_MINOR)
+    set(OPENFPGA_VERSION_MINOR 0)
+endif()
+
+if(NOT DEFINED OPENFPGA_VERSION_PATCH)
+    set(OPENFPGA_VERSION_PATCH 0)
+endif()
+
+set(OPENFPGA_BUILD_INFO "${OPENFPGA_BUILD_INFO} ASSERT_LEVEL=${VTR_ASSERT_LEVEL}")
+
+# We always update the openfpga_version.cpp file every time the project is built, 
+# to ensure the git revision and dirty status are up to date.
+#
+# We need to do this in two stages:
+#
+# 1) We build a custom target 'version' (which is always out of date) so it will always be run.
+#    It touches the unprocessed version input file so it too will always be out of date.
+#
+# 2) The custom command depends on the touched version input file and generates the processed 
+#    version file, with updated values. The custom command uses the configure_version.cmake 
+#    script to generate the up-to-date openfpga_version.cpp
+add_custom_target(openfpga_version ALL
+    COMMAND ${CMAKE_COMMAND} -E touch ${OPENFPGA_VERSION_FILE_IN})
+
+add_custom_command(OUTPUT ${OPENFPGA_VERSION_FILE_OUT}
+    COMMAND ${CMAKE_COMMAND} 
+                    -D IN_FILE=${OPENFPGA_VERSION_FILE_IN}
+                    -D OUT_FILE=${OPENFPGA_VERSION_FILE_OUT}
+                    -D OPENFPGA_VERSION_MAJOR=${OPENFPGA_VERSION_MAJOR}
+                    -D OPENFPGA_VERSION_MINOR=${OPENFPGA_VERSION_MINOR}
+                    -D OPENFPGA_VERSION_PATCH=${OPENFPGA_VERSION_PATCH}
+                    -D OPENFPGA_VERSION_PRERELEASE=${OPENFPGA_VERSION_PRERELEASE}
+                    -D OPENFPGA_COMPILER_INFO=${OPENFPGA_COMPILER_INFO}
+                    -D OPENFPGA_BUILD_INFO=${OPENFPGA_BUILD_INFO}
+                    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/configure_version.cmake
+    MAIN_DEPENDENCY ${OPENFPGA_VERSION_FILE_IN}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	VERBATIM)
+
 #file(GLOB_RECURSE EXEC_SOURCES test/main.cpp)
 file(GLOB_RECURSE LIB_SOURCES src/*.cpp)
 file(GLOB_RECURSE LIB_HEADERS src/*.h)
 files_to_dirs(LIB_HEADERS LIB_INCLUDE_DIRS)
+
+#Add the version file to the sources
+list(APPEND LIB_SOURCES ${OPENFPGA_VERSION_FILE_OUT})
 
 #Remove test executable from library
 #list(REMOVE_ITEM LIB_SOURCES ${EXEC_SOURCES})
@@ -16,6 +72,9 @@ add_library(libopenfpgautil STATIC
             ${LIB_SOURCES})
 target_include_directories(libopenfpgautil PUBLIC ${LIB_INCLUDE_DIRS})
 set_target_properties(libopenfpgautil PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
+
+#Ensure version is always up to date by requiring version to be run first
+add_dependencies(libopenfpgautil openfpga_version)
 
 #Specify link-time dependancies
 target_link_libraries(libopenfpgautil

--- a/libopenfpga/libopenfpgautil/cmake/modules/configure_version.cmake
+++ b/libopenfpga/libopenfpgautil/cmake/modules/configure_version.cmake
@@ -1,0 +1,55 @@
+#
+# Versioning information
+#
+#Figure out the git revision
+find_package(Git QUIET)
+if(GIT_FOUND)
+    exec_program(${GIT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}
+                 ARGS describe --always --long --dirty
+                 OUTPUT_VARIABLE OPENFPGA_VCS_REVISION
+                 RETURN_VALUE GIT_DESCRIBE_RETURN_VALUE)
+
+    if(NOT GIT_DESCRIBE_RETURN_VALUE EQUAL 0)
+        #Git describe failed, usually this means we
+        #aren't in a git repo -- so don't set a VCS 
+        #revision
+        set(OPENFPGA_VCS_REVISION "unkown")
+    endif()
+
+    #Call again with exclude to get the revision excluding any tags
+    #(i.e. just the commit ID and dirty flag)
+    exec_program(${GIT_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}
+                 ARGS describe --always --long --dirty --exclude '*'
+                 OUTPUT_VARIABLE OPENFPGA_VCS_REVISION_SHORT
+                 RETURN_VALUE GIT_DESCRIBE_RETURN_VALUE)
+    if(NOT GIT_DESCRIBE_RETURN_VALUE EQUAL 0)
+        #Git describe failed, usually this means we
+        #aren't in a git repo -- so don't set a VCS 
+        #revision
+        set(OPENFPGA_VCS_REVISION_SHORT "unkown")
+    endif()
+else()
+    #Couldn't find git, so can't look-up VCS revision
+    set(OPENFPGA_VCS_REVISION "unkown")
+    set(OPENFPGA_VCS_REVISION_SHORT "unkown")
+endif()
+
+
+#Set the version according to semver.org
+set(OPENFPGA_VERSION "${OPENFPGA_VERSION_MAJOR}.${OPENFPGA_VERSION_MINOR}.${OPENFPGA_VERSION_PATCH}")
+if(OPENFPGA_VERSION_PRERELEASE)
+    set(OPENFPGA_VERSION "${OPENFPGA_VERSION}-${OPENFPGA_VERSION_PRERELEASE}")
+endif()
+set(OPENFPGA_VERSION_SHORT ${OPENFPGA_VERSION})
+if(OPENFPGA_VCS_REVISION)
+    set(OPENFPGA_VERSION "${OPENFPGA_VERSION}+${OPENFPGA_VCS_REVISION_SHORT}")
+endif()
+
+#Other build meta-data
+string(TIMESTAMP OPENFPGA_BUILD_TIMESTAMP)
+set(OPENFPGA_BUILD_TIMESTAMP "${OPENFPGA_BUILD_TIMESTAMP}")
+set(OPENFPGA_BUILD_INFO "${OPENFPGA_BUILD_INFO}")
+
+message(STATUS "OpenFPGA Version: ${OPENFPGA_VERSION}")
+
+configure_file(${IN_FILE} ${OUT_FILE})

--- a/libopenfpga/libopenfpgautil/src/openfpga_version.cpp.in
+++ b/libopenfpga/libopenfpgautil/src/openfpga_version.cpp.in
@@ -1,0 +1,21 @@
+#include "openfpga_version.h"
+
+//This file is automatically processed by CMAKE and replaces
+//the values between ampersand's with the releveant CMAKE variable
+//before being compiled.
+namespace openfpga {
+    const char* VERSION = "@OPENFPGA_VERSION@";
+    const char* VERSION_SHORT = "@OPENFPGA_VERSION_SHORT@";
+
+    const size_t VERSION_MAJOR = @OPENFPGA_VERSION_MAJOR@;
+    const size_t VERSION_MINOR = @OPENFPGA_VERSION_MINOR@;
+    const size_t VERSION_PATCH = @OPENFPGA_VERSION_PATCH@;
+    const char* VERSION_PRERELEASE = "@OPENFPGA_VERSION_PRERELEASE@";
+
+    const char* VCS_REVISION = "@OPENFPGA_VCS_REVISION@";
+    const char* VCS_REVISION_SHORT = "@OPENFPGA_VCS_REVISION_SHORT@";
+
+    const char* COMPILER = "@OPENFPGA_COMPILER_INFO@";
+    const char* BUILD_TIMESTAMP = "@OPENFPGA_BUILD_TIMESTAMP@";
+    const char* BUILD_INFO = "@OPENFPGA_BUILD_INFO@";
+}

--- a/libopenfpga/libopenfpgautil/src/openfpga_version.h
+++ b/libopenfpga/libopenfpgautil/src/openfpga_version.h
@@ -1,0 +1,20 @@
+#ifndef OPENFPGA_VERSION_H
+#define OPENFPGA_VERSION_H
+#include <cstddef>
+
+namespace openfpga {
+extern const char* VERSION;
+extern const char* VERSION_SHORT;
+
+extern const size_t VERSION_MAJOR;
+extern const size_t VERSION_MINOR;
+extern const size_t VERSION_PATCH;
+extern const char* VERSION_PRERELEASE;
+
+extern const char* VCS_REVISION;
+extern const char* COMPILER;
+extern const char* BUILD_TIMESTAMP;
+extern const char* BUILD_INFO;
+} // namespace openfpga
+
+#endif

--- a/openfpga/src/base/openfpga_title.cpp
+++ b/openfpga/src/base/openfpga_title.cpp
@@ -3,6 +3,7 @@
  * which introduces generality of OpenFPGA framework
  *******************************************************************/
 #include "openfpga_title.h"
+#include "openfpga_version.h"
 
 /********************************************************************
  * Generate a string of openfpga title introduction
@@ -47,6 +48,14 @@ std::string create_openfpga_title() {
   title += std::string("LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n");
   title += std::string("OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n");
   title += std::string("THE SOFTWARE.\n");
+  title += std::string("\n");
+
+  /* Display version */
+  title += std::string("Version: " + std::string(openfpga::VERSION) + "\n");
+  title += std::string("Revision: " + std::string(openfpga::VCS_REVISION) + "\n");
+  title += std::string("Compiled: " + std::string(openfpga::BUILD_TIMESTAMP) + "\n");
+  title += std::string("Compiler: " + std::string(openfpga::COMPILER) + "\n");
+  title += std::string("Build Info: " + std::string(openfpga::BUILD_INFO) + "\n");
   title += std::string("\n");
 
   return title;


### PR DESCRIPTION
### Motivate of the pull request
- [X] To address an existing issue. If so, please provide a link to the issue.
- [ ] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
To address issue #180 

- What does this pull request change?
This PR added version display when launching the binary of OpenFPGA.
For example, when executing `openfpga -i`, the shell interface will display:

```
Start interactive mode of OpenFPGA...

            ___                   _____ ____   ____    _     
           / _ \ _ __   ___ _ __ |  ___|  _ \ / ___|  / \    
          | | | | '_ \ / _ \ '_ \| |_  | |_) | |  _  / _ \   
          | |_| | |_) |  __/ | | |  _| |  __/| |_| |/ ___ \  
           \___/| .__/ \___|_| |_|_|   |_|    \____/_/   \_\ 
                |_|                                          

               OpenFPGA: An Open-source FPGA IP Generator
                     Versatile Place and Route (VPR)
                           FPGA-Verilog
                           FPGA-SPICE
                           FPGA-SDC
                           FPGA-Bitstream

             This is a free software under the MIT License

             Copyright (c) 2018 LNIS - The University of Utah

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in
all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
THE SOFTWARE.

Version: 1.0.0-dev+1823eb85-dirty
Revision: 1823eb85-dirty
Compiled: 2021-01-23T16:36:40
Compiler: GNU 8.4.0 on Linux-3.10.0-1127.18.2.el7.x86_64 x86_64
Build Info: debug ASSERT_LEVEL=2
```

It will show the basic information, i.e.,
- Commit id: 1823eb85
- Compiler information
- Build timestamp


### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [X] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [X] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
