### PR TITLE
Synchronize the out-of-date XML syntax 'disable_in_pack' with VPR upstream

### DIFF
--- a/docs/source/manual/arch_lang/addon_vpr_syntax.rst
+++ b/docs/source/manual/arch_lang/addon_vpr_syntax.rst
@@ -14,13 +14,13 @@ Each ``<pb_type>`` should contain a ``<mode>`` that describe the physical implem
 
 .. note:: Currently, OpenFPGA only supports 1 ``<equivalent_sites>`` to be defined under each ``<tile>``
 
-.. option:: <mode packable="<bool">/>
+.. option:: <mode disable_packing="<bool">/>
 
-  OpenFPGA allows users to define it a mode is packable for VPR.
-  By default, the packable is set to ``true``. 
+  OpenFPGA allows users to define it a mode is disabled for VPR packer.
+  By default, the ``disable_packing`` is set to ``false``. 
   This is mainly used for the mode that describes the physical implementation, which is typically not packable. Disable it in the packing and signficantly accelerate the packing runtime.
 
-  .. note:: Once a mode is set to unpackable, its child modes will be unpackable as well.
+  .. note:: Once a mode is disabled in packing, its child modes will be disabled as well.
 
 Layout
 ~~~~~~

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1963,7 +1963,7 @@ static void ProcessMode(pugi::xml_node Parent, t_mode* mode, const bool timing_e
         mode->packable = mode->parent_pb_type->parent_mode->packable;
     }
     /* Override if user specify */
-    mode->packable = ~get_attribute(Parent, "disable_packing", loc_data, ReqOpt::OPTIONAL).as_bool(~mode->packable);
+    mode->packable = !get_attribute(Parent, "disable_packing", loc_data, ReqOpt::OPTIONAL).as_bool(!mode->packable);
     if (false == mode->packable) {
         VTR_LOG("mode '%s[%s]' is disabled in packing by user\n",
                  mode->parent_pb_type->name,

--- a/libs/libarchfpga/src/read_xml_arch_file.cpp
+++ b/libs/libarchfpga/src/read_xml_arch_file.cpp
@@ -1963,9 +1963,9 @@ static void ProcessMode(pugi::xml_node Parent, t_mode* mode, const bool timing_e
         mode->packable = mode->parent_pb_type->parent_mode->packable;
     }
     /* Override if user specify */
-    mode->packable = get_attribute(Parent, "packable", loc_data, ReqOpt::OPTIONAL).as_bool(mode->packable);
+    mode->packable = ~get_attribute(Parent, "disable_packing", loc_data, ReqOpt::OPTIONAL).as_bool(~mode->packable);
     if (false == mode->packable) {
-        VTR_LOG("mode '%s[%s]' is defined by user to be not packable\n",
+        VTR_LOG("mode '%s[%s]' is disabled in packing by user\n",
                  mode->parent_pb_type->name,
                  mode->name);
     }

--- a/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
@@ -144,7 +144,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
@@ -144,7 +144,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile4Clk_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile4Clk_40nm.xml
@@ -147,7 +147,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_40nm.xml
@@ -146,7 +146,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
@@ -150,7 +150,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzBr_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzBr_40nm.xml
@@ -149,7 +149,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTl_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTl_40nm.xml
@@ -149,7 +149,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTr_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTr_40nm.xml
@@ -149,7 +149,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_full_output_crossbar_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_full_output_crossbar_40nm.xml
@@ -145,7 +145,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_no_local_routing_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_no_local_routing_40nm.xml
@@ -148,7 +148,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_N5_tileable_pattern_local_routing_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N5_tileable_pattern_local_routing_40nm.xml
@@ -144,7 +144,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_fracNative_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_fracNative_N4_tileable_40nm.xml
@@ -170,7 +170,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -242,7 +242,7 @@
         <output name="out" num_pins="2"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <output name="out" num_pins="2"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_40nm.xml
@@ -170,7 +170,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -242,7 +242,7 @@
         <output name="out" num_pins="2"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <output name="out" num_pins="2"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_40nm.xml
@@ -170,7 +170,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -242,7 +242,7 @@
         <output name="out" num_pins="2"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <output name="out" num_pins="2"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_40nm.xml
@@ -195,7 +195,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -271,7 +271,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_40nm.xml
@@ -238,7 +238,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -314,7 +314,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_40nm.xml
@@ -253,7 +253,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -329,7 +329,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_frac_dsp32_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_frac_dsp32_40nm.xml
@@ -265,7 +265,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -341,7 +341,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_lutram_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_lutram_40nm.xml
@@ -188,7 +188,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -260,7 +260,7 @@
         <output name="out" num_pins="2"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <output name="out" num_pins="2"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -269,7 +269,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -354,7 +354,7 @@
         <output name="scout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="regin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_embedded_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_embedded_io_skywater130nm.xml
@@ -335,7 +335,7 @@
         <output name="scout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="regin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -273,7 +273,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -360,7 +360,7 @@
         <output name="sc_out" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="reg_in" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -289,7 +289,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -380,7 +380,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="reg_in" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_N10_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_N10_40nm.xml
@@ -137,7 +137,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
@@ -137,7 +137,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_40nm.xml
@@ -163,7 +163,7 @@
       <!-- A mode denotes the physical implementation of an I/O
            This mode will be not packable but is mainly used for fabric verilog generation
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -235,7 +235,7 @@
         <output name="out" num_pins="2"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <output name="out" num_pins="2"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_40nm.xml
@@ -250,7 +250,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -326,7 +326,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_mem16K_40nm.xml
@@ -290,7 +290,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -366,7 +366,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_40nm.xml
@@ -163,7 +163,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -235,7 +235,7 @@
         <output name="out" num_pins="2"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <output name="out" num_pins="2"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_40nm.xml
@@ -250,7 +250,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -326,7 +326,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_frac_mem32K_frac_dsp36_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_frac_mem32K_frac_dsp36_40nm.xml
@@ -345,7 +345,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -428,7 +428,7 @@
         <clock name="clk" num_pins="1"/>
 
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_40nm.xml
@@ -290,7 +290,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -366,7 +366,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_aib_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_aib_40nm.xml
@@ -358,7 +358,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -434,7 +434,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_multi_io_capacity_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_multi_io_capacity_40nm.xml
@@ -327,7 +327,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -403,7 +403,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_reduced_io_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_reduced_io_40nm.xml
@@ -294,7 +294,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -370,7 +370,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_wide_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_wide_mem16K_40nm.xml
@@ -290,7 +290,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -366,7 +366,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_chain_40nm.xml
@@ -255,7 +255,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -335,7 +335,7 @@
         <output name="regout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" packable="false">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_40nm.xml
@@ -271,7 +271,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -355,7 +355,7 @@
         <output name="scout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" packable="false">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_40nm.xml
@@ -223,7 +223,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -311,7 +311,7 @@
         <clock name="clk" num_pins="1"/>
 
         <!-- Describe physical mode begins -->
-        <mode name="physical" packable="false">
+        <mode name="physical" disable_packing="true">
           <pb_type name="frac_logic" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>
@@ -383,7 +383,7 @@
         </mode>
         <!-- Define physical mode begins -->
         <!-- Define n2_lut5 mode begins -->
-        <mode name="n2_lut5" packable="true">
+        <mode name="n2_lut5" disable_packing="false">
           <pb_type name="lut5inter" num_pb="1">
             <input name="in" num_pins="5"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_spypad_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_spypad_40nm.xml
@@ -261,7 +261,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -349,7 +349,7 @@
         <clock name="clk" num_pins="1"/>
 
         <!-- Describe physical mode begins -->
-        <mode name="physical" packable="false">
+        <mode name="physical" disable_packing="true">
           <pb_type name="frac_logic" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>
@@ -421,7 +421,7 @@
         </mode>
         <!-- Define physical mode begins -->
         <!-- Define n2_lut5 mode begins -->
-        <mode name="n2_lut5" packable="true">
+        <mode name="n2_lut5" disable_packing="false">
           <pb_type name="lut5inter" num_pb="1">
             <input name="in" num_pins="5"/>
             <input name="cin" num_pins="1"/>
@@ -776,7 +776,7 @@
         <clock name="clk" num_pins="1"/>
 
         <!-- Describe physical mode begins -->
-        <mode name="physical" packable="false">
+        <mode name="physical" disable_packing="true">
           <pb_type name="frac_logic" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>
@@ -848,7 +848,7 @@
         </mode>
         <!-- Define physical mode begins -->
         <!-- Define n2_lut5 mode begins -->
-        <mode name="n2_lut5" packable="true">
+        <mode name="n2_lut5" disable_packing="false">
           <pb_type name="lut5inter" num_pb="1">
             <input name="in" num_pins="5"/>
             <input name="cin" num_pins="1"/>
@@ -1103,7 +1103,7 @@
         <clock name="clk" num_pins="1"/>
 
         <!-- Describe physical mode begins -->
-        <mode name="physical" packable="false">
+        <mode name="physical" disable_packing="true">
           <pb_type name="frac_logic" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>
@@ -1175,7 +1175,7 @@
         </mode>
         <!-- Define physical mode begins -->
         <!-- Define n2_lut5 mode begins -->
-        <mode name="n2_lut5" packable="true">
+        <mode name="n2_lut5" disable_packing="false">
           <pb_type name="lut5inter" num_pb="1">
             <input name="in" num_pins="5"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_mem16K_depop50_12nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_mem16K_depop50_12nm.xml
@@ -260,7 +260,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" packable="false">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -351,7 +351,7 @@
         <!-- Timing annotation is not require for unpackable mode
              It will not be used by timing analyzer
           -->
-        <mode name="physical" packable="false">
+        <mode name="physical" disable_packing="true">
           <pb_type name="frac_logic" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>
@@ -423,7 +423,7 @@
         </mode>
         <!-- Define physical mode begins -->
         <!-- Define n2_lut5 mode begins -->
-        <mode name="n2_lut5" packable="true">
+        <mode name="n2_lut5" disable_packing="false">
           <pb_type name="lut5inter" num_pb="1">
             <input name="in" num_pins="5"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_mem16K_40nm.xml
@@ -297,7 +297,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -373,7 +373,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_wide_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_wide_mem16K_40nm.xml
@@ -290,7 +290,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -366,7 +366,7 @@
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <input name="cin" num_pins="1"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N8_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N8_tileable_40nm.xml
@@ -163,7 +163,7 @@
       <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
         -->
-      <mode name="physical" disabled_in_pack="true">
+      <mode name="physical" disable_packing="true">
         <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
           <input name="outpad" num_pins="1"/>
           <output name="inpad" num_pins="1"/>
@@ -235,7 +235,7 @@
         <output name="out" num_pins="2"/>
         <clock name="clk" num_pins="1"/>
         <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
+        <mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="6"/>
             <output name="out" num_pins="2"/>

--- a/vpr/src/pack/cluster.cpp
+++ b/vpr/src/pack/cluster.cpp
@@ -1186,6 +1186,64 @@ static void alloc_and_load_pb_stats(t_pb* pb, const int feasible_block_array_siz
 /*****************************************/
 
 /**
+ *  * Cleans up a pb after unsuccessful molecule packing
+ *   */
+static bool cleanup_pb(t_pb* pb) {
+    bool can_free = true;
+
+    /* Recursively check if there are any children with already assigned atoms */
+    if (pb->child_pbs != nullptr) {
+        const t_mode* mode = &pb->pb_graph_node->pb_type->modes[pb->mode];
+        VTR_ASSERT(mode != nullptr);
+
+        /* Check each mode */
+        for (int i = 0; i < mode->num_pb_type_children; ++i) {
+            /* Check each child */
+            if (pb->child_pbs[i] != nullptr) {
+                for (int j = 0; j < mode->pb_type_children[i].num_pb; ++j) {
+                    t_pb* pb_child = &pb->child_pbs[i][j];
+                    t_pb_type* pb_type = pb_child->pb_graph_node->pb_type;
+
+                    /* Primitive, check occupancy */
+                    if (pb_type->num_modes == 0) {
+                        if (pb_child->name != nullptr) {
+                            can_free = false;
+                        }
+                    }
+
+                    /* Non-primitive, recurse */
+                    else {
+                        if (!cleanup_pb(pb_child)) {
+                            can_free = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        /* Free if can */
+        if (can_free) {
+            for (int i = 0; i < mode->num_pb_type_children; ++i) {
+                if (pb->child_pbs[i] != nullptr) {
+                    delete[] pb->child_pbs[i];
+                }
+            }
+
+            delete[] pb->child_pbs;
+            pb->child_pbs = nullptr;
+            pb->mode = 0;
+
+            if (pb->name) {
+                free(pb->name);
+                pb->name = nullptr;
+            }
+        }
+    }
+
+    return can_free;
+}
+
+/**
  * Try pack molecule into current cluster
  */
 static enum e_block_pack_status try_pack_molecule(t_cluster_placement_stats* cluster_placement_stats_ptr,
@@ -1364,6 +1422,10 @@ static enum e_block_pack_status try_pack_molecule(t_cluster_placement_stats* clu
                         revert_place_atom_block(molecule->atom_block_ids[i], router_data, atom_molecules);
                     }
                 }
+
+                /* Placement failed, clean the pb */
+                cleanup_pb(pb);
+
             } else {
                 VTR_LOGV(verbosity > 3, "\t\tPASSED pack molecule\n");
             }


### PR DESCRIPTION
### Motivate of the pull request
- [X] To address an existing issue. If so, please provide a link to the issue.
To address issue #216 
- [ ] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
- What does this pull request change?
Now, we use the same XML sytnax ``disable_packing`` as VPR upstream. See details at [VPR documentation](https://docs.verilogtorouting.org/en/latest/arch/reference/?highlight=disable_packing#tag-%3Cmodename=)

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [X] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [X] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [X] Require code changes. 
- [ ] Require new tests to be added
- [X] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [X] Break back-compatibility. If so, please list who may be influenced.
SOFA architecture should be updated due to this patch. @tpagarani 
