### PR TITLE
Enable correct reset stimuli in testbench generators

### DIFF
--- a/libopenfpga/libpcf/src/pin_constraints.cpp
+++ b/libopenfpga/libpcf/src/pin_constraints.cpp
@@ -81,3 +81,11 @@ PinConstraintId PinConstraints::create_pin_constraint(const openfpga::BasicPort&
 bool PinConstraints::valid_pin_constraint_id(const PinConstraintId& pin_constraint_id) const {
   return ( size_t(pin_constraint_id) < pin_constraint_ids_.size() ) && ( pin_constraint_id == pin_constraint_ids_[pin_constraint_id] ); 
 }
+
+bool PinConstraints::unconstrained_net(const std::string& net) const {
+  return net.empty();
+}
+
+bool PinConstraints::unmapped_net(const std::string& net) const {
+  return std::string(PIN_CONSTRAINT_OPEN_NET) == net;
+}

--- a/libopenfpga/libpcf/src/pin_constraints.cpp
+++ b/libopenfpga/libpcf/src/pin_constraints.cpp
@@ -49,6 +49,17 @@ std::string PinConstraints::pin_net(const openfpga::BasicPort& pin) const {
   return constrained_net_name;
 }
 
+openfpga::BasicPort PinConstraints::net_pin(const std::string& net) const {
+  openfpga::BasicPort constrained_pin;
+  for (const PinConstraintId& pin_constraint : pin_constraints()) {
+    if (net == pin_constraint_nets_[pin_constraint]) {
+      constrained_pin = pin(pin_constraint); 
+      break;
+    }
+  }
+  return constrained_pin;
+} 
+
 bool PinConstraints::empty() const {
   return 0 == pin_constraint_ids_.size();
 }

--- a/libopenfpga/libpcf/src/pin_constraints.h
+++ b/libopenfpga/libpcf/src/pin_constraints.h
@@ -61,7 +61,6 @@ class PinConstraints {
     bool empty() const;
 
   public: /* Public Mutators */
-
     /* Reserve a number of design constraints to be memory efficent */
     void reserve_pin_constraints(const size_t& num_pin_constraints);
 
@@ -70,7 +69,22 @@ class PinConstraints {
                                           const std::string& net);
 
   public: /* Public invalidators/validators */
+    /* Show if the pin constraint id is a valid for data queries */
     bool valid_pin_constraint_id(const PinConstraintId& pin_constraint_id) const;
+
+    /* Show if the net has no constraints (free to map to any pin) 
+     * This function is used to identify the net name returned by APIs:
+     * - pin_net()
+     * - net()
+     */
+    bool unconstrained_net(const std::string& net) const;
+
+    /* Show if the net is defined specifically not to map to any pin 
+     * This function is used to identify the net name returned by APIs:
+     * - pin_net()
+     * - net()
+     */
+    bool unmapped_net(const std::string& net) const;
   private: /* Internal data */
     /* Unique ids for each design constraint */
     vtr::vector<PinConstraintId, PinConstraintId> pin_constraint_ids_;

--- a/libopenfpga/libpcf/src/pin_constraints.h
+++ b/libopenfpga/libpcf/src/pin_constraints.h
@@ -57,6 +57,12 @@ class PinConstraints {
      */
     std::string pin_net(const openfpga::BasicPort& pin) const;
 
+    /* Find the pin that a net is constrained to
+     * If not found, the return port will be an invalid BasicPort
+     * TODO: this function will only return the first pin found in the constraint list    
+     */
+    openfpga::BasicPort net_pin(const std::string& net) const; 
+
     /* Check if there are any pin constraints */
     bool empty() const;
 

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -203,6 +203,8 @@ int fpga_verilog_testbench(const ModuleManager &module_manager,
                                        random_top_testbench_file_path,
                                        atom_ctx,
                                        netlist_annotation,
+                                       module_manager,
+                                       fabric_global_port_info,
                                        pin_constraints,
                                        simulation_setting,
                                        options.explicit_port_mapping());

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -19,6 +19,7 @@
 
 #include "openfpga_atom_netlist_utils.h"
 #include "simulation_utils.h"
+#include "fabric_global_port_info_utils.h"
 
 #include "verilog_constants.h"
 #include "verilog_writer_utils.h"
@@ -168,6 +169,82 @@ void print_verilog_random_testbench_fpga_instance(std::fstream& fp,
   fp << std::endl;
 }
 
+/********************************************************************
+ * Generate random stimulus for the reset port
+ * This function is designed to drive the reset port of a benchmark module
+ * The reset signal will be 
+ * - enabled in the 1st clock cycle
+ * - disabled in the rest of clock cycles
+ *******************************************************************/
+static 
+void print_verilog_random_testbench_reset_stimuli(std::fstream& fp,
+                                                  const AtomContext& atom_ctx,
+                                                  const VprNetlistAnnotation& netlist_annotation,
+                                                  const ModuleManager& module_manager,
+                                                  const FabricGlobalPortInfo& global_ports,
+                                                  const PinConstraints& pin_constraints,
+                                                  const std::vector<std::string>& clock_port_names,
+                                                  const BasicPort& clock_port) {
+  valid_file_stream(fp);
+
+  print_verilog_comment(fp, "----- Begin reset signal generation -----");
+
+  for (const AtomBlockId& atom_blk : atom_ctx.nlist.blocks()) {
+    /* Bypass non-input atom blocks ! */
+    if (AtomBlockType::INPAD != atom_ctx.nlist.block_type(atom_blk)) {
+      continue;
+    }
+
+    /* The block may be renamed as it contains special characters which violate Verilog syntax */
+    std::string block_name = atom_ctx.nlist.block_name(atom_blk);
+    if (true == netlist_annotation.is_block_renamed(atom_blk)) {
+      block_name = netlist_annotation.block_name(atom_blk);
+    } 
+
+    /* Bypass clock ports because their stimulus cannot be random */
+    if (clock_port_names.end() != std::find(clock_port_names.begin(), clock_port_names.end(), block_name)) {
+      continue;
+    }
+
+    /* Bypass any constained net that are mapped to a global port of the FPGA fabric
+     * because their stimulus cannot be random
+     */
+    if (false == port_is_fabric_global_reset_port(global_ports, module_manager, pin_constraints.net_pin(block_name))) { 
+      continue;
+    }
+
+    /* Generete stimuli for this net which is how reset signal works */
+    BasicPort reset_port(block_name, 1);
+    size_t initial_value = 1;
+    if (1 == global_ports.global_port_default_value(find_fabric_global_port(global_ports, module_manager,  pin_constraints.net_pin(block_name)))) {
+      initial_value = 0;
+    }
+
+    fp << "initial" << std::endl;
+    fp << "\tbegin" << std::endl;
+    fp << "\t";
+    std::vector<size_t> initial_values(reset_port.get_width(), initial_value);
+    fp << "\t";
+    fp << generate_verilog_port_constant_values(reset_port, initial_values);
+    fp << ";" << std::endl;
+
+    /* Flip the reset at the second negative edge of the clock port
+     * So the generic reset stimuli is applicable to both synchronous reset and asynchronous reset
+     * This is because the reset is activated in a complete clock cycle 
+     * This gaurantees that even for synchronous reset, the reset can be sensed in the 1st rising/falling 
+     * edge of the clock signal
+     */
+    fp << "\t@(negedge " << generate_verilog_port(VERILOG_PORT_CONKT, clock_port) << ");" << std::endl;
+    fp << "\t@(negedge " << generate_verilog_port(VERILOG_PORT_CONKT, clock_port) << ");" << std::endl;
+    print_verilog_wire_connection(fp, reset_port, reset_port, true);
+    fp << "\tend" << std::endl;
+  }
+
+  print_verilog_comment(fp, "----- End reset signal generation -----");
+
+  fp << std::endl;
+}
+
 /*********************************************************************
  * Top-level function in this file:
  * Create a Verilog testbench using random input vectors 
@@ -197,6 +274,8 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
                                         const std::string& verilog_fname,
                                         const AtomContext& atom_ctx,
                                         const VprNetlistAnnotation& netlist_annotation,
+                                        const ModuleManager& module_manager,
+                                        const FabricGlobalPortInfo& global_ports,
                                         const PinConstraints& pin_constraints,
                                         const SimulationSetting& simulation_parameters,
                                         const bool& explicit_port_mapping) {
@@ -240,8 +319,23 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
                                         pin_constraints, 
                                         simulation_parameters, 
                                         clock_ports);
+  /* TODO: use the first clock now because we do not have information how the reset is 
+   * correlated to clock ports. Once we have such information, the limitation should be removed!
+   */
+  print_verilog_random_testbench_reset_stimuli(fp, 
+                                               atom_ctx,
+                                               netlist_annotation, 
+                                               module_manager,
+                                               global_ports, 
+                                               pin_constraints, 
+                                               clock_port_names, 
+                                               clock_ports[0]);
+
   print_verilog_testbench_random_stimuli(fp, atom_ctx,
                                          netlist_annotation, 
+                                         module_manager,
+                                         global_ports, 
+                                         pin_constraints, 
                                          clock_port_names, 
                                          std::string(CHECKFLAG_PORT_POSTFIX),
                                          clock_ports);

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.h
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.h
@@ -7,6 +7,8 @@
 #include <string>
 #include "vpr_context.h"
 #include "pin_constraints.h"
+#include "module_manager.h"
+#include "fabric_global_port_info.h"
 #include "simulation_setting.h"
 
 /********************************************************************
@@ -20,6 +22,8 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
                                         const std::string& verilog_fname,
                                         const AtomContext& atom_ctx,
                                         const VprNetlistAnnotation& netlist_annotation,
+                                        const ModuleManager& module_manager,
+                                        const FabricGlobalPortInfo& global_ports,
                                         const PinConstraints& pin_constraints,
                                         const SimulationSetting& simulation_parameters,
                                         const bool& explicit_port_mapping);

--- a/openfpga/src/fpga_verilog/verilog_preconfig_top_module.cpp
+++ b/openfpga/src/fpga_verilog/verilog_preconfig_top_module.cpp
@@ -138,7 +138,7 @@ int print_verilog_preconfig_top_module_connect_global_ports(std::fstream &fp,
         std::string constrained_net_name = pin_constraints.pin_net(module_clock_pin);
 
         /* If constrained to an open net or there is no clock in the benchmark, we assign it to a default value */
-        if ( (std::string(PIN_CONSTRAINT_OPEN_NET) == constrained_net_name)
+        if ( (true == pin_constraints.unmapped_net(constrained_net_name))
           || (true == benchmark_clock_port_names.empty())) {
           std::vector<size_t> default_values(1, fabric_global_ports.global_port_default_value(global_port_id));
           print_verilog_wire_constant_values(fp, module_clock_pin, default_values);
@@ -146,7 +146,7 @@ int print_verilog_preconfig_top_module_connect_global_ports(std::fstream &fp,
         }
 
         std::string clock_name_to_connect;
-        if (!constrained_net_name.empty()) {
+        if (!pin_constraints.unconstrained_net(constrained_net_name)) {
           clock_name_to_connect = constrained_net_name;
         } else {
           /* Otherwise, we must have a clear one-to-one clock net corresponding!!! */
@@ -178,8 +178,8 @@ int print_verilog_preconfig_top_module_connect_global_ports(std::fstream &fp,
       /* - If constrained to a given net in the benchmark, we connect the global pin to the net
        * - If constrained to an open net in the benchmark, we assign it to a default value 
        */
-      if ( (std::string(PIN_CONSTRAINT_OPEN_NET) != constrained_net_name)
-        && (!constrained_net_name.empty())) {
+      if ( (false == pin_constraints.unconstrained_net(constrained_net_name))
+        && (false == pin_constraints.unmapped_net(constrained_net_name))) {
         BasicPort benchmark_pin(constrained_net_name + std::string(FORMAL_VERIFICATION_TOP_MODULE_PORT_POSTFIX), 1);
         print_verilog_wire_connection(fp, module_global_pin, benchmark_pin, false);
       } else {

--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
@@ -21,6 +21,7 @@
 #include "verilog_port_types.h"
 
 #include "module_manager_utils.h"
+#include "fabric_global_port_info_utils.h"
 
 #include "verilog_constants.h"
 #include "verilog_writer_utils.h"
@@ -537,6 +538,9 @@ void print_verilog_testbench_clock_stimuli(std::fstream& fp,
 void print_verilog_testbench_random_stimuli(std::fstream& fp,
                                             const AtomContext& atom_ctx,
                                             const VprNetlistAnnotation& netlist_annotation,
+                                            const ModuleManager& module_manager,
+                                            const FabricGlobalPortInfo& global_ports,
+                                            const PinConstraints& pin_constraints,
                                             const std::vector<std::string>& clock_port_names,
                                             const std::string& check_flag_port_postfix,
                                             const std::vector<BasicPort>& clock_ports) {
@@ -560,8 +564,15 @@ void print_verilog_testbench_random_stimuli(std::fstream& fp,
       block_name = netlist_annotation.block_name(atom_blk);
     } 
 
-    /* Bypass clock ports */
+    /* Bypass clock ports because their stimulus cannot be random */
     if (clock_port_names.end() != std::find(clock_port_names.begin(), clock_port_names.end(), block_name)) {
+      continue;
+    }
+
+    /* Bypass any constained net that are mapped to a global port of the FPGA fabric
+     * because their stimulus cannot be random
+     */
+    if (true == port_is_fabric_global_reset_port(global_ports, module_manager, pin_constraints.net_pin(block_name))) { 
       continue;
     }
 
@@ -620,8 +631,15 @@ void print_verilog_testbench_random_stimuli(std::fstream& fp,
       block_name = netlist_annotation.block_name(atom_blk);
     } 
 
-    /* Bypass clock ports */
+    /* Bypass clock ports because their stimulus cannot be random */
     if (clock_port_names.end() != std::find(clock_port_names.begin(), clock_port_names.end(), block_name)) {
+      continue;
+    }
+
+    /* Bypass any constained net that are mapped to a global port of the FPGA fabric
+     * because their stimulus cannot be random
+     */
+    if (true == port_is_fabric_global_reset_port(global_ports, module_manager, pin_constraints.net_pin(block_name))) { 
       continue;
     }
 

--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.h
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.h
@@ -12,6 +12,7 @@
 #include "vpr_context.h"
 #include "io_location_map.h"
 #include "vpr_netlist_annotation.h"
+#include "fabric_global_port_info.h"
 #include "pin_constraints.h"
 #include "simulation_setting.h"
 
@@ -84,6 +85,9 @@ void print_verilog_testbench_clock_stimuli(std::fstream& fp,
 void print_verilog_testbench_random_stimuli(std::fstream& fp,
                                             const AtomContext& atom_ctx,
                                             const VprNetlistAnnotation& netlist_annotation,
+                                            const ModuleManager& module_manager,
+                                            const FabricGlobalPortInfo& global_ports,
+                                            const PinConstraints& pin_constraints,
                                             const std::vector<std::string>& clock_port_names,
                                             const std::string& check_flag_port_postfix,
                                             const std::vector<BasicPort>& clock_ports);

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -409,8 +409,8 @@ void print_verilog_top_testbench_global_reset_ports_stimuli(std::fstream& fp,
         std::string constrained_net_name = pin_constraints.pin_net(module_global_pin);
 
         /* - If constrained to a given net in the benchmark, we connect the global pin to the net */
-        if ( (std::string(PIN_CONSTRAINT_OPEN_NET) != constrained_net_name)
-          && (!constrained_net_name.empty())) {
+        if ( (false == pin_constraints.unconstrained_net(constrained_net_name))
+          && (false == pin_constraints.unmapped_net(constrained_net_name))) {
           BasicPort benchmark_pin(constrained_net_name, 1);
           print_verilog_wire_connection(fp, module_global_pin,
                                         benchmark_pin,

--- a/openfpga/src/utils/fabric_global_port_info_utils.h
+++ b/openfpga/src/utils/fabric_global_port_info_utils.h
@@ -6,6 +6,7 @@
  *******************************************************************/
 #include <vector>
 #include "fabric_global_port_info.h"
+#include "module_manager.h"
 
 /********************************************************************
  * Function declaration
@@ -17,6 +18,14 @@ namespace openfpga {
 std::vector<FabricGlobalPortId> find_fabric_global_programming_reset_ports(const FabricGlobalPortInfo& fabric_global_port_info);
 
 std::vector<FabricGlobalPortId> find_fabric_global_programming_set_ports(const FabricGlobalPortInfo& fabric_global_port_info);
+
+bool port_is_fabric_global_reset_port(const FabricGlobalPortInfo& fabric_global_port_info,
+                                      const ModuleManager& module_manager,
+                                      const BasicPort& port);
+
+FabricGlobalPortId find_fabric_global_port(const FabricGlobalPortInfo& fabric_global_port_info,
+                                           const ModuleManager& module_manager,
+                                           const BasicPort& port);
 
 } /* end namespace openfpga */
 


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [X] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details
- What is currently done? (Provide issue link if applicable)

Currently, OpenFPGA assign random waveforms to drive reset pins of users' HDL designs in both full testbench and preconfigured testbench.
This has causes verification to be low coverage for those benchmarks with reset signals. 

- What does this pull request change?

This PR improves the testbench generator to
- [x] Wire reset pin to be driven by the generic reset/set stimuli in both full testbench and preconfigured testbench, **when there is a pin constraint forcing a net mapped to a reset pin of FPGA fabric**.
- [X] Also this PR improves the APIs of pin constraints data structure to help developers to analyze the meaning of net name returned by data queries.

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [X] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [X] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
