### PR TITLE
Support frame-based configuration protocol in bitstream writer and full testbench that reads external bitstream file

### DIFF
--- a/docs/source/manual/file_formats/fabric_bitstream.rst
+++ b/docs/source/manual/file_formats/fabric_bitstream.rst
@@ -63,7 +63,14 @@ The information depends on the type of configuration procotol.
 
 .. option:: frame_based 
 
-  Multiple lines will be included, each of which is organized as <address><space><bits>.
+  Multiple lines will be included, each of which is organized as ``<address><data_input_bits>``.
+  The size of address line and data input bits are shown as a comment in the bitstream file, which eases the development of bitstream downloader.
+  For example 
+  
+  .. code-block:: verilog
+
+    // Bitstream width (LSB -> MSB): <address 14 bits><data input 1 bits>
+
   Note that the address may include don't care bit which is denoted as ``x``.
 
   .. note:: OpenFPGA automatically convert don't care bit to logic ``0`` when generating testbenches.
@@ -72,10 +79,10 @@ The information depends on the type of configuration procotol.
    
   .. code-block:: xml 
      
-     <frame_address> <bit_value> 
-     <frame_address> <bit_value> 
+     <frame_address><bit_value> 
+     <frame_address><bit_value> 
      ...
-     <frame_address> <bit_value> 
+     <frame_address><bit_value> 
 
   .. note:: When there are multiple configuration regions, each ``<bit_value>`` may consist of multiple bits. For example, ``0110`` represents the bits for 4 configuration regions, where the 4 digits correspond to the bits from region ``0, 1, 2, 3`` respectively.
 

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -215,15 +215,48 @@ int write_memory_bank_fabric_bitstream_to_text_file(std::fstream& fp,
  *******************************************************************/
 static 
 int write_frame_based_fabric_bitstream_to_text_file(std::fstream& fp,
+                                                    const bool& fast_configuration,
+                                                    const bool& bit_value_to_skip,
                                                     const FabricBitstream& fabric_bitstream) {
   int status = 0;
 
   FrameFabricBitstream fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
 
+  /* The address sizes and data input sizes are the same across any element, 
+   * just get it from the 1st element to save runtime
+   */
+  size_t addr_size = fabric_bits_by_addr.begin()->first.size(); 
+  size_t din_size = fabric_bits_by_addr.begin()->second.size(); 
+
+  /* Identify and output bitstream size information */
+  size_t num_bits_to_skip = 0;
+  if (true == fast_configuration) {
+    num_bits_to_skip = find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+    VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
+    VTR_LOG("Fast configuration will skip %g% (%lu/%lu) of configuration bitstream.\n",
+            100. * (float) num_bits_to_skip / (float) fabric_bits_by_addr.size(),
+            num_bits_to_skip, fabric_bits_by_addr.size());
+  }
+
+  /* Output information about how to intepret the bitstream */
+  fp << "// Bitstream length: " << fabric_bits_by_addr.size() - num_bits_to_skip << std::endl;
+  fp << "// Bitstream address size (LSB -> MSB): " << addr_size << std::endl;
+  fp << "// Bitstream data input size (LSB -> MSB): " << din_size << std::endl;
+
   for (const auto& addr_din_pair : fabric_bits_by_addr) {
+    /* When fast configuration is enabled,
+     * the rule to skip any configuration bit should consider the whole data input values.
+     * Only all the bits in the din port match the value to be skipped,
+     * the programming cycle can be skipped!
+     */
+    if (true == fast_configuration) {
+      if (addr_din_pair.second == std::vector<bool>(addr_din_pair.second.size(), bit_value_to_skip)) {
+        continue;
+      }
+    }
+
     /* Write address code */
     fp << addr_din_pair.first;
-    fp << " ";
 
     /* Write data input */
     for (const bool& din_value : addr_din_pair.second) {
@@ -306,6 +339,8 @@ int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manage
     break;
   case CONFIG_MEM_FRAME_BASED:
     status = write_frame_based_fabric_bitstream_to_text_file(fp,
+                                                             apply_fast_configuration,
+                                                             bit_value_to_skip,
                                                              fabric_bitstream);
     break;
   default:

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -231,7 +231,7 @@ int write_frame_based_fabric_bitstream_to_text_file(std::fstream& fp,
   /* Identify and output bitstream size information */
   size_t num_bits_to_skip = 0;
   if (true == fast_configuration) {
-    num_bits_to_skip = find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+    num_bits_to_skip = fabric_bits_by_addr.size() - find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
     VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
     VTR_LOG("Fast configuration will skip %g% (%lu/%lu) of configuration bitstream.\n",
             100. * (float) num_bits_to_skip / (float) fabric_bits_by_addr.size(),

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -240,8 +240,7 @@ int write_frame_based_fabric_bitstream_to_text_file(std::fstream& fp,
 
   /* Output information about how to intepret the bitstream */
   fp << "// Bitstream length: " << fabric_bits_by_addr.size() - num_bits_to_skip << std::endl;
-  fp << "// Bitstream address size (LSB -> MSB): " << addr_size << std::endl;
-  fp << "// Bitstream data input size (LSB -> MSB): " << din_size << std::endl;
+  fp << "// Bitstream width (LSB -> MSB): <address " << addr_size << " bits><data input " << din_size << " bits>" << std::endl;
 
   for (const auto& addr_din_pair : fabric_bits_by_addr) {
     /* When fast configuration is enabled,

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -2122,6 +2122,128 @@ void print_verilog_full_testbench_configuration_chain_bitstream(std::fstream& fp
   print_verilog_comment(fp, "----- End bitstream loading during configuration phase -----");
 }
 
+/********************************************************************
+ * Print stimulus for a FPGA fabric with a frame-based configuration protocol
+ * where configuration bits are programming in serial (one by one)
+ *******************************************************************/
+static
+void print_verilog_full_testbench_frame_decoder_bitstream(std::fstream& fp,
+                                                          const std::string& bitstream_file,
+                                                          const bool& fast_configuration,
+                                                          const bool& bit_value_to_skip,
+                                                          const ModuleManager& module_manager,
+                                                          const ModuleId& top_module,
+                                                          const FabricBitstream& fabric_bitstream) {
+  /* Validate the file stream */
+  valid_file_stream(fp);
+
+  /* Reorganize the fabric bitstream by the same address across regions */
+  FrameFabricBitstream fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
+
+  /* For fast configuration, identify the final bitstream size to be used */
+  size_t num_bits_to_skip = 0;
+  if (true == fast_configuration) {
+    num_bits_to_skip = find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+  }
+  VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
+
+  /* Feed address and data input pair one by one
+   * Note: the first cycle is reserved for programming reset
+   * We should give dummy values
+   */
+  ModulePortId addr_port_id = module_manager.find_module_port(top_module,
+                                                              std::string(DECODER_ADDRESS_PORT_NAME));
+  BasicPort addr_port = module_manager.module_port(top_module, addr_port_id);
+  std::vector<size_t> initial_addr_values(addr_port.get_width(), 0);
+
+  ModulePortId din_port_id = module_manager.find_module_port(top_module,
+                                                             std::string(DECODER_DATA_IN_PORT_NAME));
+  BasicPort din_port = module_manager.module_port(top_module, din_port_id);
+  std::vector<size_t> initial_din_values(din_port.get_width(), 0);
+
+  /* Define a constant for the bitstream length */
+  print_verilog_define_flag(fp, std::string(TOP_TB_BITSTREAM_LENGTH_VARIABLE), fabric_bits_by_addr.size() - num_bits_to_skip); 
+  print_verilog_define_flag(fp, std::string(TOP_TB_BITSTREAM_WIDTH_VARIABLE), addr_port.get_width() + din_port.get_width()); 
+
+  /* Declare local variables for bitstream loading in Verilog */
+  print_verilog_comment(fp, "----- Virtual memory to store the bitstream from external file -----");
+  fp << "reg [0:`" << TOP_TB_BITSTREAM_WIDTH_VARIABLE << " - 1] ";
+  fp << TOP_TB_BITSTREAM_MEM_REG_NAME << "[0:`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << " - 1];";
+  fp << std::endl;
+
+  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << ") - 1:0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
+
+  print_verilog_comment(fp, "----- Preload bitstream file to a virtual memory -----");
+  fp << "initial begin" << std::endl;
+  fp << "\t";
+  fp << "$readmemb(\"" << bitstream_file << "\", " << TOP_TB_BITSTREAM_MEM_REG_NAME << ");";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- Address port default input -----");
+  fp << "\t";
+  fp << generate_verilog_port_constant_values(addr_port, initial_addr_values);
+  fp << ";";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- Data-input port default input -----");
+  fp << "\t";
+  fp << generate_verilog_port_constant_values(din_port, initial_din_values);
+  fp << ";";
+  fp << std::endl;
+
+  fp << "end";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- Begin bitstream loading during configuration phase -----");
+  BasicPort prog_clock_port(std::string(TOP_TB_PROG_CLOCK_PORT_NAME) + std::string(TOP_TB_CLOCK_REG_POSTFIX), 1);
+  fp << "always";
+  fp << " @(negedge " << generate_verilog_port(VERILOG_PORT_CONKT, prog_clock_port) << ")"; 
+  fp << " begin";
+  fp << std::endl;
+
+  fp << "\t";
+  fp << "if (";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME;
+  fp << " >= ";
+  fp << "`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE;
+  fp << ") begin";
+  fp << std::endl;
+
+  BasicPort config_done_port(std::string(TOP_TB_CONFIG_DONE_PORT_NAME), 1);
+  fp << "\t\t";
+  std::vector<size_t> config_done_final_values(config_done_port.get_width(), 1);
+  fp << generate_verilog_port_constant_values(config_done_port, config_done_final_values, true);
+  fp << ";" << std::endl;
+
+  fp << "\t";
+  fp << "end else begin";
+  fp << std::endl;
+
+  fp << "\t\t";
+  fp << "{";
+  fp << generate_verilog_port(VERILOG_PORT_CONKT, addr_port); 
+  fp << ", ";
+  fp << generate_verilog_port(VERILOG_PORT_CONKT, din_port); 
+  fp << "}";
+  fp << " <= ";
+  fp << TOP_TB_BITSTREAM_MEM_REG_NAME << "[" << TOP_TB_BITSTREAM_INDEX_REG_NAME << "]";
+  fp << ";" << std::endl;
+
+  fp << "\t\t";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME;
+  fp << " <= ";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME << " + 1";
+  fp << ";" << std::endl;
+
+  fp << "\t";
+  fp << "end";
+  fp << std::endl;
+
+  fp << "end";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- End bitstream loading during configuration phase -----");
+}
 
 /********************************************************************
  * Generate the stimuli for the full testbench
@@ -2155,6 +2277,12 @@ void print_verilog_full_testbench_bitstream(std::fstream& fp,
   case CONFIG_MEM_MEMORY_BANK:
     break;
   case CONFIG_MEM_FRAME_BASED:
+    print_verilog_full_testbench_frame_decoder_bitstream(fp, bitstream_file,
+                                                         fast_configuration, 
+                                                         bit_value_to_skip,
+                                                         module_manager, top_module,
+                                                         fabric_bitstream);
+
     break;
   default:
     VTR_LOGF_ERROR(__FILE__, __LINE__,

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -2191,6 +2191,11 @@ void print_verilog_full_testbench_frame_decoder_bitstream(std::fstream& fp,
   fp << ";";
   fp << std::endl;
 
+  fp << "\t";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME << " <= 0";
+  fp << ";";
+  fp << std::endl;
+
   fp << "end";
   fp << std::endl;
 

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -2143,7 +2143,7 @@ void print_verilog_full_testbench_frame_decoder_bitstream(std::fstream& fp,
   /* For fast configuration, identify the final bitstream size to be used */
   size_t num_bits_to_skip = 0;
   if (true == fast_configuration) {
-    num_bits_to_skip = find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+    num_bits_to_skip = fabric_bits_by_addr.size() - find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
   }
   VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
 

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_ccff/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_ccff/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_ccff_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_scff/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_scff/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_scff_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_reset/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_reset/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_resetb/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_resetb/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_resetb_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_set/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_set/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_set_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_set_reset/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_set_reset/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_setb/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/configuration_frame_use_setb/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_setb_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_frame/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_frame/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_frame_use_set/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fast_configuration_frame_use_set/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_set_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_configuration_frame/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_configuration_frame/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_configuration_frame/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_configuration_frame/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_configuration_frame/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_configuration_frame/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Address issue #319
This is a follow-up pull request mention in #321
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [ ] Now ``write_full_testbench`` command supports configuration frame when building a testbench which loads an external bitstream file.
- [ ] All the configuration frame test cases now use ``write_full_testbench`` command (including ``--fast_configuration`` support)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
