### PR TITLE
Support fast configuration in bitstream writer and full testbench that reads external bitstream file

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_bitstream_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_bitstream_commands.rst
@@ -69,6 +69,15 @@ write_fabric_bitstream
     Specify the file format [``plain_text`` | ``xml``]. By default is ``plain_text``.
     See file formats in :ref:`file_formats_fabric_bitstream_xml` and :ref:`file_formats_fabric_bitstream_plain_text`.
 
+  .. option:: --fast_configuration
+
+    Reduce the bitstream size when outputing by skipping dummy configuration bits. It is applicable to configuration chain, memory bank and frame-based configuration protocols. For configuration chain, when enabled, the zeros at the head of the bitstream will be skipped. For memory bank and frame-based, when enabled, all the zero configuration bits will be skipped. So ensure that your memory cells can be correctly reset to zero with a reset signal. 
+   
+    .. warning:: Fast configuration is only applicable to plain text file format!
+
+    .. note:: If both reset and set ports are defined in the circuit modeling for programming, OpenFPGA will pick the one that will bring largest benefit in speeding up configuration.
+
+
   .. option:: --verbose
 
     Show verbose log

--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
@@ -114,6 +114,12 @@ write_full_testbench
     Specify the *Pin Constraints File* (PCF) if you want to custom stimulus in testbenches. For example, ``-pin_constraints_file pin_constraints.xml``
     Strongly recommend for multi-clock simulations. See detailed file format about :ref:`file_format_pin_constraints_file`.
 
+  .. option:: --fast_configuration
+
+    Enable fast configuration phase for the top-level testbench in order to reduce runtime of simulations. It is applicable to configuration chain, memory bank and frame-based configuration protocols. For configuration chain, when enabled, the zeros at the head of the bitstream will be skipped. For memory bank and frame-based, when enabled, all the zero configuration bits will be skipped. So ensure that your memory cells can be correctly reset to zero with a reset signal. 
+
+    .. note:: If both reset and set ports are defined in the circuit modeling for programming, OpenFPGA will pick the one that will bring largest benefit in speeding up configuration.
+
   .. option:: --explicit_port_mapping
 
     Use explicit port mapping when writing the Verilog netlists

--- a/openfpga/src/base/openfpga_bitstream.cpp
+++ b/openfpga/src/base/openfpga_bitstream.cpp
@@ -91,6 +91,7 @@ int write_fabric_bitstream(const OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_verbose = cmd.option("verbose");
   CommandOptionId opt_file = cmd.option("file");
   CommandOptionId opt_file_format = cmd.option("format");
+  CommandOptionId opt_fast_config = cmd.option("fast_configuration");
 
   /* Write fabric bitstream if required */
   int status = CMD_EXEC_SUCCESS;
@@ -119,7 +120,9 @@ int write_fabric_bitstream(const OpenfpgaContext& openfpga_ctx,
     status = write_fabric_bitstream_to_text_file(openfpga_ctx.bitstream_manager(),
                                                  openfpga_ctx.fabric_bitstream(),
                                                  openfpga_ctx.arch().config_protocol,
+                                                 openfpga_ctx.fabric_global_port_info(),
                                                  cmd_context.option_value(cmd, opt_file),
+                                                 cmd_context.option_enable(cmd, opt_fast_config),
                                                  cmd_context.option_enable(cmd, opt_verbose));
   }
   

--- a/openfpga/src/base/openfpga_bitstream_command.cpp
+++ b/openfpga/src/base/openfpga_bitstream_command.cpp
@@ -151,6 +151,9 @@ ShellCommandId add_openfpga_write_fabric_bitstream_command(openfpga::Shell<Openf
   CommandOptionId opt_file_format = shell_cmd.add_option("format", false, "file format of fabric bitstream [plain_text|xml]. Default: plain_text");
   shell_cmd.set_option_require_value(opt_file_format, openfpga::OPT_STRING);
 
+  /* Add an option '--fast_configuration' */
+  shell_cmd.add_option("fast_configuration", false, "Reduce the size of bitstream to be downloaded");
+
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Enable verbose output");
 

--- a/openfpga/src/base/openfpga_verilog.cpp
+++ b/openfpga/src/base/openfpga_verilog.cpp
@@ -130,6 +130,7 @@ int write_full_testbench(OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_fabric_netlist = cmd.option("fabric_netlist_file_path");
   CommandOptionId opt_pcf = cmd.option("pin_constraints_file");
   CommandOptionId opt_reference_benchmark = cmd.option("reference_benchmark_file_path");
+  CommandOptionId opt_fast_configuration = cmd.option("fast_configuration");
   CommandOptionId opt_explicit_port_mapping = cmd.option("explicit_port_mapping");
   CommandOptionId opt_include_signal_init = cmd.option("include_signal_init");
   CommandOptionId opt_verbose = cmd.option("verbose");
@@ -141,6 +142,7 @@ int write_full_testbench(OpenfpgaContext& openfpga_ctx,
   options.set_output_directory(cmd_context.option_value(cmd, opt_output_dir));
   options.set_fabric_netlist_file_path(cmd_context.option_value(cmd, opt_fabric_netlist));
   options.set_reference_benchmark_file_path(cmd_context.option_value(cmd, opt_reference_benchmark));
+  options.set_fast_configuration(cmd_context.option_enable(cmd, opt_fast_configuration));
   options.set_explicit_port_mapping(cmd_context.option_enable(cmd, opt_explicit_port_mapping));
   options.set_verbose_output(cmd_context.option_enable(cmd, opt_verbose));
   options.set_print_top_testbench(true);

--- a/openfpga/src/base/openfpga_verilog_command.cpp
+++ b/openfpga/src/base/openfpga_verilog_command.cpp
@@ -155,6 +155,9 @@ ShellCommandId add_openfpga_write_full_testbench_command(openfpga::Shell<Openfpg
   CommandOptionId ref_bm_opt = shell_cmd.add_option("reference_benchmark_file_path", true, "Specify the file path to the reference Verilog netlist");
   shell_cmd.set_option_require_value(ref_bm_opt, openfpga::OPT_STRING);
 
+  /* Add an option '--fast_configuration' */
+  shell_cmd.add_option("fast_configuration", false, "Reduce the period of configuration by skip certain data points");
+
   /* Add an option '--explicit_port_mapping' */
   shell_cmd.add_option("explicit_port_mapping", false, "Use explicit port mapping in Verilog netlists");
 

--- a/openfpga/src/fpga_bitstream/fast_configuration.cpp
+++ b/openfpga/src/fpga_bitstream/fast_configuration.cpp
@@ -1,0 +1,128 @@
+/********************************************************************
+ * This file includes functions that are used to create
+ * an auto-check top-level testbench for a FPGA fabric
+ *******************************************************************/
+#include <vector>
+
+/* Headers from vtrutil library */
+#include "vtr_log.h"
+#include "vtr_assert.h"
+
+#include "fabric_global_port_info_utils.h"
+#include "fast_configuration.h"
+
+/* begin namespace openfpga */
+namespace openfpga {
+
+/********************************************************************
+ * Identify if fast configuration is applicable base on the availability
+ * of programming reset and programming set ports of the FPGA fabric
+ *******************************************************************/
+bool is_fast_configuration_applicable(const FabricGlobalPortInfo& global_ports) {
+  /* Preparation: find all the reset/set ports for programming usage */
+  std::vector<FabricGlobalPortId> global_prog_reset_ports = find_fabric_global_programming_reset_ports(global_ports);
+  std::vector<FabricGlobalPortId> global_prog_set_ports = find_fabric_global_programming_set_ports(global_ports);
+
+  /* Identify if we can apply fast configuration */
+  if (global_prog_set_ports.empty() && global_prog_reset_ports.empty()) {
+    VTR_LOG_WARN("None of global reset and set ports are defined for programming purpose. Fast configuration is not applicable\n");
+    return false;
+  }
+
+  return true;
+}
+
+/********************************************************************
+ * Decide if we should use reset or set signal to acheive fast configuration
+ * - If only one type signal is specified, we use that type
+ *   For example, only reset signal is defined, we will use reset  
+ * - If both are defined, pick the one that will bring bigger reduction
+ *   i.e., larger number of configuration bits can be skipped
+ *******************************************************************/
+bool find_bit_value_to_skip_for_fast_configuration(const e_config_protocol_type& config_protocol_type,  
+                                                   const FabricGlobalPortInfo& global_ports,
+                                                   const BitstreamManager& bitstream_manager,
+                                                   const FabricBitstream& fabric_bitstream) {
+  /* Preparation: find all the reset/set ports for programming usage */
+  std::vector<FabricGlobalPortId> global_prog_reset_ports = find_fabric_global_programming_reset_ports(global_ports);
+  std::vector<FabricGlobalPortId> global_prog_set_ports = find_fabric_global_programming_set_ports(global_ports);
+
+  /* Early exit conditions */
+  if (!global_prog_reset_ports.empty() && global_prog_set_ports.empty()) {
+    return false; 
+  } else if (!global_prog_set_ports.empty() && global_prog_reset_ports.empty()) {
+    return true; 
+  }
+
+  /* If both types of ports are not defined, the fast configuration is not applicable */
+  VTR_ASSERT(!global_prog_set_ports.empty() && !global_prog_reset_ports.empty());
+  bool bit_value_to_skip = false;
+
+  VTR_LOG("Both reset and set ports are defined for programming controls, selecting the best-fit one...\n");
+
+  size_t num_ones_to_skip = 0;
+  size_t num_zeros_to_skip = 0;
+
+  /* Branch on the type of configuration protocol */
+  switch (config_protocol_type) {
+  case CONFIG_MEM_STANDALONE:
+    break;
+  case CONFIG_MEM_SCAN_CHAIN: {
+    /* We can only skip the ones/zeros at the beginning of the bitstream */
+    /* Count how many logic '1' bits we can skip */
+    for (const FabricBitId& bit_id : fabric_bitstream.bits()) {
+      if (false == bitstream_manager.bit_value(fabric_bitstream.config_bit(bit_id))) {
+        break;
+      }
+      VTR_ASSERT(true == bitstream_manager.bit_value(fabric_bitstream.config_bit(bit_id)));
+      num_ones_to_skip++;
+    }
+    /* Count how many logic '0' bits we can skip */
+    for (const FabricBitId& bit_id : fabric_bitstream.bits()) {
+      if (true == bitstream_manager.bit_value(fabric_bitstream.config_bit(bit_id))) {
+        break;
+      }
+      VTR_ASSERT(false == bitstream_manager.bit_value(fabric_bitstream.config_bit(bit_id)));
+      num_zeros_to_skip++;
+    }
+    break;
+  }
+  case CONFIG_MEM_MEMORY_BANK:
+  case CONFIG_MEM_FRAME_BASED: {
+    /* Count how many logic '1' and logic '0' bits we can skip */
+    for (const FabricBitId& bit_id : fabric_bitstream.bits()) {
+      if (false == bitstream_manager.bit_value(fabric_bitstream.config_bit(bit_id))) {
+        num_zeros_to_skip++;
+      } else {
+        VTR_ASSERT(true == bitstream_manager.bit_value(fabric_bitstream.config_bit(bit_id)));
+        num_ones_to_skip++;
+      }
+    }
+    break;
+  }
+  default:
+    VTR_LOGF_ERROR(__FILE__, __LINE__,
+                   "Invalid configuration protocol type!\n");
+    exit(1);
+  }
+
+  VTR_LOG("Using reset will skip %g% (%lu/%lu) of configuration bitstream.\n",
+          100. * (float) num_zeros_to_skip / (float) fabric_bitstream.num_bits(),
+          num_zeros_to_skip, fabric_bitstream.num_bits());
+
+  VTR_LOG("Using set will skip %g% (%lu/%lu) of configuration bitstream.\n",
+          100. * (float) num_ones_to_skip / (float) fabric_bitstream.num_bits(),
+          num_ones_to_skip, fabric_bitstream.num_bits());
+
+  /* By default, we prefer to skip zeros (when the numbers are the same */
+  if (num_ones_to_skip > num_zeros_to_skip) {
+    VTR_LOG("Will use set signal in fast configuration\n");
+    bit_value_to_skip = true;
+  } else {
+    VTR_LOG("Will use reset signal in fast configuration\n");
+  }
+
+  return bit_value_to_skip;
+}
+
+} /* end namespace openfpga */

--- a/openfpga/src/fpga_bitstream/fast_configuration.h
+++ b/openfpga/src/fpga_bitstream/fast_configuration.h
@@ -1,0 +1,30 @@
+#ifndef FAST_CONFIGURATION_H
+#define FAST_CONFIGURATION_H
+
+/********************************************************************
+ * Include header files that are required by function declaration
+ *******************************************************************/
+#include <string>
+#include <vector>
+#include "fabric_global_port_info.h"
+#include "config_protocol.h"
+#include "bitstream_manager.h"
+#include "fabric_bitstream.h"
+
+/********************************************************************
+ * Function declaration
+ *******************************************************************/
+
+/* begin namespace openfpga */
+namespace openfpga {
+
+bool is_fast_configuration_applicable(const FabricGlobalPortInfo& global_ports);
+
+bool find_bit_value_to_skip_for_fast_configuration(const e_config_protocol_type& config_protocol_type,  
+                                                   const FabricGlobalPortInfo& global_ports,
+                                                   const BitstreamManager& bitstream_manager,
+                                                   const FabricBitstream& fabric_bitstream);
+
+} /* end namespace openfpga */
+
+#endif

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -13,6 +13,7 @@
 
 /* Headers from openfpgautil library */
 #include "openfpga_digest.h"
+#include "openfpga_version.h"
 
 #include "openfpga_naming.h"
 
@@ -23,6 +24,21 @@
 
 /* begin namespace openfpga */
 namespace openfpga {
+
+/********************************************************************
+ * This function write header information to a bitstream file
+ *******************************************************************/
+static 
+void write_fabric_bitstream_text_file_head(std::fstream& fp) {
+  valid_file_stream(fp);
+ 
+  auto end = std::chrono::system_clock::now(); 
+  std::time_t end_time = std::chrono::system_clock::to_time_t(end);
+
+  fp << "// Fabric bitstream" << std::endl;
+  fp << "// Version: " << openfpga::VERSION << std::endl;
+  fp << "// Date: " << std::ctime(&end_time) << std::endl;
+}
 
 /********************************************************************
  * Write a configuration bit into a plain text file
@@ -138,6 +154,11 @@ int write_config_chain_fabric_bitstream_to_text_file(std::fstream& fp,
             num_bits_to_skip, regional_bitstream_max_size);
   }
 
+  /* Output bitstream size information */
+  fp << "// Bitstream length: " << regional_bitstream_max_size - num_bits_to_skip << std::endl;
+  fp << "// Bitstream width (LSB -> MSB): " << fabric_bitstream.num_regions() << std::endl;
+
+  /* Output bitstream data */
   for (size_t ibit = num_bits_to_skip; ibit < regional_bitstream_max_size; ++ibit) { 
     for (const auto& region_bitstream : regional_bitstreams) {
       fp << region_bitstream[ibit];
@@ -257,6 +278,9 @@ int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manage
                                                                       bitstream_manager,
                                                                       fabric_bitstream);
   }
+
+  /* Write file head */
+  write_fabric_bitstream_text_file_head(fp);
 
   /* Output fabric bitstream to the file */
   int status = 0;

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -37,7 +37,7 @@ void write_fabric_bitstream_text_file_head(std::fstream& fp) {
 
   fp << "// Fabric bitstream" << std::endl;
   fp << "// Version: " << openfpga::VERSION << std::endl;
-  fp << "// Date: " << std::ctime(&end_time) << std::endl;
+  fp << "// Date: " << std::ctime(&end_time);
 }
 
 /********************************************************************
@@ -163,7 +163,9 @@ int write_config_chain_fabric_bitstream_to_text_file(std::fstream& fp,
     for (const auto& region_bitstream : regional_bitstreams) {
       fp << region_bitstream[ibit];
     }
-    fp << std::endl;
+    if (ibit < regional_bitstream_max_size - 1) {
+      fp << std::endl;
+    }
   }
 
   return status;

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -132,12 +132,11 @@ int write_config_chain_fabric_bitstream_to_text_file(std::fstream& fp,
   size_t num_bits_to_skip = 0;
   if (true == fast_configuration) {
     num_bits_to_skip = find_configuration_chain_fabric_bitstream_size_to_be_skipped(fabric_bitstream, bitstream_manager, bit_value_to_skip);
+    VTR_ASSERT(num_bits_to_skip < regional_bitstream_max_size);
+    VTR_LOG("Fast configuration will skip %g% (%lu/%lu) of configuration bitstream.\n",
+            100. * (float) num_bits_to_skip / (float) regional_bitstream_max_size,
+            num_bits_to_skip, regional_bitstream_max_size);
   }
-  VTR_ASSERT(num_bits_to_skip < regional_bitstream_max_size);
-
-  VTR_LOG("Fast configuration will skip %g% (%lu/%lu) of configuration bitstream.\n",
-          100. * (float) num_bits_to_skip / (float) regional_bitstream_max_size,
-          num_bits_to_skip, regional_bitstream_max_size);
 
   for (size_t ibit = num_bits_to_skip; ibit < regional_bitstream_max_size; ++ibit) { 
     for (const auto& region_bitstream : regional_bitstreams) {
@@ -246,7 +245,7 @@ int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manage
 
   check_file_stream(fname.c_str(), fp);
 
-  bool apply_fast_configuration = is_fast_configuration_applicable(global_ports);
+  bool apply_fast_configuration = is_fast_configuration_applicable(global_ports) && fast_configuration;
   if (fast_configuration && apply_fast_configuration != fast_configuration) {
     VTR_LOG_WARN("Disable fast configuration even it is enabled by user\n");
   }

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -16,6 +16,7 @@
 
 #include "openfpga_naming.h"
 
+#include "fast_configuration.h"
 #include "bitstream_manager_utils.h"
 #include "fabric_bitstream_utils.h"
 #include "write_text_fabric_bitstream.h"
@@ -118,6 +119,8 @@ int write_flatten_fabric_bitstream_to_text_file(std::fstream& fp,
  *******************************************************************/
 static 
 int write_config_chain_fabric_bitstream_to_text_file(std::fstream& fp,
+                                                     const bool& fast_configuration,
+                                                     const bool& bit_value_to_skip,
                                                      const BitstreamManager& bitstream_manager,
                                                      const FabricBitstream& fabric_bitstream) {
   int status = 0;
@@ -125,7 +128,18 @@ int write_config_chain_fabric_bitstream_to_text_file(std::fstream& fp,
   size_t regional_bitstream_max_size = find_fabric_regional_bitstream_max_size(fabric_bitstream);
   ConfigChainFabricBitstream regional_bitstreams = build_config_chain_fabric_bitstream_by_region(bitstream_manager, fabric_bitstream);
 
-  for (size_t ibit = 0; ibit < regional_bitstream_max_size; ++ibit) { 
+  /* For fast configuration, the bitstream size counts from the first bit '1' */
+  size_t num_bits_to_skip = 0;
+  if (true == fast_configuration) {
+    num_bits_to_skip = find_configuration_chain_fabric_bitstream_size_to_be_skipped(fabric_bitstream, bitstream_manager, bit_value_to_skip);
+  }
+  VTR_ASSERT(num_bits_to_skip < regional_bitstream_max_size);
+
+  VTR_LOG("Fast configuration will skip %g% (%lu/%lu) of configuration bitstream.\n",
+          100. * (float) num_bits_to_skip / (float) regional_bitstream_max_size,
+          num_bits_to_skip, regional_bitstream_max_size);
+
+  for (size_t ibit = num_bits_to_skip; ibit < regional_bitstream_max_size; ++ibit) { 
     for (const auto& region_bitstream : regional_bitstreams) {
       fp << region_bitstream[ibit];
     }
@@ -214,7 +228,9 @@ int write_frame_based_fabric_bitstream_to_text_file(std::fstream& fp,
 int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manager,
                                         const FabricBitstream& fabric_bitstream,
                                         const ConfigProtocol& config_protocol,
+                                        const FabricGlobalPortInfo& global_ports,
                                         const std::string& fname,
+                                        const bool& fast_configuration,
                                         const bool& verbose) {
   /* Ensure that we have a valid file name */
   if (true == fname.empty()) {
@@ -230,6 +246,19 @@ int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manage
 
   check_file_stream(fname.c_str(), fp);
 
+  bool apply_fast_configuration = is_fast_configuration_applicable(global_ports);
+  if (fast_configuration && apply_fast_configuration != fast_configuration) {
+    VTR_LOG_WARN("Disable fast configuration even it is enabled by user\n");
+  }
+
+  bool bit_value_to_skip = false;
+  if (apply_fast_configuration) {
+    bit_value_to_skip = find_bit_value_to_skip_for_fast_configuration(config_protocol.type(),  
+                                                                      global_ports,
+                                                                      bitstream_manager,
+                                                                      fabric_bitstream);
+  }
+
   /* Output fabric bitstream to the file */
   int status = 0;
   switch (config_protocol.type()) {
@@ -241,6 +270,8 @@ int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manage
     break;
   case CONFIG_MEM_SCAN_CHAIN:
     status = write_config_chain_fabric_bitstream_to_text_file(fp,
+                                                              apply_fast_configuration,
+                                                              bit_value_to_skip,
                                                               bitstream_manager,
                                                               fabric_bitstream);
     break;

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.h
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.h
@@ -9,6 +9,7 @@
 #include "bitstream_manager.h"
 #include "fabric_bitstream.h"
 #include "config_protocol.h"
+#include "fabric_global_port_info.h"
 
 /********************************************************************
  * Function declaration
@@ -20,7 +21,9 @@ namespace openfpga {
 int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manager,
                                         const FabricBitstream& fabric_bitstream,
                                         const ConfigProtocol& config_protocol,
+                                        const FabricGlobalPortInfo& global_ports,
                                         const std::string& fname,
+                                        const bool& fast_configuration,
                                         const bool& verbose);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -359,7 +359,6 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
 
   /* Add Icarus requirement */
   print_verilog_timeout_and_vcd(fp, 
-                                std::string(ICARUS_SIMULATOR_FLAG),
                                 std::string(circuit_name + std::string(FORMAL_RANDOM_TOP_TESTBENCH_POSTFIX)),
                                 std::string(circuit_name + std::string("_formal.vcd")), 
                                 std::string(FORMAL_TB_SIM_START_PORT_NAME),

--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
@@ -300,7 +300,6 @@ void print_verilog_testbench_connect_fpga_ios(std::fstream& fp,
  * Note that: these codes are tuned for Icarus simulator!!!
  *******************************************************************/
 void print_verilog_timeout_and_vcd(std::fstream& fp,
-                                   const std::string& icarus_preprocessing_flag,
                                    const std::string& module_name,
                                    const std::string& vcd_fname,
                                    const std::string& simulation_start_counter_name,
@@ -309,20 +308,14 @@ void print_verilog_timeout_and_vcd(std::fstream& fp,
   /* Validate the file stream */
   valid_file_stream(fp);
 
-  /* The following verilog codes are tuned for Icarus */
-  print_verilog_preprocessing_flag(fp, icarus_preprocessing_flag); 
-
-  print_verilog_comment(fp, std::string("----- Begin Icarus requirement -------"));
+  print_verilog_comment(fp, std::string("----- Begin output waveform to VCD file-------"));
 
   fp << "\tinitial begin" << std::endl;
   fp << "\t\t$dumpfile(\"" << vcd_fname << "\");" << std::endl;
   fp << "\t\t$dumpvars(1, " << module_name << ");" << std::endl;
   fp << "\tend" << std::endl;
 
-  /* Condition ends for the Icarus requirement */
-  print_verilog_endif(fp);
-
-  print_verilog_comment(fp, std::string("----- END Icarus requirement -------"));
+  print_verilog_comment(fp, std::string("----- END output waveform to VCD file -------"));
 
   /* Add an empty line as splitter */
   fp << std::endl;

--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.h
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.h
@@ -55,7 +55,6 @@ void print_verilog_testbench_connect_fpga_ios(std::fstream& fp,
                                               const size_t& unused_io_value);
 
 void print_verilog_timeout_and_vcd(std::fstream& fp,
-                                   const std::string& icarus_preprocessing_flag,
                                    const std::string& module_name,
                                    const std::string& vcd_fname,
                                    const std::string& simulation_start_counter_name,

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -2496,7 +2496,6 @@ void print_verilog_top_testbench(const ModuleManager& module_manager,
    * Always ceil the simulation time so that we test a sufficient length of period!!!
    */
   print_verilog_timeout_and_vcd(fp,
-                                std::string(ICARUS_SIMULATOR_FLAG),
                                 std::string(circuit_name + std::string(AUTOCHECK_TOP_TESTBENCH_VERILOG_MODULE_POSTFIX)),
                                 std::string(circuit_name + std::string("_formal.vcd")),
                                 std::string(TOP_TESTBENCH_SIM_START_PORT_NAME),
@@ -2758,7 +2757,6 @@ int print_verilog_full_testbench(const ModuleManager& module_manager,
    * Always ceil the simulation time so that we test a sufficient length of period!!!
    */
   print_verilog_timeout_and_vcd(fp,
-                                std::string(ICARUS_SIMULATOR_FLAG),
                                 std::string(circuit_name + std::string(AUTOCHECK_TOP_TESTBENCH_VERILOG_MODULE_POSTFIX)),
                                 std::string(circuit_name + std::string("_formal.vcd")),
                                 std::string(TOP_TESTBENCH_SIM_START_PORT_NAME),

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1953,7 +1953,6 @@ void print_verilog_full_testbench_configuration_chain_bitstream(std::fstream& fp
                                                                 const bool& bit_value_to_skip,
                                                                 const ModuleManager& module_manager,
                                                                 const ModuleId& top_module,
-                                                                const BitstreamManager& bitstream_manager,
                                                                 const FabricBitstream& fabric_bitstream) {
   /* Validate the file stream */
   valid_file_stream(fp);
@@ -2078,7 +2077,7 @@ void print_verilog_full_testbench_bitstream(std::fstream& fp,
                                                                fast_configuration, 
                                                                bit_value_to_skip,
                                                                module_manager, top_module,
-                                                               bitstream_manager, fabric_bitstream);
+                                                               fabric_bitstream);
     break;
   case CONFIG_MEM_MEMORY_BANK:
     break;

--- a/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
@@ -55,7 +55,7 @@ write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --pri
 #  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
 #  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
 #  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
-write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --explicit_port_mapping --bitstream fabric_bitstream.bit
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --explicit_port_mapping --bitstream fabric_bitstream.bit ${OPENFPGA_FAST_CONFIGURATION}
 
 # Write the SDC files for PnR backend
 #  - Turn on every options here

--- a/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
@@ -43,7 +43,7 @@ build_architecture_bitstream --verbose --write_file fabric_independent_bitstream
 build_fabric_bitstream --verbose
 
 # Write fabric-dependent bitstream
-write_fabric_bitstream --file fabric_bitstream.bit --format plain_text
+write_fabric_bitstream --file fabric_bitstream.bit --format plain_text ${OPENFPGA_FAST_CONFIGURATION}
 
 # Write the Verilog netlist for FPGA fabric
 #  - Enable the use of explicit port mapping in Verilog netlist

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain/config/task.conf
@@ -20,6 +20,7 @@ openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scrip
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
 openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_config_enable_scff/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_config_enable_scff/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 1*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/configuration_chain_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_cfgscff_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_reset/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_reset/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/configuration_chain_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_resetb/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_resetb/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/configuration_chain_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_resetb_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_set/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_set/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/configuration_chain_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_set_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_set_reset/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_set_reset/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/configuration_chain_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_setb/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_chain_use_setb/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/configuration_chain_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_setb_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_chain/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_chain/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_chain_use_set/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_chain_use_set/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_set_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_configuration_chain/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_configuration_chain/config/task.conf
@@ -20,6 +20,7 @@ openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scrip
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_cc_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
 openfpga_vpr_device_layout=--device 2x2
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_configuration_chain/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_configuration_chain/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_configuration_chain/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_configuration_chain/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_cc_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Address issue #319 
This is a follow-up pull request mention in #320 
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
 - [X] Enable option ``--fast_configuration`` for ``write_full_testbench`` command
 - [X] Enable option ``--fast_configuration`` for ``write_fabric_bitstream`` command
 - [X] All the configuration chain test case now use ``write_full_testbench`` command
 - [X] Added a head to bitstream file to help debugging
 
An example of bitstream file (*.bit):
```
// Fabric bitstream
// Version: 1.0.0-dev+27fa1560-dirty
// Date: Fri Jun  4 19:48:11 2021

// Bitstream length: 571
// Bitstream width (LSB -> MSB): 4
0000
0000
0000
0000
```

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [X] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [X] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [X] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
