### PR TITLE
Patch FPGA-SDC to consider time unit in global port timing constraints

### DIFF
--- a/openfpga/src/fpga_sdc/pnr_sdc_global_port.cpp
+++ b/openfpga/src/fpga_sdc/pnr_sdc_global_port.cpp
@@ -20,6 +20,7 @@
 /* Headers from openfpgautil library */
 #include "openfpga_port.h"
 #include "openfpga_digest.h"
+#include "openfpga_scale.h"
 
 #include "sdc_writer_naming.h"
 #include "sdc_writer_utils.h"
@@ -59,6 +60,7 @@ void print_pnr_sdc_clock_port(std::fstream& fp,
  *******************************************************************/
 static 
 void print_pnr_sdc_global_clock_ports(std::fstream& fp, 
+                                      const float& time_unit,
                                       const ModuleManager& module_manager,
                                       const ModuleId& top_module,
                                       const FabricGlobalPortInfo& fabric_global_port_info,
@@ -103,7 +105,7 @@ void print_pnr_sdc_global_clock_ports(std::fstream& fp,
 
       print_pnr_sdc_clock_port(fp, 
                                port_to_constrain,
-                               clock_period);
+                               clock_period / time_unit);
     }
   }
 }
@@ -118,6 +120,7 @@ void print_pnr_sdc_global_clock_ports(std::fstream& fp,
  *******************************************************************/
 static 
 void print_pnr_sdc_global_non_clock_ports(std::fstream& fp, 
+                                          const float& time_unit,
                                           const float& operating_critical_path_delay,
                                           const ModuleManager& module_manager,
                                           const ModuleId& top_module,
@@ -144,7 +147,7 @@ void print_pnr_sdc_global_non_clock_ports(std::fstream& fp,
 
       print_pnr_sdc_clock_port(fp, 
                                port_to_constrain,
-                               clock_period);
+                               clock_period / time_unit);
     }
   }
 }
@@ -161,6 +164,7 @@ void print_pnr_sdc_global_non_clock_ports(std::fstream& fp,
  * In general, we do not recommend to do this
  *******************************************************************/
 void print_pnr_sdc_global_ports(const std::string& sdc_dir, 
+                                const float& time_unit,
                                 const ModuleManager& module_manager,
                                 const ModuleId& top_module,
                                 const FabricGlobalPortInfo& global_ports,
@@ -183,12 +187,15 @@ void print_pnr_sdc_global_ports(const std::string& sdc_dir,
   /* Generate the descriptions*/
   print_sdc_file_header(fp, std::string("Clock contraints for PnR"));
 
-  print_pnr_sdc_global_clock_ports(fp, 
+  /* Print time unit for the SDC file */
+  print_sdc_timescale(fp, time_unit_to_string(time_unit));
+
+  print_pnr_sdc_global_clock_ports(fp, time_unit, 
                                    module_manager, top_module,
                                    global_ports, sim_setting);
 
   if (true == constrain_non_clock_port) {
-    print_pnr_sdc_global_non_clock_ports(fp, 
+    print_pnr_sdc_global_non_clock_ports(fp, time_unit, 
                                          1./sim_setting.default_operating_clock_frequency(),
                                          module_manager, top_module,
                                          global_ports);

--- a/openfpga/src/fpga_sdc/pnr_sdc_global_port.h
+++ b/openfpga/src/fpga_sdc/pnr_sdc_global_port.h
@@ -18,6 +18,7 @@
 namespace openfpga {
 
 void print_pnr_sdc_global_ports(const std::string& sdc_dir, 
+                                const float& time_unit,
                                 const ModuleManager& module_manager,
                                 const ModuleId& top_module,
                                 const FabricGlobalPortInfo& global_ports,

--- a/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
+++ b/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
@@ -336,6 +336,7 @@ void print_pnr_sdc(const PnrSdcOption& sdc_options,
   /* Constrain global ports */
   if (true == sdc_options.constrain_global_port()) {
     print_pnr_sdc_global_ports(sdc_options.sdc_dir(),
+                               sdc_options.time_unit(),
                                module_manager, top_module, global_ports,
                                sim_setting,
                                sdc_options.constrain_non_clock_global_port());


### PR DESCRIPTION
…straints

> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
Address issue #316 

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> This PR improves in the following aspects:
>  - [X] Add time unit support to SDC writer on the timing constraints for global port


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [X] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
