### PR TITLE
Introduce Micro benchmark: 1-bit Blinking 

### DIFF
--- a/openfpga_flow/benchmarks/micro_benchmark/blinking/blinking.v
+++ b/openfpga_flow/benchmarks/micro_benchmark/blinking/blinking.v
@@ -1,0 +1,17 @@
+// ------------------------------
+// Design Name: Blinking
+// Functionality: 1-bit blinking
+// ------------------------------
+module blinking(
+  clk,
+  out
+);
+
+input clk;
+output out;
+
+  always @(posedge clk) begin
+    out = ~out;
+  end
+
+endmodule

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_chain/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_chain/config/task.conf
@@ -27,6 +27,7 @@ arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
 bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/or2/or2.v
 bench2=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_latch/and2_latch.v
+bench3=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/blinking/blinking.v
 
 [SYNTHESIS_PARAM]
 bench0_top = and2
@@ -37,6 +38,9 @@ bench1_chan_width = 300
 
 bench2_top = and2_latch
 bench2_chan_width = 300
+
+bench3_top = blinking
+bench3_chan_width = 300
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
 end_flow_with_test=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [X] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
>  Benchmark suites are never enough for OpenFPGA.
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> This PR improves in the following aspects: 
>  - [ ] Add a 1-bit blinking to the micro benchmark suite
>  - [ ] Use the blinking benchmark in tests

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [X] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
