### PR TITLE
Throw fatal error when the number of configurable region is different between fabric key and architecture definition

### DIFF
--- a/docs/source/manual/arch_lang/config_protocol.rst
+++ b/docs/source/manual/arch_lang/config_protocol.rst
@@ -13,7 +13,7 @@ Template
 .. code-block:: xml
 
   <configuration_protocol>
-    <organization type="<string>" circuit_model_name="<string>"/>
+    <organization type="<string>" circuit_model_name="<string>" num_regions="<int>"/>
   </configuration_protocol>
 
 .. option:: type="scan_chain|memory_bank|standalone"

--- a/openfpga/src/fabric/build_top_module.cpp
+++ b/openfpga/src/fabric/build_top_module.cpp
@@ -368,14 +368,14 @@ int build_top_module(ModuleManager& module_manager,
                                        compact_routing_hierarchy);
   } else {
     VTR_ASSERT_SAFE(false == fabric_key.empty());
-    /* Give a warning message that the fabric key may overwrite existing region organization.
-     * Only applicable when number of regions defined in configuration protocol is different
-     * than the number of regions defined in the fabric key 
+    /* Throw a fatal error when the fabric key has a mismatch in region organization.
+     * between architecture file and fabric key
      */
     if (size_t(config_protocol.num_regions()) != fabric_key.regions().size()) {
-      VTR_LOG_WARN("Fabric key will overwrite the region organization (='%ld') than architecture definition (=%d)!\n",
-                   fabric_key.regions().size(),
-                   config_protocol.num_regions());
+      VTR_LOG_ERROR("Fabric key has a different number of configurable regions (='%ld') than architecture definition (=%d)!\n",
+                    fabric_key.regions().size(),
+                    config_protocol.num_regions());
+      return CMD_EXEC_FATAL_ERROR;
     }
 
     status = load_top_module_memory_modules_from_fabric_key(module_manager, top_module,


### PR DESCRIPTION
### Motivate of the pull request
- [X] To address an existing issue. If so, please provide a link to the issue.
- [ ] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
To address issue #240 

- What does this pull request change?
Instead of a warning message, now OpenFPGA will abort and throw a fatal error message when the number of configurable region is different between fabric key and architecture definition

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [X] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [X] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
