### PR TITLE
Disabling verilog testbench generation for quicklogic tests

### DIFF
--- a/openfpga_flow/openfpga_shell_scripts/quicklogic_flow_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/quicklogic_flow_example_script.openfpga
@@ -46,31 +46,6 @@ build_fabric_bitstream --verbose
 # Write fabric-dependent bitstream
 write_fabric_bitstream --file fabric_bitstream.xml --format xml
 
-# Write the Verilog netlist for FPGA fabric
-#  - Enable the use of explicit port mapping in Verilog netlist
-write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --print_user_defined_template --verbose
-
-# Write the Verilog testbench for FPGA fabric
-#  - We suggest the use of same output directory as fabric Verilog netlists
-#  - Must specify the reference benchmark file if you want to output any testbenches
-#  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
-#  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
-#  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
-write_verilog_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --print_top_testbench --print_preconfig_top_testbench --print_simulation_ini ./SimulationDeck/simulation_deck.ini --include_signal_init --support_icarus_simulator 
-
-# Write the SDC files for PnR backend
-#  - Turn on every options here
-write_pnr_sdc --file ./SDC
-
-# Write SDC to constrain timing of configuration chain
-write_configuration_chain_sdc --file ./SDC/ccff_timing.sdc --time_unit ns --max_delay 5 --min_delay 2.5
-
-# Write SDC to disable timing for configure ports
-write_sdc_disable_timing_configure_ports --file ./SDC/disable_configure_ports.sdc
-
-# Write the SDC to run timing analysis for a mapped FPGA fabric
-write_analysis_sdc --file ./SDC_analysis
-
 # Finish and exit OpenFPGA
 exit
 


### PR DESCRIPTION
---
name: Pull request
about: Push a change to this project
---

### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [ ] Breaking new feature. If so, please decribe details in the description part.
Removing verilog testbench generation as lot of disk space is required and test bench generation is anyways not required as these tests are not running simulation.
### Describe the technical details
- What is currently done? (Provide issue link if applicable)
- What does this pull request change?

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
