### PR TITLE
Support batch mode when executing OpenFPGA commands

### DIFF
--- a/docs/source/manual/openfpga_shell/launch_openfpga_shell.rst
+++ b/docs/source/manual/openfpga_shell/launch_openfpga_shell.rst
@@ -15,6 +15,13 @@ To launch OpenFPGA shell, users can choose two modes.
 
   Launch OpenFPGA in script mode where users write commands in scripts and FPGA will execute them
 
+.. option::	--batch_execution or -batch
+
+  Execute OpenFPGA script in batch mode. This option is only valid for script mode.
+
+  - If in batch mode, OpenFPGA will abort immediately when fatal errors occurred.
+  - If not in batch mode, OpenFPGA will enter interactive mode when fatal errors occurred.
+
 .. option::	--help or -h
 	
   Show the help desk

--- a/libopenfpga/libopenfpgashell/src/shell.h
+++ b/libopenfpga/libopenfpgashell/src/shell.h
@@ -143,7 +143,9 @@ class Shell {
     /* Start the interactive mode, where users will type-in command by command */
     void run_interactive_mode(T& context, const bool& quiet_mode = false);
     /* Start the script mode, where users provide a file which includes all the commands to run */
-    void run_script_mode(const char* script_file_name, T& context);
+    void run_script_mode(const char* script_file_name,
+                         T& context,
+                         const bool& batch_mode = false);
     /* Print all the commands by their classes. This is actually the help desk */
     void print_commands() const;
     /* Quit the shell */

--- a/libopenfpga/libopenfpgashell/src/shell.h
+++ b/libopenfpga/libopenfpgashell/src/shell.h
@@ -148,6 +148,10 @@ class Shell {
                          const bool& batch_mode = false);
     /* Print all the commands by their classes. This is actually the help desk */
     void print_commands() const;
+    /* Find the exit code (assume quit shell now) */
+    int exit_code() const;
+    /* Show statistics of errors during command execution */
+    int execution_errors() const;
     /* Quit the shell */
     void exit() const;
   private: /* Private executors */

--- a/libopenfpga/libopenfpgashell/src/shell.h
+++ b/libopenfpga/libopenfpgashell/src/shell.h
@@ -153,7 +153,7 @@ class Shell {
     /* Show statistics of errors during command execution */
     int execution_errors() const;
     /* Quit the shell */
-    void exit() const;
+    void exit(const int& init_err = 0) const;
   private: /* Private executors */
     /* Execute a command, the command line is the user's input to launch a command
      * The common_context is the data structure to exchange data between commands

--- a/libopenfpga/libopenfpgashell/src/shell.tpp
+++ b/libopenfpga/libopenfpgashell/src/shell.tpp
@@ -363,8 +363,12 @@ void Shell<T>::run_script_mode(const char* script_file_name,
        */
       if (CMD_EXEC_FATAL_ERROR == status) {
         VTR_LOG("Fatal error occurred!\n");
-        /* If not in the batch mode, we will got to interactive mode */ 
+        /* If in the batch mode, we will exit with errors */ 
         VTR_LOGV(batch_mode, "OpenFPGA Abort\n");
+        if (batch_mode) {
+          exit(CMD_EXEC_FATAL_ERROR);
+        }
+        /* If not in the batch mode, we will got to interactive mode */ 
         VTR_LOGV(!batch_mode, "Enter interactive mode\n");
         break;
       }
@@ -438,15 +442,15 @@ int Shell<T>::execution_errors() const {
 }
 
 template <class T>
-void Shell<T>::exit() const {
+void Shell<T>::exit(const int& init_err) const {
   /* Check all the command status, if we see fatal errors or minor errors, we drop an error code */
-  int shell_exit_code = exit_code();
+  int shell_exit_code = exit_code() | init_err;
 
   /* Show error message if we detect any errors */
-  int num_err = 0;
-  if (0 != shell_exit_code) {
+  int num_err = init_err;
+  if (CMD_EXEC_SUCCESS != shell_exit_code) {
     VTR_LOG("\n");
-    num_err = execution_errors();
+    num_err += execution_errors();
   }
 
   VTR_LOG("\nFinish execution with %d errors\n",

--- a/libopenfpga/libopenfpgashell/src/shell.tpp
+++ b/libopenfpga/libopenfpgashell/src/shell.tpp
@@ -272,7 +272,9 @@ void Shell<T>::run_interactive_mode(T& context, const bool& quiet_mode) {
 }
 
 template <class T>
-void Shell<T>::run_script_mode(const char* script_file_name, T& context) {
+void Shell<T>::run_script_mode(const char* script_file_name,
+                               T& context,
+                               const bool& batch_mode) {
 
   time_start_ = std::clock();
 
@@ -356,17 +358,24 @@ void Shell<T>::run_script_mode(const char* script_file_name, T& context) {
       /* Empty the line ready to start a new line */
       cmd_line.clear();
 
-      /* Check the execution status of the command, if fatal error happened, we should abort immediately */
+      /* Check the execution status of the command, 
+       * if fatal error happened, we should abort immediately 
+       */
       if (CMD_EXEC_FATAL_ERROR == status) {
-        VTR_LOG("Fatal error occurred!\nAbort and enter interactive mode\n");
+        VTR_LOG("Fatal error occurred!\n");
+        /* If not in the batch mode, we will got to interactive mode */ 
+        VTR_LOGV(batch_mode, "OpenFPGA Abort\n");
+        VTR_LOGV(!batch_mode, "Enter interactive mode\n");
         break;
       }
     }
   }
   fp.close();
 
-  /* Return to interactive mode, stay tuned */
-  run_interactive_mode(context, true); 
+  /* If not in batch mode, switch to interactive mode, stay tuned */
+  if (!batch_mode) {
+    run_interactive_mode(context, true); 
+  }
 }
 
 template <class T>

--- a/libopenfpga/libopenfpgashell/src/shell.tpp
+++ b/libopenfpga/libopenfpgashell/src/shell.tpp
@@ -487,6 +487,7 @@ int Shell<T>::execute_command(const char* cmd_line,
               commands_[dep_cmd].name().c_str(), commands_[cmd_id].name().c_str());
       /* Echo the command help desk */
       print_command_options(commands_[cmd_id]);
+      command_status_[cmd_id] = CMD_EXEC_FATAL_ERROR;
       return CMD_EXEC_FATAL_ERROR;
     } 
   }
@@ -521,6 +522,7 @@ int Shell<T>::execute_command(const char* cmd_line,
   if (false == parse_command(tokens, commands_[cmd_id], command_contexts_[cmd_id])) {
     /* Echo the command */
     print_command_options(commands_[cmd_id]);
+    command_status_[cmd_id] = CMD_EXEC_FATAL_ERROR;
     return CMD_EXEC_FATAL_ERROR;
   }
  

--- a/openfpga/src/main.cpp
+++ b/openfpga/src/main.cpp
@@ -29,9 +29,10 @@ int main(int argc, char** argv) {
 
   /* Create the command to launch shell in different modes */
   openfpga::Command start_cmd("OpenFPGA");
-  /* Add two options:
+  /* Add options:
    * '--interactive', -i': launch the interactive mode 
    * '--file', -f': launch the script mode 
+   * '--batch_execution': execute the script in batch mode. Will exit immediately when fatal errors occurred
    */
   openfpga::CommandOptionId opt_interactive = start_cmd.add_option("interactive", false, "Launch OpenFPGA in interactive mode");
   start_cmd.set_option_short_name(opt_interactive, "i");
@@ -39,6 +40,9 @@ int main(int argc, char** argv) {
   openfpga::CommandOptionId opt_script_mode = start_cmd.add_option("file", false, "Launch OpenFPGA in script mode");
   start_cmd.set_option_require_value(opt_script_mode, openfpga::OPT_STRING);
   start_cmd.set_option_short_name(opt_script_mode, "f");
+
+  openfpga::CommandOptionId opt_batch_exec = start_cmd.add_option("batch_execution", false, "Launch OpenFPGA in batch  mode when running scripts");
+  start_cmd.set_option_short_name(opt_batch_exec, "batch");
 
   openfpga::CommandOptionId opt_help = start_cmd.add_option("help", false, "Help desk"); 
   start_cmd.set_option_short_name(opt_help, "h");
@@ -100,7 +104,8 @@ int main(int argc, char** argv) {
 
     if (true == start_cmd_context.option_enable(start_cmd, opt_script_mode)) {
       shell.run_script_mode(start_cmd_context.option_value(start_cmd, opt_script_mode).c_str(),
-                            openfpga_context);
+                            openfpga_context,
+                            start_cmd_context.option_enable(start_cmd, opt_batch_exec));
       return 0;
     }
     /* Reach here there is something wrong, show the help desk */

--- a/openfpga/src/main.cpp
+++ b/openfpga/src/main.cpp
@@ -99,18 +99,21 @@ int main(int argc, char** argv) {
     if (true == start_cmd_context.option_enable(start_cmd, opt_interactive)) {
 
       shell.run_interactive_mode(openfpga_context);
-      return 0;
+      return shell.exit_code();
     } 
 
     if (true == start_cmd_context.option_enable(start_cmd, opt_script_mode)) {
       shell.run_script_mode(start_cmd_context.option_value(start_cmd, opt_script_mode).c_str(),
                             openfpga_context,
                             start_cmd_context.option_enable(start_cmd, opt_batch_exec));
-      return 0;
+      return shell.exit_code();
     }
     /* Reach here there is something wrong, show the help desk */
     openfpga::print_command_options(start_cmd);
   }
 
-  return 0;
+  /* Reach here, it means shell execution has critical errors.
+   * Return a code with fatal errors  
+   */
+  return 1;
 }


### PR DESCRIPTION
### Motivate of the pull request
- [X] To address an existing issue. If so, please provide a link to the issue.
- [ ] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
- To address issue #183 
- What does this pull request change?
Now openfpga shell has a new option ``--batch_execution`` or in short as ``-batch``
which allows batch execution of openfpga commands.
When enabled, OpenFPGA will abort immediately when fatal errors occurred.
Otherwise, OpenFPGA will enter interactive mode when fatal errors occurred.
Documentation has been updated for the new option.

Also, this PR enhanced the return code of OpenFPGA shell.
If aborted, OpenFPGA will return error code (1) as fatal errors occurred.


### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [X] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [X] Require code changes. 
- [ ] Require new tests to be added
- [X] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
