### PR TITLE
[Flow] ACE is optional during flow script, only runs when power estimation is on 

### DIFF
--- a/openfpga_flow/scripts/run_fpga_flow.py
+++ b/openfpga_flow/scripts/run_fpga_flow.py
@@ -257,17 +257,12 @@ def main():
         logger.info('Running "yosys_vpr" Flow')
         run_yosys_with_abc()
         # TODO Make it optional if activity file is provided
-        run_ace2()
-        run_pro_blif_3arg()
         if args.power:
+            run_ace2()
+            run_pro_blif_3arg()
             run_rewrite_verilog()
     if (args.fpga_flow == "vpr_blif"):
         collect_files_for_vpr()
-    # if (args.fpga_flow == "vtr"):
-    #     run_odin2()
-    #     run_abc_vtr()
-    # if (args.fpga_flow == "vtr_standard"):
-    #     run_abc_for_standarad()
     logger.info("Runing OpenFPGA Shell Engine ")
     run_openfpga_shell()
     if args.end_flow_with_test:


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable) ACE for every run of yosys_vpr flow 
- What does this pull request change?  This pull request makes ACE2 run optional (it only executes when Power estimation flag is made true)

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [x] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
