### PR TITLE
Fabric bitstream writer supports multiple regions

### DIFF
--- a/docs/source/manual/file_formats/fabric_bitstream.rst
+++ b/docs/source/manual/file_formats/fabric_bitstream.rst
@@ -19,11 +19,31 @@ The information depends on the type of configuration procotol.
 
 .. option:: scan_chain
 
-  A line consisting of ``0`` | ``1``
+  Multiple lines consisting of ``0`` | ``1``
+
+  For example, a bitstream for 1 configuration regions:
+
+  .. code-block:: xml 
+
+     0
+     1
+     0
+     0
+
+  For example, a bitstream for 4 configuration regions:
+
+  .. code-block:: xml 
+
+     0000
+     1010
+     0110
+     0120
+
+  .. note:: When there are multiple configuration regions, each line may consist of multiple bits. For example, ``0110`` represents the bits for 4 configuration regions, where the 4 digits correspond to the bits from region ``0, 1, 2, 3`` respectively.
 
 .. option:: memory_bank
 
-  Multiple lines will be included, each of which is organized as <address><space><bit>.
+  Multiple lines will be included, each of which is organized as <address><space><bits>.
   Note that due to the use of Bit-Line and Word-Line decoders, every two lines are paired.
   The first line represents the Bit-Line address and configuration bit.
   The second line represents the Word-Line address and configuration bit.
@@ -39,11 +59,15 @@ The information depends on the type of configuration procotol.
      <bitline_address> <bit_value> 
      <wordline_address> <bit_value> 
 
+  .. note:: When there are multiple configuration regions, each ``<bit_value>`` may consist of multiple bits. For example, ``0110`` represents the bits for 4 configuration regions, where the 4 digits correspond to the bits from region ``0, 1, 2, 3`` respectively.
+
 .. option:: frame_based 
 
-  Multiple lines will be included, each of which is organized as <address><space><bit>.
+  Multiple lines will be included, each of which is organized as <address><space><bits>.
   Note that the address may include don't care bit which is denoted as ``x``.
-  OpenFPGA automatically convert don't care bit to logic ``0`` when generating testbenches.
+
+  .. note:: OpenFPGA automatically convert don't care bit to logic ``0`` when generating testbenches.
+
   For example
    
   .. code-block:: xml 
@@ -53,6 +77,7 @@ The information depends on the type of configuration procotol.
      ...
      <frame_address> <bit_value> 
 
+  .. note:: When there are multiple configuration regions, each ``<bit_value>`` may consist of multiple bits. For example, ``0110`` represents the bits for 4 configuration regions, where the 4 digits correspond to the bits from region ``0, 1, 2, 3`` respectively.
 
 .. _file_formats_fabric_bitstream_xml:
 
@@ -61,7 +86,21 @@ XML (.xml)
 
 This file format is designed to generate testbenches using external tools, e.g., CocoTB.
 
-In principle, the file consist a number of XML node ``<bit>``, each bit contains the following attributes:
+In principle, the file consist a number of XML node ``<region>``, each region has a unique id, and contains a number of XML nodes ``<bit>``.
+
+- ``id``: The unique id of a configuration region in the fabric bitstream.
+
+A quick example:
+
+.. code-block:: xml
+
+  <region id="0">
+    <bit id="0" value="1" path="fpga_top.grid_clb_1__2_.logical_tile_clb_mode_clb__0.mem_fle_9_in_5.mem_out[0]"/>
+    </bit>
+  </region>
+
+
+Each XML node ``<bit>`` contains the following attributes:
 
 - ``id``: The unique id of the configuration bit in the fabric bitstream.
 

--- a/openfpga/src/fpga_bitstream/write_xml_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_xml_fabric_bitstream.cpp
@@ -162,7 +162,7 @@ int write_fabric_regional_config_bit_to_xml_file(std::fstream& fp,
   int status = 0;
 
   write_tab_to_file(fp, xml_hierarchy_depth);
-  fp << "<region";
+  fp << "<region ";
   fp << "id=\"";
   fp << size_t(fabric_region);
   fp << "\"";

--- a/openfpga/src/fpga_bitstream/write_xml_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_xml_fabric_bitstream.cpp
@@ -71,12 +71,13 @@ int write_fabric_config_bit_to_xml_file(std::fstream& fp,
                                         const BitstreamManager& bitstream_manager,
                                         const FabricBitstream& fabric_bitstream,
                                         const FabricBitId& fabric_bit,
-                                        const e_config_protocol_type& config_type) {
+                                        const e_config_protocol_type& config_type,
+                                        const int& xml_hierarchy_depth) {
   if (false == valid_file_stream(fp)) {
     return 1;
   }
 
-  write_tab_to_file(fp, 1);
+  write_tab_to_file(fp, xml_hierarchy_depth);
   fp << "<bit id=\"" << size_t(fabric_bit) << "\"";
   fp << " value=\"";
   fp << bitstream_manager.bit_value(fabric_bitstream.config_bit(fabric_bit));
@@ -104,14 +105,14 @@ int write_fabric_config_bit_to_xml_file(std::fstream& fp,
     break;
   case CONFIG_MEM_MEMORY_BANK: { 
     /* Bit line address */
-    write_tab_to_file(fp, 2);
+    write_tab_to_file(fp, xml_hierarchy_depth + 1);
     fp << "<bl address=\"";
     for (const char& addr_bit : fabric_bitstream.bit_bl_address(fabric_bit)) {
       fp << addr_bit;
     }
     fp << "\"/>\n";   
  
-    write_tab_to_file(fp, 2);
+    write_tab_to_file(fp, xml_hierarchy_depth + 1);
     fp << "<wl address=\"";
     for (const char& addr_bit : fabric_bitstream.bit_wl_address(fabric_bit)) {
       fp << addr_bit;
@@ -120,7 +121,7 @@ int write_fabric_config_bit_to_xml_file(std::fstream& fp,
     break;
   }
   case CONFIG_MEM_FRAME_BASED: {
-    write_tab_to_file(fp, 2);
+    write_tab_to_file(fp, xml_hierarchy_depth + 1);
     fp << "<frame address=\"";
     for (const char& addr_bit : fabric_bitstream.bit_address(fabric_bit)) {
       fp << addr_bit;
@@ -134,10 +135,54 @@ int write_fabric_config_bit_to_xml_file(std::fstream& fp,
     return 1;
   }
 
-  write_tab_to_file(fp, 1);
+  write_tab_to_file(fp, xml_hierarchy_depth);
   fp << "</bit>\n";
 
   return 0;
+}
+
+/********************************************************************
+ * Write the fabric bitstream in a specific configuration region to an XML file 
+ *
+ * Return:
+ *  - 0 if succeed
+ *  - 1 if critical errors occured
+ *******************************************************************/
+static 
+int write_fabric_regional_config_bit_to_xml_file(std::fstream& fp,
+                                                 const BitstreamManager& bitstream_manager,
+                                                 const FabricBitstream& fabric_bitstream,
+                                                 const FabricBitRegionId& fabric_region,
+                                                 const e_config_protocol_type& config_type,
+                                                 const int& xml_hierarchy_depth) {
+  if (false == valid_file_stream(fp)) {
+    return 1;
+  }
+
+  int status = 0;
+
+  write_tab_to_file(fp, xml_hierarchy_depth);
+  fp << "<region";
+  fp << "id=\"";
+  fp << size_t(fabric_region);
+  fp << "\"";
+  fp << ">\n";
+
+  for (const FabricBitId& fabric_bit : fabric_bitstream.region_bits(fabric_region)) {
+    status = write_fabric_config_bit_to_xml_file(fp, bitstream_manager,
+                                                 fabric_bitstream,
+                                                 fabric_bit,
+                                                 config_type,
+                                                 xml_hierarchy_depth + 1);
+    if (1 == status) {
+      return status;
+    }
+  }
+
+  write_tab_to_file(fp, xml_hierarchy_depth);
+  fp << "</region>\n";
+
+  return status;
 }
 
 /********************************************************************
@@ -173,15 +218,17 @@ int write_fabric_bitstream_to_xml_file(const BitstreamManager& bitstream_manager
   /* Write XML head */
   write_fabric_bitstream_xml_file_head(fp);
 
+  int xml_hierarchy_depth = 0;
   fp << "<fabric_bitstream>\n";
 
   /* Output fabric bitstream to the file */
   int status = 0;
-  for (const FabricBitId& fabric_bit : fabric_bitstream.bits()) {
-    status = write_fabric_config_bit_to_xml_file(fp, bitstream_manager,
-                                                 fabric_bitstream,
-                                                 fabric_bit,
-                                                 config_protocol.type());
+  for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
+    status = write_fabric_regional_config_bit_to_xml_file(fp, bitstream_manager,
+                                                          fabric_bitstream,
+                                                          region,
+                                                          config_protocol.type(),
+                                                          xml_hierarchy_depth + 1);
     if (1 == status) {
       break;
     }

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1484,24 +1484,7 @@ void print_verilog_top_testbench_configuration_chain_bitstream(std::fstream& fp,
   VTR_ASSERT(num_bits_to_skip < regional_bitstream_max_size);
 
   /* Reorganize the regional bitstreams to be the same size */
-  std::vector<std::vector<bool>> regional_bitstreams;
-  regional_bitstreams.reserve(fabric_bitstream.regions().size());
-  for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
-    std::vector<bool> curr_regional_bitstream;
-    curr_regional_bitstream.resize(regional_bitstream_max_size, false);
-    /* Starting index should consider the offset between the current bitstream size and 
-     * the maximum size of regional bitstream
-     */
-    size_t offset = regional_bitstream_max_size - fabric_bitstream.region_bits(region).size();
-    for (const FabricBitId& bit_id : fabric_bitstream.region_bits(region)) {
-      curr_regional_bitstream[offset] = bitstream_manager.bit_value(fabric_bitstream.config_bit(bit_id));
-      offset++;
-    }
-    VTR_ASSERT(offset == regional_bitstream_max_size);
-   
-    /* Add the adapt sub-bitstream */
-    regional_bitstreams.push_back(curr_regional_bitstream);
-  }
+  ConfigChainFabricBitstream regional_bitstreams = build_config_chain_fabric_bitstream_by_region(bitstream_manager, fabric_bitstream);
 
   /* Attention: when the fast configuration is enabled, we will start from the first bit '1'
    * This requires a reset signal (as we forced in the first clock cycle)

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1602,7 +1602,7 @@ void print_verilog_top_testbench_memory_bank_bitstream(std::fstream& fp,
   fp << std::endl;
 
   /* Reorganize the fabric bitstream by the same address across regions */
-  std::map<std::pair<std::string, std::string>, std::vector<bool>> fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
+  MemoryBankFabricBitstream fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
 
   for (const auto& addr_din_pair : fabric_bits_by_addr) {
     /* When fast configuration is enabled,
@@ -1711,7 +1711,7 @@ void print_verilog_top_testbench_frame_decoder_bitstream(std::fstream& fp,
   fp << std::endl;
 
   /* Reorganize the fabric bitstream by the same address across regions */
-  std::map<std::string, std::vector<bool>> fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
+  FrameFabricBitstream fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
 
   for (const auto& addr_din_pair : fabric_bits_by_addr) {
     /* When fast configuration is enabled,

--- a/openfpga/src/utils/fabric_bitstream_utils.cpp
+++ b/openfpga/src/utils/fabric_bitstream_utils.cpp
@@ -78,8 +78,8 @@ size_t find_configuration_chain_fabric_bitstream_size_to_be_skipped(const Fabric
  *
  * Note: the std::map may cause large memory footprint for large bitstream databases!
  *******************************************************************/
-std::map<std::string, std::vector<bool>> build_frame_based_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream) {
-  std::map<std::string, std::vector<bool>> fabric_bits_by_addr;
+FrameFabricBitstream build_frame_based_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream) {
+  FrameFabricBitstream fabric_bits_by_addr;
   for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
     for (const FabricBitId& bit_id : fabric_bitstream.region_bits(region)) {
       /* Create string for address */
@@ -129,7 +129,7 @@ std::map<std::string, std::vector<bool>> build_frame_based_fabric_bitstream_by_a
  *******************************************************************/
 size_t find_frame_based_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
                                                                  const bool& bit_value_to_skip) {
-  std::map<std::string, std::vector<bool>> fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
+  FrameFabricBitstream fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
 
   size_t num_bits = 0;
 
@@ -161,8 +161,8 @@ size_t find_frame_based_fast_configuration_fabric_bitstream_size(const FabricBit
  *
  * Note: the std::map may cause large memory footprint for large bitstream databases!
  *******************************************************************/
-std::map<std::pair<std::string, std::string>, std::vector<bool>> build_memory_bank_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream) {
-  std::map<std::pair<std::string, std::string>, std::vector<bool>> fabric_bits_by_addr;
+MemoryBankFabricBitstream build_memory_bank_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream) {
+  MemoryBankFabricBitstream fabric_bits_by_addr;
   for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
     for (const FabricBitId& bit_id : fabric_bitstream.region_bits(region)) {
       /* Create string for BL address */
@@ -217,7 +217,7 @@ std::map<std::pair<std::string, std::string>, std::vector<bool>> build_memory_ba
  *******************************************************************/
 size_t find_memory_bank_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
                                                                  const bool& bit_value_to_skip) {
-  std::map<std::pair<std::string, std::string>, std::vector<bool>> fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
+  MemoryBankFabricBitstream fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
 
   size_t num_bits = 0;
 

--- a/openfpga/src/utils/fabric_bitstream_utils.h
+++ b/openfpga/src/utils/fabric_bitstream_utils.h
@@ -24,13 +24,16 @@ size_t find_fabric_regional_bitstream_max_size(const FabricBitstream& fabric_bit
 size_t find_configuration_chain_fabric_bitstream_size_to_be_skipped(const FabricBitstream& fabric_bitstream,
                                                                     const BitstreamManager& bitstream_manager,
                                                                     const bool& bit_value_to_skip);
-
-std::map<std::string, std::vector<bool>> build_frame_based_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream);
+/* Alias to a specific organization of bitstreams for frame-based configuration protocol */
+typedef std::map<std::string, std::vector<bool>> FrameFabricBitstream;
+FrameFabricBitstream build_frame_based_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream);
 
 size_t find_frame_based_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
                                                                  const bool& bit_value_to_skip);
 
-std::map<std::pair<std::string, std::string>, std::vector<bool>> build_memory_bank_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream);
+/* Alias to a specific organization of bitstreams for memory bank configuration protocol */
+typedef std::map<std::pair<std::string, std::string>, std::vector<bool>> MemoryBankFabricBitstream;
+MemoryBankFabricBitstream build_memory_bank_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream);
 
 size_t find_memory_bank_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
                                                                  const bool& bit_value_to_skip);

--- a/openfpga/src/utils/fabric_bitstream_utils.h
+++ b/openfpga/src/utils/fabric_bitstream_utils.h
@@ -24,6 +24,12 @@ size_t find_fabric_regional_bitstream_max_size(const FabricBitstream& fabric_bit
 size_t find_configuration_chain_fabric_bitstream_size_to_be_skipped(const FabricBitstream& fabric_bitstream,
                                                                     const BitstreamManager& bitstream_manager,
                                                                     const bool& bit_value_to_skip);
+
+/* Alias to a specific organization of bitstreams for frame-based configuration protocol */
+typedef std::vector<std::vector<bool>> ConfigChainFabricBitstream;
+ConfigChainFabricBitstream build_config_chain_fabric_bitstream_by_region(const BitstreamManager& bitstream_manager,
+                                                                         const FabricBitstream& fabric_bitstream);
+
 /* Alias to a specific organization of bitstreams for frame-based configuration protocol */
 typedef std::map<std::string, std::vector<bool>> FrameFabricBitstream;
 FrameFabricBitstream build_frame_based_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream);


### PR DESCRIPTION
### Motivate of the pull request
- [X] To address an existing issue. If so, please provide a link to the issue.
- [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)
To address issue #268 
Previously, OpenFPGA's fabric bitstream file formats only supports single configuration region.

- What does this pull request change?
This PR improves the fabric bitstream writers to output bitstream files supporting multiple configuration regions.
- [X] Added ``<region id="<int>"/>`` to XML files describing fabric bitstreams, so that users can extract bitstreams for different configuration regions
- [X] Reworked the plain text format, where configuration bits from multiple regions are written in one lines (the bits are supposed to be loaded to configuration protocols in the same clock cycle).
- [X] Documentation has been updated for the file format changes
- [X] Use alias to complex data types used in fabric bitstreams, in order to make future refactoring easier


### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [X] FPGA-Verilog
- [X] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [X] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
