### PR TITLE
Add tutorial videos to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 
 The award-winning OpenFPGA framework is the **first open-source FPGA IP generator** supporting highly-customizable homogeneous FPGA architectures. OpenFPGA provides a full set of EDA support for customized FPGAs, including Verilog-to-bitstream generation and self-testing verification. OpenFPGA opens the door to democratizing FPGA technology and EDA techniques, with agile prototyping approaches and constantly evolving EDA tools for chip designers and researchers.
 
+**If this is the first time you learn OpenFPGA, we strongly recommend you to watch the [introduction video about OpenFPGA](https://youtu.be/ocODUGcYGqo)**
+
 A quick overview of OpenFPGA tools can be found [**here**](https://openfpga.readthedocs.io/en/master/tutorials/tools/).
 We also recommend potential users to checkout the summary of [**technical capabilities**](https://openfpga.readthedocs.io/en/master/overview/tech_highlights.html) before compiling.
 
 ## Compilation
+
+**A tutorial video about how-to-compile can be found [here](https://youtu.be/F9sMRmDewM0)**
 
 Before start, we strongly recommend you to read the required dependencies at [**compilation guidelines**](https://openfpga.readthedocs.io/en/master/tutorials/compile).
 It also includes detailed information about docker image. 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,9 @@
 #Handle references in bibtex format
 sphinxcontrib-bibtex<2.0.0
 
+# Package required to embed youtube video
+sphinxcontrib-yt
+
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:
 #  * https://github.com/sphinx-doc/sphinx/issues/3951

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,14 @@ try:
 except ImportError:
     have_sphinxcontrib_bibtex = False
 
+# Import sphinxcontrib.yt
+have_sphinxcontrib_youtube = True
+try:
+    import sphinxcontrib.yt
+except ImportError:
+    have_sphinxcontrib_youtube = False
+
+
 # -- Project information -----------------------------------------------------
 
 project = u'OpenFPGA'
@@ -57,6 +65,7 @@ extensions = [
     'sphinx.ext.graphviz',
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
+    'sphinxcontrib.yt',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/overview/motivation.rst
+++ b/docs/source/overview/motivation.rst
@@ -1,6 +1,8 @@
 Why OpenFPGA?
 -------------
 
+.. note:: If this is the first time you learn OpenFPGA, we strongly recommend you to watch the `introduction video <https://youtu.be/ocODUGcYGqo>`_ .
+
 OpenFPGA aims to be an open-source framework that enables rapid prototyping of customizable FPGA architectures. As shown in :numref:`fig_openfpga_motivation`, a conventional approach will take a large group of experienced engineers more than one year to achieve production-ready layout and assoicated CAD tools. In fact, most of the engineering efforts are spent on manual layouts and developing ad-hoc CAD support.
 
 .. _fig_openfpga_motivation:

--- a/docs/source/overview/motivation.rst
+++ b/docs/source/overview/motivation.rst
@@ -1,7 +1,9 @@
 Why OpenFPGA?
 -------------
 
-.. note:: If this is the first time you learn OpenFPGA, we strongly recommend you to watch the `introduction video <https://youtu.be/ocODUGcYGqo>`_ .
+.. note:: If this is the first time you learn OpenFPGA, we strongly recommend you to watch the introduction video.
+   
+.. youtube:: ocODUGcYGqo
 
 OpenFPGA aims to be an open-source framework that enables rapid prototyping of customizable FPGA architectures. As shown in :numref:`fig_openfpga_motivation`, a conventional approach will take a large group of experienced engineers more than one year to achieve production-ready layout and assoicated CAD tools. In fact, most of the engineering efforts are spent on manual layouts and developing ad-hoc CAD support.
 

--- a/docs/source/tutorials/compile.rst
+++ b/docs/source/tutorials/compile.rst
@@ -1,4 +1,4 @@
-.. _compile:
+.. _tutorial_compile:
 
 How to Compile
 --------------

--- a/docs/source/tutorials/compile.rst
+++ b/docs/source/tutorials/compile.rst
@@ -3,7 +3,9 @@
 How to Compile
 --------------
 
-.. note:: A tutorial video about how-to-compile can be found `here <https://youtu.be/F9sMRmDewM0>`_
+.. note:: We recommend you to watch a tutorial video about how-to-compile before getting started
+
+.. youtube:: F9sMRmDewM0
 
 General Guidelines
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorials/compile.rst
+++ b/docs/source/tutorials/compile.rst
@@ -3,6 +3,8 @@
 How to Compile
 --------------
 
+.. note:: A tutorial video about how-to-compile can be found `here <https://youtu.be/F9sMRmDewM0>`_
+
 General Guidelines
 ~~~~~~~~~~~~~~~~~~
 OpenFPGA uses CMake to generate the Makefile scripts

--- a/docs/source/tutorials/design_flow/generate_fabric.rst
+++ b/docs/source/tutorials/design_flow/generate_fabric.rst
@@ -3,7 +3,9 @@
 Generate Fabric Netlists
 ------------------------
 
-.. note:: A tutorial video can be found `here <https://youtu.be/aJ0OkZ1uh68>`_.
+.. note:: You may watch the video representation of this tutorial
+
+.. youtube:: aJ0OkZ1uh68
 
 This tutorial will show an example how to 
   - generate Verilog netlists for a FPGA fabric

--- a/docs/source/tutorials/design_flow/generate_fabric.rst
+++ b/docs/source/tutorials/design_flow/generate_fabric.rst
@@ -1,0 +1,69 @@
+.. _tutorial_generate_fabric:
+
+Generate Fabric Netlists
+------------------------
+
+.. note:: A tutorial video can be found `here <https://youtu.be/aJ0OkZ1uh68>`_.
+
+This tutorial will show an example how to 
+  - generate Verilog netlists for a FPGA fabric
+
+.. note:: Before running any design flows, please checkout the tutorial :ref:`tutorial_compile`, to ensure that you have an operating copy of OpenFPGA installed on your computer.
+
+
+Prepare Task Configuration File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+OpenFPGA provides push-button scripts for users to run design flows (see details in :ref:`run_fpga_task`). Users can customize their flow-run by crafting a task configuration file.
+
+Here, we consider an existing test case ``generate_fabric``.
+In the `task configuration file <https://github.com/lnis-uofu/OpenFPGA/blob/master/openfpga_flow/tasks/basic_tests/generate_fabric/config/task.conf>`_, you can specify the XML-based architecture files in ``LINE 21`` and ``LINE 25``  that describe the architecture of the FPGA fabric. In this example, we are using a low-cost FPGA architecture similar to the lattice ICE40 series
+
+Also, in ``LINE 20``, you can specify the openfpga shell script to be executed. Here, we are using an example script which is golden reference to generate Verilog netlists
+
+.. note:: You can use text editor to customize the configuration file. Here, we use it as is.
+
+
+Run OpenFPGA Task
+~~~~~~~~~~~~~~~~~
+
+After finalizing your configuration file, you can run the task by calling the python script with the given path to task configuration file.
+
+.. code-block:: shell
+
+  python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/generate_fabric 
+
+When the flow run is executed, you can visit the runtime directory and check the Verilog netlists.
+
+Note that your task-run outcomes are stored in the directory called ``latest`` in the same level of your task configuration file.
+
+The Verilog netlists are generated in the following directory
+
+.. code-block:: shell
+
+  ${OPENFPGA_PATH}/openfpga_flow/tasks/basic_tests/generate_fabric/latest/k6_frac_N10_tileable_40nm/and2/MIN_ROUTE_CHAN_WIDTH/SRC
+
+.. note:: ``${OPENFPGA_PATH}`` is the root directory of OpenFPGA 
+   
+.. note:: See :ref:`fabric_netlists` for the netlist details. 
+
+In the Verilog files, you can validate if the Verilog description is consistent as your definition in the architecture file. The Verilog files can be then used to drive different tools, such as layout generation *etc*.
+
+Run icarus iVerilog Compilation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Go to the directory 
+
+.. code-block:: shell
+
+   cd ${OPENFPGA_PATH}/openfpga_flow/tasks/basic_tests/generate_fabric/latest/k6_frac_N10_tileable_40nm/and2/MIN_ROUTE_CHAN_WIDTH
+
+Compile with iVerilog command:
+
+.. code-block:: shell
+
+  iverilog SRC/fabric_netlists.v
+
+.. note:: Please ensure that iVerilog is installed correctly on your computer
+
+If compilation is successful, you can see a file ``a.out`` in the directory.

--- a/docs/source/tutorials/design_flow/index.rst
+++ b/docs/source/tutorials/design_flow/index.rst
@@ -7,6 +7,8 @@ Design Flows
 .. toctree::
    :maxdepth: 2
 
+   generate_fabric
+
    verilog2verification
 
    verilog2gds2

--- a/docs/source/tutorials/design_flow/verilog2verification.rst
+++ b/docs/source/tutorials/design_flow/verilog2verification.rst
@@ -8,6 +8,8 @@ This tutorial will show an example how to
   - generate Verilog testbenches for a RTL design
   - run HDL simulation to verify the functional correctness of the implemented FPGA fabric
 
+.. note:: Before running any design flows, please checkout the tutorial :ref:`tutorial_compile`, to ensure that you have an operating copy of OpenFPGA installed on your computer.
+
 Netlist Generation
 ~~~~~~~~~~~~~~~~~~
 We will use the openfpga_flow scripts (see details in :ref:`run_fpga_task`) to generate the Verilog netlists and testbenches.


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [X] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
Current OpenFPGA miss tutorial videos.

- What does this pull request change?
This PR added to README.md about the youtube links to the tutorial video.
This PR also added embedded video to online documentation.
This is how it looks like.
![image](https://user-images.githubusercontent.com/11499826/107135134-55a24800-68b5-11eb-99ba-de4af312625e.png)

In addition, a new tutorial `generate_fabric` was added along with an embedded video.

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [X] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
