### PR TITLE
Move quicklogic regresssion tests to a dedicated CI run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,6 +209,7 @@ jobs:
           - name: fpga_bitstream_reg_test
           - name: fpga_sdc_reg_test
           - name: fpga_spice_reg_test
+          - name: quicklogic_reg_test
     steps:
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v2
@@ -253,6 +254,7 @@ jobs:
           - name: fpga_bitstream_reg_test
           - name: fpga_sdc_reg_test
           - name: fpga_spice_reg_test
+          - name: quicklogic_reg_test
     steps:
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v2

--- a/.github/workflows/quicklogic_reg_test.sh
+++ b/.github/workflows/quicklogic_reg_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+source openfpga.sh
+PYTHON_EXEC=python3.8
+###############################################
+# OpenFPGA Shell with VPR8
+##############################################
+echo -e "QuickLogic regression tests";
+
+echo -e "Testing yosys flow using custom ys script for running quicklogic device";
+run-task quicklogic_tests/flow_test --debug --show_thread_logs


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [X] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
Currently, Quicklogic's regression tests are part of the basic tests.
As quicklogic's test is going to grow with more benchmark suites to be imported, it is proper to create a dedicated regression test run.

- What does this pull request change?
This PR move the current test cases for QuickLogic to a dedicated CI run, in parallel to basic_tests, fpga_verilog_tests, *etc.*

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
