### PR TITLE
[Bugfix] Docker regression using master regression scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,7 @@ jobs:
           bash .github/workflows/install_dependencies_run.sh
           ${PYTHON_EXEC} -m pip install -r requirements.txt
           rsync -am --exclude='openfpga_flow/**' /opt/openfpga/. .
+          unset OPENFPGA_PATH
           source openfpga.sh && source openfpga_flow/regression_test_scripts/${{matrix.config.name}}.sh
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
### Motivate of the pull request
- [x] To address an existing issue. If so, please provide a link to the issue. #239 
- [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
The docker image has OPENFPGA_PATH already setup to the already installed binary, during current regression test it uses that path to run regression script. This commit unset the OPENFPGA_PATH so that new PATH can be setup.

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [x] Regression test
