### PR TITLE
Support SVG in Sphinx Latex building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,10 @@
 # Required configuration file version
 version: 2
 
+# Specify docker image for building the doc
+build:
+  image: latest
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: dirhtml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,6 +20,6 @@ formats: all
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.7
-  use_system_site_packages: true
+  system_packages: true
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,5 +20,6 @@ formats: all
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.7
+  use_system_site_packages: true
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,9 @@ sphinxcontrib-bibtex<2.0.0
 # Package required to embed youtube video
 sphinxcontrib-yt
 
+# Package required to convert SVG for latex building
+sphinxcontrib-svg2pdfconverter
+
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:
 #  * https://github.com/sphinx-doc/sphinx/issues/3951

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ sphinxcontrib-bibtex<2.0.0
 sphinxcontrib-yt
 
 # Package required to convert svg for pdf builder
-sphinxcontrib-svg2pdfconverter[CairoSVG]
+#sphinxcontrib-svg2pdfconverter[CairoSVG]
 #sphinx-ext-imgconverter
 
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ sphinxcontrib-bibtex<2.0.0
 sphinxcontrib-yt
 
 # Package required to convert svg for pdf builder
-#sphinxcontrib-svg2pdfconverter[CairoSVG]
+sphinxcontrib-svg2pdfconverter[CairoSVG]
 #sphinx-ext-imgconverter
 
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,10 +11,6 @@ sphinxcontrib-bibtex<2.0.0
 # Package required to embed youtube video
 sphinxcontrib-yt
 
-# Package required to convert svg for pdf builder
-sphinxcontrib-svg2pdfconverter[CairoSVG]
-#sphinx-ext-imgconverter
-
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:
 #  * https://github.com/sphinx-doc/sphinx/issues/3951

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,8 @@ sphinxcontrib-bibtex<2.0.0
 sphinxcontrib-yt
 
 # Package required to convert svg for pdf builder
-sphinxcontrib-svg2pdfconverter
+#sphinxcontrib-svg2pdfconverter
+sphinxcontrib-ext-imgconverter
 
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,8 +12,8 @@ sphinxcontrib-bibtex<2.0.0
 sphinxcontrib-yt
 
 # Package required to convert svg for pdf builder
-#sphinxcontrib-svg2pdfconverter
-sphinx-ext-imgconverter
+sphinxcontrib-svg2pdfconverter
+#sphinx-ext-imgconverter
 
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ sphinxcontrib-bibtex<2.0.0
 sphinxcontrib-yt
 
 # Package required to convert svg for pdf builder
-sphinxcontrib-svg2pdfconverter
+sphinxcontrib-svg2pdfconverter[CairoSVG]
 #sphinx-ext-imgconverter
 
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ sphinxcontrib-yt
 
 # Package required to convert svg for pdf builder
 #sphinxcontrib-svg2pdfconverter
-sphinxcontrib-ext-imgconverter
+sphinx-ext-imgconverter
 
 #Work-around bug "AttributeError: 'Values' object has no attribute 'character_level_inline_markup'" with docutils 0.13.1
 #See:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,11 +38,14 @@ except ImportError:
     have_sphinxcontrib_youtube = False
 
 # Import sphinxcontrib.svg2pdfconverter
-have_sphinxcontrib_svg2pdfconverter = True
+#have_sphinxcontrib_svg2pdfconverter = True
+have_sphinxcontrib_ext_imgconverter = True
 try:
-    import sphinxcontrib.svg2pdfconverter
+#    import sphinxcontrib.svg2pdfconverter
+    import sphinxcontrib.ext.imgconverter
 except ImportError:
-    have_sphinxcontrib_svg2pdfconverter = False
+#    have_sphinxcontrib_svg2pdfconverter = False
+    have_sphinxcontrib_ext_imgconverter = False
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,8 +27,8 @@ import sphinx_rtd_theme
 import sphinxcontrib.bibtex
 # For embedded youtube
 import sphinxcontrib.yt
-# For converting SVG to PNG using inkscape
-import sphinxcontrib.inkscapeconverter
+# For converting SVG to PNG using rsvg
+import sphinxcontrib.rsvgconverter
 
 # -- Project information -----------------------------------------------------
 
@@ -58,7 +58,7 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
-    'sphinxcontrib.inkscapeconverter',
+    'sphinxcontrib.rsvgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,13 +38,13 @@ except ImportError:
     have_sphinxcontrib_youtube = False
 
 # Import sphinxcontrib.svg2pdfconverter
-#have_sphinxcontrib_svg2pdfconverter = True
+have_sphinxcontrib_svg2pdfconverter = True
 have_sphinx_ext_imgconverter = True
 try:
-#    import sphinxcontrib.svg2pdfconverter
+    import sphinxcontrib.svg2pdfconverter
     import sphinx.ext.imgconverter
 except ImportError:
-#    have_sphinxcontrib_svg2pdfconverter = False
+    have_sphinxcontrib_svg2pdfconverter = False
     have_sphinx_ext_imgconverter = False
 
 # -- Project information -----------------------------------------------------
@@ -75,8 +75,8 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
-#    'sphinxcontrib.cairosvgconverter',
-    'sphinx.ext.imgconverter',
+    'sphinxcontrib.cairosvgconverter',
+#    'sphinx.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,6 +170,8 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
+    'preamble': '\\usepackage{tikz}',
+    'preamble': '\\usepackage{svg}',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,11 +41,11 @@ except ImportError:
 #have_sphinxcontrib_svg2pdfconverter = True
 have_sphinx_ext_imgconverter = True
 try:
-#    import sphinxcontrib.svg2pdfconverter
-    import sphinx.ext.imgconverter
+    import sphinxcontrib.svg2pdfconverter
+#    import sphinx.ext.imgconverter
 except ImportError:
-#    have_sphinxcontrib_svg2pdfconverter = False
-    have_sphinx_ext_imgconverter = False
+    have_sphinxcontrib_svg2pdfconverter = False
+#    have_sphinx_ext_imgconverter = False
 
 # -- Project information -----------------------------------------------------
 
@@ -75,8 +75,8 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
-#    'sphinxcontrib.svg2pdfconverter',
-    'sphinx.ext.imgconverter',
+    'sphinxcontrib.svg2pdfconverter',
+#    'sphinx.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,8 +27,8 @@ import sphinx_rtd_theme
 import sphinxcontrib.bibtex
 # For embedded youtube
 import sphinxcontrib.yt
-# For converting SVG to PNG
-import sphinx.ext.imgconverter
+# For converting SVG to PNG using inkscape
+import sphinxcontrib.inkscapeconverter
 
 # -- Project information -----------------------------------------------------
 
@@ -58,7 +58,7 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
-    'sphinx.ext.imgconverter',
+    'sphinxcontrib.inkscapeconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,8 +38,8 @@ except ImportError:
     have_sphinxcontrib_youtube = False
 
 # Import sphinxcontrib.svg2pdfconverter
-#have_sphinxcontrib_svg2pdfconverter = True
-have_sphinx_ext_imgconverter = True
+have_sphinxcontrib_svg2pdfconverter = True
+#have_sphinx_ext_imgconverter = True
 try:
     import sphinxcontrib.svg2pdfconverter
 #    import sphinx.ext.imgconverter
@@ -75,7 +75,7 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
-    'sphinxcontrib.svg2pdfconverter',
+    'sphinxcontrib.cairosvgconverter',
 #    'sphinx.ext.imgconverter',
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,6 +75,8 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
+#    'sphinxcontrib.svg2pdfconverter',
+    'sphinxcontrib.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,29 +23,12 @@ import sphinx_rtd_theme
 #html_theme = "sphinx_rtd_theme"
 #html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-# Import sphinxcontrib.bibtex
-have_sphinxcontrib_bibtex = True
-try:
-    import sphinxcontrib.bibtex
-except ImportError:
-    have_sphinxcontrib_bibtex = False
-
-# Import sphinxcontrib.yt
-have_sphinxcontrib_youtube = True
-try:
-    import sphinxcontrib.yt
-except ImportError:
-    have_sphinxcontrib_youtube = False
-
-# Import sphinxcontrib.svg2pdfconverter
-have_sphinxcontrib_svg2pdfconverter = True
-have_sphinx_ext_imgconverter = True
-try:
-    import sphinxcontrib.svg2pdfconverter
-    import sphinx.ext.imgconverter
-except ImportError:
-    have_sphinxcontrib_svg2pdfconverter = False
-    have_sphinx_ext_imgconverter = False
+# For bibtex support
+import sphinxcontrib.bibtex
+# For embedded youtube
+import sphinxcontrib.yt
+# For converting SVG to PNG
+import sphinx.ext.imgconverter
 
 # -- Project information -----------------------------------------------------
 
@@ -75,8 +58,7 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
-    'sphinxcontrib.cairosvgconverter',
-#    'sphinx.ext.imgconverter',
+    'sphinx.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -170,8 +152,6 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
-    'preamble': '\\usepackage{tikz}',
-    'preamble': '\\usepackage{svg}',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,14 +38,14 @@ except ImportError:
     have_sphinxcontrib_youtube = False
 
 # Import sphinxcontrib.svg2pdfconverter
-have_sphinxcontrib_svg2pdfconverter = True
-#have_sphinx_ext_imgconverter = True
+#have_sphinxcontrib_svg2pdfconverter = True
+have_sphinx_ext_imgconverter = True
 try:
-    import sphinxcontrib.svg2pdfconverter
-#    import sphinx.ext.imgconverter
+#    import sphinxcontrib.svg2pdfconverter
+    import sphinx.ext.imgconverter
 except ImportError:
-    have_sphinxcontrib_svg2pdfconverter = False
-#    have_sphinx_ext_imgconverter = False
+#    have_sphinxcontrib_svg2pdfconverter = False
+    have_sphinx_ext_imgconverter = False
 
 # -- Project information -----------------------------------------------------
 
@@ -75,8 +75,8 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
-    'sphinxcontrib.cairosvgconverter',
-#    'sphinx.ext.imgconverter',
+#    'sphinxcontrib.cairosvgconverter',
+    'sphinx.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,13 +39,13 @@ except ImportError:
 
 # Import sphinxcontrib.svg2pdfconverter
 #have_sphinxcontrib_svg2pdfconverter = True
-have_sphinxcontrib_ext_imgconverter = True
+have_sphinx_ext_imgconverter = True
 try:
 #    import sphinxcontrib.svg2pdfconverter
-    import sphinxcontrib.ext.imgconverter
+    import sphinx.ext.imgconverter
 except ImportError:
 #    have_sphinxcontrib_svg2pdfconverter = False
-    have_sphinxcontrib_ext_imgconverter = False
+    have_sphinx_ext_imgconverter = False
 
 # -- Project information -----------------------------------------------------
 
@@ -76,7 +76,7 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.yt',
 #    'sphinxcontrib.svg2pdfconverter',
-    'sphinxcontrib.ext.imgconverter',
+    'sphinx.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/manual/arch_lang/circuit_model_examples.rst
+++ b/docs/source/manual/arch_lang/circuit_model_examples.rst
@@ -1160,7 +1160,7 @@ Template
 
 .. option:: <wire_param model_type="<string>" R="<float>" C="<float>" num_level="<int>"/>
 
-  - ``model_type="pi|T"`` Specify the type of RC models for this wire segement. Currently, OpenFPGA supports the π-type and T-type multi-level RC models.
+  - ``model_type="pi|T"`` Specify the type of RC models for this wire segement. Currently, OpenFPGA supports the :math:`\pi`-type and T-type multi-level RC models.
   - ``R="<float>"`` Specify the total resistance of the wire
   - ``C="<float>"`` Specify the total capacitance of the wire.
   - ``num_level="<int>"`` Specify the number of levels of the RC wire model.
@@ -1193,7 +1193,7 @@ The code describing this wire is:
 
 This example shows
   - A routing track wire has 1 input and output 
-  - The routing wire will be modelled as a 1-level π-type RC wire model with a total resistance of :math:`103.84\Omega` and a total capacitance of :math:`13.89fF`
+  - The routing wire will be modelled as a 1-level :math:`\pi`-type RC wire model with a total resistance of :math:`103.84\Omega` and a total capacitance of :math:`13.89fF`
 
 I/O pads
 ~~~~~~~~


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [X] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
- Sphinx builder skip SVG when outputting latex
- 
- What does this pull request change?
- Add package 'imgconverter' to convert the SVG to PNG, when building the latex files.

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [X] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
