### PR TITLE
Test addition for FPGA architecture with multi-width DSP blocks

### DIFF
--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -50,6 +50,9 @@ run-task fpga_verilog/dsp/single_mode_mult_8x8 --debug --show_thread_logs
 echo -e "Testing Verilog generation with heterogeneous fabric using 16-bit multi-mode multipliers ";
 run-task fpga_verilog/dsp/multi_mode_mult_16x16 --debug --show_thread_logs
 
+echo -e "Testing Verilog generation with heterogeneous fabric using multi-width 16-bit multi-mode multipliers ";
+run-task fpga_verilog/dsp/wide_multi_mode_mult_16x16 --debug --show_thread_logs
+
 echo -e "Testing Verilog generation with different I/O capacities on each side of an FPGA ";
 run-task fpga_verilog/io/multi_io_capacity --debug --show_thread_logs
 

--- a/openfpga_flow/tasks/fpga_verilog/dsp/wide_multi_mode_mult_16x16/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/dsp/wide_multi_mode_mult_16x16/config/task.conf
@@ -1,0 +1,45 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_heterogeneous_device_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadder_register_scan_chain_frac_dsp16_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+# Yosys script parameters
+yosys_cell_sim_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k4_frac_N8_tileable_reset_softadder_register_scan_chain_frac_dsp16_nonLR_caravel_io_skywater130nm_cell_sim.v
+yosys_dsp_map_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k4_frac_N8_tileable_reset_softadder_register_scan_chain_frac_dsp16_nonLR_caravel_io_skywater130nm_dsp_map.v
+yosys_dsp_map_parameters=-D DSP_A_MAXWIDTH=8 -D DSP_B_MAXWIDTH=8 -D DSP_A_MINWIDTH=2 -D DSP_B_MINWIDTH=2 -D DSP_NAME=mult_8x8
+# VPR parameter
+openfpga_vpr_device_layout=4x4
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_wide_frac_dsp16_nonLR_caravel_io_skywater130nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_8/mac_8.v
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_16/mac_16.v
+
+[SYNTHESIS_PARAM]
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dsp_flow.ys
+bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys
+
+bench0_top = mac_8
+bench1_top = mac_16
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_wide_frac_dsp16_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_wide_frac_dsp16_nonLR_caravel_io_skywater130nm.xml
@@ -1,0 +1,966 @@
+<!-- 
+  Low-cost homogeneous FPGA Architecture.
+
+  - Skywater 130 nm technology
+  - General purpose logic block: 
+    K = 4, N = 8, fracturable 4 LUTs (can operate as one 4-LUT or two 3-LUTs with all 3 inputs shared)
+    with optionally registered outputs
+  - Heterogeneous block
+    8-bit multiplier
+  - Routing architecture:
+      - 10% L = 1, fc_in = 0.15, Fc_out = 0.10
+      - 10% L = 2, fc_in = 0.15, Fc_out = 0.10
+      - 80% L = 4, fc_in = 0.15, Fc_out = 0.10
+      - 100 routing tracks per channel
+
+  Authors: Xifan Tang
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <model name="mult_8">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <model name="mult_16">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="adder_lut4">
+      <input_ports>
+        <port name="in" combinational_sink_ports="lut2_out lut4_out"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower_physical">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="reset" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+         If you need to register the I/O, define clocks in the circuit models
+         These clocks can be handled in back-end
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" capacity="9" area="0">
+      <equivalent_sites>
+        <site pb_type="io"/>
+      </equivalent_sites>
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="custom">
+        <loc side="bottom">io_top.outpad io_top.inpad</loc>
+      </pinlocations>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" capacity="9" area="0">
+      <equivalent_sites>
+        <site pb_type="io"/>
+      </equivalent_sites>
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="custom">
+        <loc side="left">io_right.outpad io_right.inpad</loc>
+      </pinlocations>
+    </tile>
+    <!-- Bottom-side has 9 I/O per tile -->
+    <tile name="io_bottom" capacity="9" area="0">
+      <equivalent_sites>
+        <site pb_type="io"/>
+      </equivalent_sites>
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="custom">
+        <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+      </pinlocations>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" capacity="9" area="0">
+      <equivalent_sites>
+        <site pb_type="io"/>
+      </equivalent_sites>
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="custom">
+        <loc side="right">io_left.outpad io_left.inpad</loc>
+      </pinlocations>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <equivalent_sites>
+        <site pb_type="clb"/>
+      </equivalent_sites>
+      <input name="I0" num_pins="2" equivalent="full"/>
+      <input name="I0i" num_pins="2" equivalent="none"/>
+      <input name="I1" num_pins="2" equivalent="full"/>
+      <input name="I1i" num_pins="2" equivalent="none"/>
+      <input name="I2" num_pins="2" equivalent="full"/>
+      <input name="I2i" num_pins="2" equivalent="none"/>
+      <input name="I3" num_pins="2" equivalent="full"/>
+      <input name="I3i" num_pins="2" equivalent="none"/>
+      <input name="I4" num_pins="2" equivalent="full"/>
+      <input name="I4i" num_pins="2" equivalent="none"/>
+      <input name="I5" num_pins="2" equivalent="full"/>
+      <input name="I5i" num_pins="2" equivalent="none"/>
+      <input name="I6" num_pins="2" equivalent="full"/>
+      <input name="I6i" num_pins="2" equivalent="none"/>
+      <input name="I7" num_pins="2" equivalent="full"/>
+      <input name="I7i" num_pins="2" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+        <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+      </fc>
+      <!--pinlocations pattern="spread"/-->
+      <pinlocations pattern="custom">
+        <loc side="left">clb.clk clb.reset</loc>
+        <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>
+        <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+        <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
+      </pinlocations>
+    </tile>
+    <tile name="mult_16" height="2" width="2" area="396000">
+      <equivalent_sites>
+        <site pb_type="mult_16" pin_mapping="direct"/>
+      </equivalent_sites>
+      <input name="a" num_pins="16"/>
+      <input name="b" num_pins="16"/>
+      <output name="out" num_pins="32"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+      <!--pinlocations pattern="spread"/-->
+      <pinlocations pattern="custom">
+        <loc side="left" yoffset="0">mult_16.a[0:1] mult_16.b[0:1] mult_16.out[0:3]</loc>
+        <loc side="left" yoffset="1">mult_16.a[2:3] mult_16.b[2:3] mult_16.out[4:7]</loc>
+        <loc side="top" xoffset="0" yoffset="1">mult_16.a[4:5] mult_16.b[4:5] mult_16.out[8:11]</loc>
+        <loc side="top" xoffset="1" yoffset="1">mult_16.a[6:7] mult_16.b[6:7] mult_16.out[12:15]</loc>
+        <loc side="right" xoffset="1" yoffset="0">mult_16.a[8:9] mult_16.b[8:9] mult_16.out[16:19]</loc>
+        <loc side="right" xoffset="1" yoffset="1">mult_16.a[10:11] mult_16.b[10:11] mult_16.out[20:23]</loc>
+        <loc side="bottom" xoffset="0">mult_16.a[12:13] mult_16.b[12:13] mult_16.out[24:27]</loc>
+        <loc side="bottom" xoffset="1">mult_16.a[14:15] mult_16.b[14:15] mult_16.out[28:31]</loc>
+      </pinlocations>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </auto_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	       book area formula. This means the mux transistors are about 5x minimum drive strength.
+	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+	       2.5x when looking up in Jeff's tables.
+	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+           If you need to register the I/O, define clocks in the circuit models
+           These clocks can be handled in back-end
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
+         the 4 inputs of fracturable LUT4 are no longer equivalent, 
+         because the 4th input can not be switched when the dual-LUT3 modes are used.
+         So pin equivalence should be applied to the first 3 inputs only
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="2" equivalent="full"/>
+      <input name="I0i" num_pins="2" equivalent="none"/>
+      <input name="I1" num_pins="2" equivalent="full"/>
+      <input name="I1i" num_pins="2" equivalent="none"/>
+      <input name="I2" num_pins="2" equivalent="full"/>
+      <input name="I2i" num_pins="2" equivalent="none"/>
+      <input name="I3" num_pins="2" equivalent="full"/>
+      <input name="I3i" num_pins="2" equivalent="none"/>
+      <input name="I4" num_pins="2" equivalent="full"/>
+      <input name="I4i" num_pins="2" equivalent="none"/>
+      <input name="I5" num_pins="2" equivalent="full"/>
+      <input name="I5i" num_pins="2" equivalent="none"/>
+      <input name="I6" num_pins="2" equivalent="full"/>
+      <input name="I6i" num_pins="2" equivalent="none"/>
+      <input name="I7" num_pins="2" equivalent="full"/>
+      <input name="I7i" num_pins="2" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
+             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+             The outputs of the fracturable logic element can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reg_in" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="cin" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="2"/>
+              <output name="cout" num_pins="1"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut2_out" num_pins="2"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">
+                <input name="a" num_pins="1"/>
+                <input name="b" num_pins="1"/>
+                <input name="cin" num_pins="1"/>
+                <output name="cout" num_pins="1"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>
+                <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>
+                <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>
+                <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
+                <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
+                <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
+                <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+                <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <input name="reset" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>         
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>
+              <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>
+              <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>
+              <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>
+              <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Arithmetic mode definition begin -->
+        <mode name="arithmetic">
+          <pb_type name="soft_adder" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="sumout" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <!-- Define special LUT marco to be used as adder -->
+            <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="lut2_out" num_pins="2"/>
+              <output name="lut4_out" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>
+            </pb_type>
+            <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>
+              <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>
+              <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>
+              </direct>
+              <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">
+                <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
+                     considered by packer -->
+                <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>
+              </direct>
+              <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
+              </direct>
+              <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>
+              </direct>
+              <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
+              </direct>
+              <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="soft_adder.in"/>
+            <direct name="direct2" input="fle.cin" output="soft_adder.cin">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>
+            </direct>
+            <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>
+            <direct name="direct4" input="soft_adder.cout" output="fle.cout">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Arithmetic mode definition end -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                           we instead take the average of these numbers to get more stable results
+                      82e-12
+                      173e-12
+                      261e-12
+                      263e-12
+                      398e-12
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  235e-12
+                  235e-12
+                  235e-12
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  398e-12
+                  397e-12
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                261e-12
+                261e-12
+                261e-12
+                261e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="reg_in" num_pins="1"/>
+            <output name="ff_out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>
+              <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>
+              <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end --> 
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
+             The global local routing is going to compensate the loss in routability
+          -->
+        <!-- FIXME: The implicit port definition results in I0[0] connected to
+                    in[2]. Such twisted connection is not expected.
+                    I[0] should be connected to in[0]
+          -->
+        <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+               naive specification).
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
+          <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <pb_type name="mult_16">
+      <input name="a" num_pins="16"/>
+      <input name="b" num_pins="16"/>
+      <output name="out" num_pins="32"/>
+      <mode name="mult_8x8">
+        <pb_type name="mult_8x8_slice" num_pb="2">
+          <input name="A_cfg" num_pins="8"/>
+          <input name="B_cfg" num_pins="8"/>
+          <output name="OUT_cfg" num_pins="16"/>
+          <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">
+            <input name="A" num_pins="8"/>
+            <input name="B" num_pins="8"/>
+            <output name="Y" num_pins="16"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.A">
+            </direct>
+            <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.B">
+            </direct>
+            <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="a2a_0" input="mult_16.a[0:7]" output="mult_8x8_slice[0].A_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[0:7]" out_port="mult_8x8_slice[0].A_cfg[0:7]"/>
+          </direct>
+          <direct name="a2a_1" input="mult_16.a[8:15]" output="mult_8x8_slice[1].A_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[8:15]" out_port="mult_8x8_slice[1].A_cfg[0:7]"/>
+          </direct>
+          <direct name="b2b_0" input="mult_16.b[0:7]" output="mult_8x8_slice[0].B_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[0:7]" out_port="mult_8x8_slice[0].B_cfg[0:7]"/>
+          </direct>
+          <direct name="b2b_1" input="mult_16.b[8:15]" output="mult_8x8_slice[1].B_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[8:15]" out_port="mult_8x8_slice[1].B_cfg[0:7]"/>
+          </direct>
+          <direct name="out2out_0" input="mult_8x8_slice[0].OUT_cfg[0:15]" output="mult_16.out[0:15]">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[0].OUT_cfg[0:15]" out_port="mult_16.out[0:15]"/>
+          </direct>
+          <direct name="out2out_1" input="mult_8x8_slice[1].OUT_cfg[0:15]" output="mult_16.out[16:31]">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[1].OUT_cfg[0:15]" out_port="mult_16.out[16:31]"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_16x16">
+        <pb_type name="mult_16x16_slice" num_pb="1">
+          <input name="A_cfg" num_pins="16"/>
+          <input name="B_cfg" num_pins="16"/>
+          <output name="OUT_cfg" num_pins="32"/>
+          <pb_type name="mult_16x16" blif_model=".subckt mult_16" num_pb="1">
+            <input name="A" num_pins="16"/>
+            <input name="B" num_pins="16"/>
+            <output name="Y" num_pins="32"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.A" out_port="mult_16x16.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.B" out_port="mult_16x16.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_16x16_slice.A_cfg" output="mult_16x16.A">
+            </direct>
+            <direct name="b2b" input="mult_16x16_slice.B_cfg" output="mult_16x16.B">
+            </direct>
+            <direct name="out2out" input="mult_16x16.Y" output="mult_16x16_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="a2a" input="mult_16.a" output="mult_16x16_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a" out_port="mult_16x16_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_16.b" output="mult_16x16_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b" out_port="mult_16x16_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_16x16_slice.OUT_cfg" output="mult_16.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_16x16_slice.OUT_cfg" out_port="mult_16.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+  </complexblocklist>
+</architecture>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [X] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> Currently, OpenFPGA has the following limitations:
> - [x] DSP block has a width=1 while height > 1
> This has not covered some typical cases where heterogeneous blocks have width > 1
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> This PR improves in the following aspects:
> - [x] Added a new architecture where a fracturable 16-bit DSP block has a width of 2 and a height of 2
> - [x] Added a test for the new architecture using 8/16-bit MAC benchmarks
> Screen shot of the example architecture considering 4x4 array:
> 
![image](https://user-images.githubusercontent.com/11499826/116159942-5c6b7a80-a6ae-11eb-8eaf-b26163fabb41.png)


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [X] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [X] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
