### PR TITLE
Documentation Patches on Supporting PDF builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,9 @@ sphinxcontrib-bibtex<2.0.0
 # Package required to embed youtube video
 sphinxcontrib-yt
 
+# Package required to convert svg for pdf builder
+sphinxcontrib-svg2pdfconverter
+
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:
 #  * https://github.com/sphinx-doc/sphinx/issues/3951

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,12 @@ try:
 except ImportError:
     have_sphinxcontrib_youtube = False
 
+# Import sphinxcontrib.svg2pdfconverter
+have_sphinxcontrib_svg2pdfconverter = True
+try:
+    import sphinxcontrib.svg2pdfconverter
+except ImportError:
+    have_sphinxcontrib_svg2pdfconverter = False
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/overview/motivation.rst
+++ b/docs/source/overview/motivation.rst
@@ -1,9 +1,11 @@
 Why OpenFPGA?
 -------------
 
-.. note:: If this is the first time you learn OpenFPGA, we strongly recommend you to watch the introduction video.
+.. note:: If this is the first time you learn OpenFPGA, we strongly recommend you to watch the `introduction video <https://youtu.be/ocODUGcYGqo>`_
    
-.. youtube:: ocODUGcYGqo
+.. only:: html
+
+  .. youtube:: ocODUGcYGqo
 
 OpenFPGA aims to be an open-source framework that enables rapid prototyping of customizable FPGA architectures. As shown in :numref:`fig_openfpga_motivation`, a conventional approach will take a large group of experienced engineers more than one year to achieve production-ready layout and assoicated CAD tools. In fact, most of the engineering efforts are spent on manual layouts and developing ad-hoc CAD support.
 

--- a/docs/source/tutorials/compile.rst
+++ b/docs/source/tutorials/compile.rst
@@ -3,9 +3,11 @@
 How to Compile
 --------------
 
-.. note:: We recommend you to watch a tutorial video about how-to-compile before getting started
+.. note:: We recommend you to watch a tutorial `video <https://youtu.be/F9sMRmDewM0>`_ about how-to-compile before getting started
 
-.. youtube:: F9sMRmDewM0
+.. only:: html
+
+  .. youtube:: F9sMRmDewM0
 
 General Guidelines
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorials/design_flow/generate_fabric.rst
+++ b/docs/source/tutorials/design_flow/generate_fabric.rst
@@ -3,9 +3,11 @@
 Generate Fabric Netlists
 ------------------------
 
-.. note:: You may watch the video representation of this tutorial
+.. note:: You may watch the `video <https://youtu.be/aJ0OkZ1uh68>`_ representation of this tutorial
 
-.. youtube:: aJ0OkZ1uh68
+.. only:: html
+
+  .. youtube:: aJ0OkZ1uh68
 
 This tutorial will show an example how to 
   - generate Verilog netlists for a FPGA fabric


### PR DESCRIPTION
### Motivate of the pull request
- [X] To address an existing issue. If so, please provide a link to the issue.

Readthedocs reports build errors when converting html to pdf.
See details at the [link](https://readthedocs.org/projects/openfpga/builds/)

- [ ] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)

- What does this pull request change?

- Skip youtube video when building pdf so that PDF generation will have no errors
-  Apply SVG2PDF converter so that svg images can be included in the pdf


### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [X] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
