### PR TITLE
Changed readthedocs.io dependencies link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We also recommend potential users to checkout the summary of [**technical capabi
 
 ## Compilation
 
-Before start, we strongly recommend you to read the required dependencies at [**compilation guidelines**](https://openfpga.readthedocs.io/en/master/tutorials/compile.html).
+Before start, we strongly recommend you to read the required dependencies at [**compilation guidelines**](https://openfpga.readthedocs.io/en/master/tutorials/compile).
 It also includes detailed information about docker image. 
 
 ---

--- a/docs/source/tutorials/compile.rst
+++ b/docs/source/tutorials/compile.rst
@@ -32,7 +32,7 @@ To quickly verify the tool is well compiled, user can run the following command 
 
 Dependencies
 ~~~~~~~~~~~~
-Full list of dependencies can be found at travis_setup_link_
+Full list of dependencies can be found at install_dependencies_build_
 In particular, OpenFPGA requires specific versions for the following dependencies:
 
 :cmake:
@@ -41,7 +41,7 @@ In particular, OpenFPGA requires specific versions for the following dependencie
 :iverilog:
   version 10.1+ is required to run Verilog-to-Verification flow
 
-.. _travis_setup_link: https://github.com/LNIS-Projects/OpenFPGA/blob/0cfb88a49f152aab0a06f309ff160f222bb51ed7/.travis.yml#L34
+.. _install_dependencies_build: https://github.com/lnis-uofu/OpenFPGA/blob/master/.github/workflows/install_dependencies_build.sh
 
 Docker
 ~~~~~~


### PR DESCRIPTION
---
Changed link to dependencies for compilation in the docs
---

### Motivation of the pull request
- [x] To address an existing issue. If so, please provide a link to the issue.
https://github.com/lnis-uofu/OpenFPGA/issues/211
- [ ] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- Current link (https://github.com/LNIS-Projects/OpenFPGA/blob/0cfb88a49f152aab0a06f309ff160f222bb51ed7/.travis.yml#L34) points to travis.yml which is out of date.
- Pull request changes the link to point to the correct file

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [x] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
