### PR TITLE
Enable constant net routing for VTR benchmarks

### DIFF
--- a/openfpga_flow/openfpga_shell_scripts/vtr_benchmark_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/vtr_benchmark_example_script.openfpga
@@ -1,8 +1,8 @@
 # Run VPR for the 'and' design
 # When the global clock is defined as a port of a tile, clock routing in VPR should be skipped
 # This is due to the Fc_in of clock port is set to 0 for global wiring
-#--write_rr_graph example_rr_graph.xml
-vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --route_chan_width ${VPR_ROUTE_CHAN_WIDTH}
+# The constant net such as logic '0' and logic '1' must be routed because current architecture cannot produce them locally
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --route_chan_width ${VPR_ROUTE_CHAN_WIDTH} --constant_net_method route
 
 # Read OpenFPGA architecture definition
 read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}


### PR DESCRIPTION
### Motivate of the pull request
- [ ] To address an existing issue. If so, please provide a link to the issue.
- [X] Breaking new feature. If so, please decribe details in the description part.

### Describe the technical details

- What is currently done? (Provide issue link if applicable)

Currently, the openfpga shell script for VTR benchmarks does not route constant nets, which are very popular in the modern benchmarks.

- What does this pull request change?

This PR enables constant net routing for VTR benchmarks.

### Which part of the code base require a change
**In general, modification on existing submodules are not acceptable. You should push changes to upstream.**
- [ ] VPR
- [ ] OpenFPGA libraries
- [ ] FPGA-Verilog
- [ ] FPGA-Bitstream
- [ ] FPGA-SDC
- [ ] FPGA-SPICE
- [ ] Flow scripts
- [ ] Architecture library
- [ ] Cell library

### Checklist of the pull request
- [ ] Require code changes. 
- [ ] Require new tests to be added
- [ ] Require an update on documentation

### Impact of the pull request
- [ ] Require a change on Quality of Results (QoR)
- [ ] Break back-compatibility. If so, please list who may be influenced.
