### PR TITLE
Support memory bank configuration protocol in bitstream writer and full testbench that reads external bitstream file

### DIFF
--- a/docs/source/manual/file_formats/fabric_bitstream.rst
+++ b/docs/source/manual/file_formats/fabric_bitstream.rst
@@ -43,21 +43,25 @@ The information depends on the type of configuration procotol.
 
 .. option:: memory_bank
 
-  Multiple lines will be included, each of which is organized as <address><space><bits>.
-  Note that due to the use of Bit-Line and Word-Line decoders, every two lines are paired.
-  The first line represents the Bit-Line address and configuration bit.
-  The second line represents the Word-Line address and configuration bit.
+  Multiple lines will be included, each of which is organized as <bl_address><wl_address><bits>.
+  The size of address line and data input bits are shown as a comment in the bitstream file, which eases the development of bitstream downloader.
+  For example 
+  
+  .. code-block:: verilog
+
+    // Bitstream width (LSB -> MSB): <bl_address 5 bits><wl_address 5 bits><data input 1 bits>
+
+  The first part represents the Bit-Line address.
+  The second part represents the Word-Line address.
+  The third part represents the configuration bit.
   For example
    
   .. code-block:: xml
      
-     <bitline_address> <bit_value> 
-     <wordline_address> <bit_value> 
-     <bitline_address> <bit_value> 
-     <wordline_address> <bit_value> 
+     <bitline_address><wordline_address><bit_value> 
+     <bitline_address><wordline_address><bit_value> 
      ...
-     <bitline_address> <bit_value> 
-     <wordline_address> <bit_value> 
+     <bitline_address><wordline_address><bit_value> 
 
   .. note:: When there are multiple configuration regions, each ``<bit_value>`` may consist of multiple bits. For example, ``0110`` represents the bits for 4 configuration regions, where the 4 digits correspond to the bits from region ``0, 1, 2, 3`` respectively.
 

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -181,20 +181,54 @@ int write_config_chain_fabric_bitstream_to_text_file(std::fstream& fp,
  *******************************************************************/
 static 
 int write_memory_bank_fabric_bitstream_to_text_file(std::fstream& fp,
-                                                     const FabricBitstream& fabric_bitstream) {
+                                                    const bool& fast_configuration,
+                                                    const bool& bit_value_to_skip,
+                                                    const FabricBitstream& fabric_bitstream) {
   int status = 0;
 
   MemoryBankFabricBitstream fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
 
+  /* The address sizes and data input sizes are the same across any element, 
+   * just get it from the 1st element to save runtime
+   */
+  size_t bl_addr_size = fabric_bits_by_addr.begin()->first.first.size(); 
+  size_t wl_addr_size = fabric_bits_by_addr.begin()->first.second.size(); 
+  size_t din_size = fabric_bits_by_addr.begin()->second.size(); 
+
+  /* Identify and output bitstream size information */
+  size_t num_bits_to_skip = 0;
+  if (true == fast_configuration) {
+    num_bits_to_skip = fabric_bits_by_addr.size() - find_memory_bank_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+    VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
+    VTR_LOG("Fast configuration will skip %g% (%lu/%lu) of configuration bitstream.\n",
+            100. * (float) num_bits_to_skip / (float) fabric_bits_by_addr.size(),
+            num_bits_to_skip, fabric_bits_by_addr.size());
+  }
+
+  /* Output information about how to intepret the bitstream */
+  fp << "// Bitstream length: " << fabric_bits_by_addr.size() - num_bits_to_skip << std::endl;
+  fp << "// Bitstream width (LSB -> MSB): ";
+  fp << "<bl_address " << bl_addr_size << " bits>";
+  fp << "<wl_address " << wl_addr_size << " bits>";
+  fp << "<data input " << din_size << " bits>";
+  fp << std::endl;
+
   for (const auto& addr_din_pair : fabric_bits_by_addr) {
+    /* When fast configuration is enabled,
+     * the rule to skip any configuration bit should consider the whole data input values.
+     * Only all the bits in the din port match the value to be skipped,
+     * the programming cycle can be skipped!
+     */
+    if (true == fast_configuration) {
+      if (addr_din_pair.second == std::vector<bool>(addr_din_pair.second.size(), bit_value_to_skip)) {
+        continue;
+      }
+    }
+
     /* Write BL address code */
     fp << addr_din_pair.first.first;
-    fp << " ";
-
     /* Write WL address code */
     fp << addr_din_pair.first.second;
-    fp << " ";
-
     /* Write data input */
     for (const bool& din_value : addr_din_pair.second) {
       fp << din_value;
@@ -334,6 +368,8 @@ int write_fabric_bitstream_to_text_file(const BitstreamManager& bitstream_manage
     break;
   case CONFIG_MEM_MEMORY_BANK: 
     status = write_memory_bank_fabric_bitstream_to_text_file(fp,
+                                                             apply_fast_configuration,
+                                                             bit_value_to_skip,
                                                              fabric_bitstream);
     break;
   case CONFIG_MEM_FRAME_BASED:

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -231,7 +231,7 @@ int write_frame_based_fabric_bitstream_to_text_file(std::fstream& fp,
   /* Identify and output bitstream size information */
   size_t num_bits_to_skip = 0;
   if (true == fast_configuration) {
-    num_bits_to_skip = find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+    num_bits_to_skip = fabric_bits_by_addr.size() - find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
     VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
     VTR_LOG("Fast configuration will skip %g% (%lu/%lu) of configuration bitstream.\n",
             100. * (float) num_bits_to_skip / (float) fabric_bits_by_addr.size(),

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -2123,6 +2123,147 @@ void print_verilog_full_testbench_configuration_chain_bitstream(std::fstream& fp
 }
 
 /********************************************************************
+ * Print stimulus for a FPGA fabric with a memory bank configuration protocol
+ * where configuration bits are programming in serial (one by one)
+ *******************************************************************/
+static
+void print_verilog_full_testbench_memory_bank_bitstream(std::fstream& fp,
+                                                        const std::string& bitstream_file,
+                                                        const bool& fast_configuration,
+                                                        const bool& bit_value_to_skip,
+                                                        const ModuleManager& module_manager,
+                                                        const ModuleId& top_module,
+                                                        const FabricBitstream& fabric_bitstream) {
+  /* Validate the file stream */
+  valid_file_stream(fp);
+
+  /* Reorganize the fabric bitstream by the same address across regions */
+  MemoryBankFabricBitstream fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
+
+  /* For fast configuration, identify the final bitstream size to be used */
+  size_t num_bits_to_skip = 0;
+  if (true == fast_configuration) {
+    num_bits_to_skip = fabric_bits_by_addr.size() - find_memory_bank_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+  }
+  VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
+
+  /* Feed address and data input pair one by one
+   * Note: the first cycle is reserved for programming reset
+   * We should give dummy values
+   */
+  ModulePortId bl_addr_port_id = module_manager.find_module_port(top_module,
+                                                                 std::string(DECODER_BL_ADDRESS_PORT_NAME));
+  BasicPort bl_addr_port = module_manager.module_port(top_module, bl_addr_port_id);
+  std::vector<size_t> initial_bl_addr_values(bl_addr_port.get_width(), 0);
+
+  ModulePortId wl_addr_port_id = module_manager.find_module_port(top_module,
+                                                                 std::string(DECODER_WL_ADDRESS_PORT_NAME));
+  BasicPort wl_addr_port = module_manager.module_port(top_module, wl_addr_port_id);
+  std::vector<size_t> initial_wl_addr_values(wl_addr_port.get_width(), 0);
+
+  ModulePortId din_port_id = module_manager.find_module_port(top_module,
+                                                             std::string(DECODER_DATA_IN_PORT_NAME));
+  BasicPort din_port = module_manager.module_port(top_module, din_port_id);
+  std::vector<size_t> initial_din_values(din_port.get_width(), 0);
+
+  /* Define a constant for the bitstream length */
+  print_verilog_define_flag(fp, std::string(TOP_TB_BITSTREAM_LENGTH_VARIABLE), fabric_bits_by_addr.size() - num_bits_to_skip); 
+  print_verilog_define_flag(fp, std::string(TOP_TB_BITSTREAM_WIDTH_VARIABLE), bl_addr_port.get_width() + wl_addr_port.get_width() + din_port.get_width()); 
+
+  /* Declare local variables for bitstream loading in Verilog */
+  print_verilog_comment(fp, "----- Virtual memory to store the bitstream from external file -----");
+  fp << "reg [0:`" << TOP_TB_BITSTREAM_WIDTH_VARIABLE << " - 1] ";
+  fp << TOP_TB_BITSTREAM_MEM_REG_NAME << "[0:`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << " - 1];";
+  fp << std::endl;
+
+  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << ") - 1:0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
+
+  print_verilog_comment(fp, "----- Preload bitstream file to a virtual memory -----");
+  fp << "initial begin" << std::endl;
+  fp << "\t";
+  fp << "$readmemb(\"" << bitstream_file << "\", " << TOP_TB_BITSTREAM_MEM_REG_NAME << ");";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- Bit-Line Address port default input -----");
+  fp << "\t";
+  fp << generate_verilog_port_constant_values(bl_addr_port, initial_bl_addr_values);
+  fp << ";";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- Word-Line Address port default input -----");
+  fp << "\t";
+  fp << generate_verilog_port_constant_values(wl_addr_port, initial_wl_addr_values);
+  fp << ";";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- Data-input port default input -----");
+  fp << "\t";
+  fp << generate_verilog_port_constant_values(din_port, initial_din_values);
+  fp << ";";
+  fp << std::endl;
+
+  fp << "\t";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME << " <= 0";
+  fp << ";";
+  fp << std::endl;
+
+  fp << "end";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- Begin bitstream loading during configuration phase -----");
+  BasicPort prog_clock_port(std::string(TOP_TB_PROG_CLOCK_PORT_NAME) + std::string(TOP_TB_CLOCK_REG_POSTFIX), 1);
+  fp << "always";
+  fp << " @(negedge " << generate_verilog_port(VERILOG_PORT_CONKT, prog_clock_port) << ")"; 
+  fp << " begin";
+  fp << std::endl;
+
+  fp << "\t";
+  fp << "if (";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME;
+  fp << " >= ";
+  fp << "`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE;
+  fp << ") begin";
+  fp << std::endl;
+
+  BasicPort config_done_port(std::string(TOP_TB_CONFIG_DONE_PORT_NAME), 1);
+  fp << "\t\t";
+  std::vector<size_t> config_done_final_values(config_done_port.get_width(), 1);
+  fp << generate_verilog_port_constant_values(config_done_port, config_done_final_values, true);
+  fp << ";" << std::endl;
+
+  fp << "\t";
+  fp << "end else begin";
+  fp << std::endl;
+
+  fp << "\t\t";
+  fp << "{";
+  fp << generate_verilog_port(VERILOG_PORT_CONKT, bl_addr_port); 
+  fp << ", ";
+  fp << generate_verilog_port(VERILOG_PORT_CONKT, wl_addr_port); 
+  fp << ", ";
+  fp << generate_verilog_port(VERILOG_PORT_CONKT, din_port); 
+  fp << "}";
+  fp << " <= ";
+  fp << TOP_TB_BITSTREAM_MEM_REG_NAME << "[" << TOP_TB_BITSTREAM_INDEX_REG_NAME << "]";
+  fp << ";" << std::endl;
+
+  fp << "\t\t";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME;
+  fp << " <= ";
+  fp << TOP_TB_BITSTREAM_INDEX_REG_NAME << " + 1";
+  fp << ";" << std::endl;
+
+  fp << "\t";
+  fp << "end";
+  fp << std::endl;
+
+  fp << "end";
+  fp << std::endl;
+
+  print_verilog_comment(fp, "----- End bitstream loading during configuration phase -----");
+}
+
+/********************************************************************
  * Print stimulus for a FPGA fabric with a frame-based configuration protocol
  * where configuration bits are programming in serial (one by one)
  *******************************************************************/
@@ -2280,6 +2421,11 @@ void print_verilog_full_testbench_bitstream(std::fstream& fp,
                                                                fabric_bitstream);
     break;
   case CONFIG_MEM_MEMORY_BANK:
+    print_verilog_full_testbench_memory_bank_bitstream(fp, bitstream_file,
+                                                       fast_configuration, 
+                                                       bit_value_to_skip,
+                                                       module_manager, top_module,
+                                                       fabric_bitstream);
     break;
   case CONFIG_MEM_FRAME_BASED:
     print_verilog_full_testbench_frame_decoder_bitstream(fp, bitstream_file,

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1993,11 +1993,11 @@ void print_verilog_full_testbench_configuration_chain_bitstream(std::fstream& fp
   fp << TOP_TB_BITSTREAM_MEM_REG_NAME << "[0:`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << " - 1];";
   fp << std::endl;
 
-  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << ") - 1:0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
+  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << "):0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
 
   BasicPort bit_skip_reg(TOP_TB_BITSTREAM_SKIP_FLAG_REG_NAME, 1);
   print_verilog_comment(fp, "----- Registers used for fast configuration logic -----");
-  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << ") - 1:0] " << TOP_TB_BITSTREAM_ITERATOR_REG_NAME << ";" << std::endl;
+  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << "):0] " << TOP_TB_BITSTREAM_ITERATOR_REG_NAME << ";" << std::endl;
   fp << generate_verilog_port(VERILOG_PORT_REG, bit_skip_reg) << ";" << std::endl;
 
   print_verilog_comment(fp, "----- Preload bitstream file to a virtual memory -----");
@@ -2176,7 +2176,7 @@ void print_verilog_full_testbench_memory_bank_bitstream(std::fstream& fp,
   fp << TOP_TB_BITSTREAM_MEM_REG_NAME << "[0:`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << " - 1];";
   fp << std::endl;
 
-  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << ") - 1:0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
+  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << "):0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
 
   print_verilog_comment(fp, "----- Preload bitstream file to a virtual memory -----");
   fp << "initial begin" << std::endl;
@@ -2312,7 +2312,7 @@ void print_verilog_full_testbench_frame_decoder_bitstream(std::fstream& fp,
   fp << TOP_TB_BITSTREAM_MEM_REG_NAME << "[0:`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << " - 1];";
   fp << std::endl;
 
-  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << ") - 1:0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
+  fp << "reg [$clog2(`" << TOP_TB_BITSTREAM_LENGTH_VARIABLE << "):0] " << TOP_TB_BITSTREAM_INDEX_REG_NAME << ";" << std::endl;
 
   print_verilog_comment(fp, "----- Preload bitstream file to a virtual memory -----");
   fp << "initial begin" << std::endl;

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -2143,7 +2143,7 @@ void print_verilog_full_testbench_frame_decoder_bitstream(std::fstream& fp,
   /* For fast configuration, identify the final bitstream size to be used */
   size_t num_bits_to_skip = 0;
   if (true == fast_configuration) {
-    num_bits_to_skip = find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+    num_bits_to_skip = fabric_bits_by_addr.size() - find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
   }
   VTR_ASSERT(num_bits_to_skip < fabric_bits_by_addr.size());
 

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fast_memory_bank/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fast_memory_bank/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fast_memory_bank_use_set/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fast_memory_bank_use_set/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_set_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_reset/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_reset/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_resetb/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_resetb/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_resetb_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_set/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_set/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_set_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_set_reset/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_set_reset/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_setb/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/memory_bank_use_setb/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_setb_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_memory_bank/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_memory_bank/config/task.conf
@@ -19,7 +19,7 @@ fpga_flow=yosys_vpr
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_bank_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
-openfpga_vpr_device_layout=2x2
+openfpga_vpr_device_layout=--device 2x2
 openfpga_fast_configuration=
 
 [ARCHITECTURES]

--- a/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_memory_bank/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_memory_bank/config/task.conf
@@ -16,10 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_bank_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
 openfpga_vpr_device_layout=2x2
+openfpga_fast_configuration=
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_memory_bank/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_memory_bank/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_memory_bank/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_memory_bank/config/task.conf
@@ -16,9 +16,11 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fast_configuration_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_bank_use_both_set_reset_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=--fast_configuration
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
- Address issue #319
- This is a follow-up pull request mention in #323
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Now ``write_full_testbench`` command supports memory bank when building a testbench which loads an external bitstream file.
- [x] All the ``memory bank`` test cases now use write_full_testbench command (including --fast_configuration support)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
