### PR TITLE
Support ``default_net_type`` customization in Verilog testbench generator

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
@@ -76,6 +76,10 @@ write_full_testbench
 
     Use explicit port mapping when writing the Verilog netlists
 
+  .. option:: --default_net_type <string>
+
+    Specify the default net type for the Verilog netlists. Currently, supported types are ``none`` and ``wire``. Default value: ``none``.
+
   .. option:: --include_signal_init
 
     Output signal initialization to Verilog testbench to smooth convergence in HDL simulation
@@ -105,6 +109,10 @@ write_preconfigured_fabric_wrapper
   .. option:: --explicit_port_mapping
 
     Use explicit port mapping when writing the Verilog netlists
+
+  .. option:: --default_net_type <string>
+
+    Specify the default net type for the Verilog netlists. Currently, supported types are ``none`` and ``wire``. Default value: ``none``.
 
   .. option:: --support_icarus_simulator
      
@@ -139,6 +147,11 @@ write_preconfigured_testbench
   .. option:: --explicit_port_mapping
 
     Use explicit port mapping when writing the Verilog netlists
+
+  .. option:: --default_net_type <string>
+
+    Specify the default net type for the Verilog netlists. Currently, supported types are ``none`` and ``wire``. Default value: ``none``.
+
 
   .. option:: --support_icarus_simulator
      

--- a/openfpga/src/base/openfpga_verilog.cpp
+++ b/openfpga/src/base/openfpga_verilog.cpp
@@ -74,6 +74,7 @@ int write_full_testbench(const OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_reference_benchmark = cmd.option("reference_benchmark_file_path");
   CommandOptionId opt_fast_configuration = cmd.option("fast_configuration");
   CommandOptionId opt_explicit_port_mapping = cmd.option("explicit_port_mapping");
+  CommandOptionId opt_default_net_type = cmd.option("default_net_type");
   CommandOptionId opt_include_signal_init = cmd.option("include_signal_init");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
@@ -89,6 +90,9 @@ int write_full_testbench(const OpenfpgaContext& openfpga_ctx,
   options.set_verbose_output(cmd_context.option_enable(cmd, opt_verbose));
   options.set_print_top_testbench(true);
   options.set_include_signal_init(cmd_context.option_enable(cmd, opt_include_signal_init));
+  if (true == cmd_context.option_enable(cmd, opt_default_net_type)) {
+    options.set_default_net_type(cmd_context.option_value(cmd, opt_default_net_type));
+  }
 
   /* If pin constraints are enabled by command options, read the file */
   PinConstraints pin_constraints;
@@ -122,6 +126,7 @@ int write_preconfigured_fabric_wrapper(const OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_fabric_netlist = cmd.option("fabric_netlist_file_path");
   CommandOptionId opt_pcf = cmd.option("pin_constraints_file");
   CommandOptionId opt_explicit_port_mapping = cmd.option("explicit_port_mapping");
+  CommandOptionId opt_default_net_type = cmd.option("default_net_type");
   CommandOptionId opt_support_icarus_simulator = cmd.option("support_icarus_simulator");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
@@ -135,6 +140,9 @@ int write_preconfigured_fabric_wrapper(const OpenfpgaContext& openfpga_ctx,
   options.set_verbose_output(cmd_context.option_enable(cmd, opt_verbose));
   options.set_support_icarus_simulator(cmd_context.option_enable(cmd, opt_support_icarus_simulator));
   options.set_print_formal_verification_top_netlist(true);
+  if (true == cmd_context.option_enable(cmd, opt_default_net_type)) {
+    options.set_default_net_type(cmd_context.option_value(cmd, opt_default_net_type));
+  }
 
   /* If pin constraints are enabled by command options, read the file */
   PinConstraints pin_constraints;
@@ -167,6 +175,7 @@ int write_preconfigured_testbench(const OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_reference_benchmark = cmd.option("reference_benchmark_file_path");
   CommandOptionId opt_support_icarus_simulator = cmd.option("support_icarus_simulator");
   CommandOptionId opt_explicit_port_mapping = cmd.option("explicit_port_mapping");
+  CommandOptionId opt_default_net_type = cmd.option("default_net_type");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
   /* This is an intermediate data structure which is designed to modularize the FPGA-Verilog
@@ -180,6 +189,9 @@ int write_preconfigured_testbench(const OpenfpgaContext& openfpga_ctx,
   options.set_explicit_port_mapping(cmd_context.option_enable(cmd, opt_explicit_port_mapping));
   options.set_verbose_output(cmd_context.option_enable(cmd, opt_verbose));
   options.set_print_preconfig_top_testbench(true);
+  if (true == cmd_context.option_enable(cmd, opt_default_net_type)) {
+    options.set_default_net_type(cmd_context.option_value(cmd, opt_default_net_type));
+  }
 
   /* If pin constraints are enabled by command options, read the file */
   PinConstraints pin_constraints;

--- a/openfpga/src/base/openfpga_verilog_command.cpp
+++ b/openfpga/src/base/openfpga_verilog_command.cpp
@@ -93,6 +93,10 @@ ShellCommandId add_openfpga_write_full_testbench_command(openfpga::Shell<Openfpg
   /* add an option '--explicit_port_mapping' */
   shell_cmd.add_option("explicit_port_mapping", false, "use explicit port mapping in verilog netlists");
 
+  /* Add an option '--default_net_type' */
+  CommandOptionId default_net_type_opt = shell_cmd.add_option("default_net_type", false, "Set the default net type for Verilog netlists. Default value is 'none'");
+  shell_cmd.set_option_require_value(default_net_type_opt, openfpga::OPT_STRING);
+
   /* add an option '--include_signal_init' */
   shell_cmd.add_option("include_signal_init", false, "initialize all the signals in verilog testbenches");
 
@@ -137,6 +141,10 @@ ShellCommandId add_openfpga_write_preconfigured_fabric_wrapper_command(openfpga:
 
   /* add an option '--explicit_port_mapping' */
   shell_cmd.add_option("explicit_port_mapping", false, "use explicit port mapping in verilog netlists");
+
+  /* Add an option '--default_net_type' */
+  CommandOptionId default_net_type_opt = shell_cmd.add_option("default_net_type", false, "Set the default net type for Verilog netlists. Default value is 'none'");
+  shell_cmd.set_option_require_value(default_net_type_opt, openfpga::OPT_STRING);
 
   /* Add an option '--support_icarus_simulator' */
   shell_cmd.add_option("support_icarus_simulator", false, "Fine-tune Verilog testbenches to support icarus simulator");
@@ -189,6 +197,10 @@ ShellCommandId add_openfpga_write_preconfigured_testbench_command(openfpga::Shel
 
   /* Add an option '--explicit_port_mapping' */
   shell_cmd.add_option("explicit_port_mapping", false, "Use explicit port mapping in Verilog netlists");
+
+  /* Add an option '--default_net_type' */
+  CommandOptionId default_net_type_opt = shell_cmd.add_option("default_net_type", false, "Set the default net type for Verilog netlists. Default value is 'none'");
+  shell_cmd.set_option_require_value(default_net_type_opt, openfpga::OPT_STRING);
 
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Enable verbose output");

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -239,7 +239,7 @@ int fpga_verilog_preconfigured_fabric_wrapper(const ModuleManager &module_manage
                                               netlist_annotation,
                                               netlist_name,
                                               formal_verification_top_netlist_file_path,
-                                              options.explicit_port_mapping());
+                                              options);
 
   return status;
 }
@@ -283,7 +283,7 @@ int fpga_verilog_preconfigured_testbench(const ModuleManager &module_manager,
                                      fabric_global_port_info,
                                      pin_constraints,
                                      simulation_setting,
-                                     options.explicit_port_mapping());
+                                     options);
 
   /* Generate a Verilog file including all the netlists that have been generated */
   print_verilog_testbench_include_netlists(src_dir_path,

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -56,12 +56,13 @@ void print_verilog_top_random_testbench_ports(std::fstream& fp,
                                               const std::string& circuit_name,
                                               const std::vector<std::string>& clock_port_names,
                                               const AtomContext& atom_ctx,
-                                              const VprNetlistAnnotation& netlist_annotation) {
+                                              const VprNetlistAnnotation& netlist_annotation,
+                                              const e_verilog_default_net_type& default_net_type) {
   /* Validate the file stream */
   valid_file_stream(fp);
 
   print_verilog_default_net_type_declaration(fp,
-                                             VERILOG_DEFAULT_NET_TYPE_NONE);
+                                             default_net_type);
  
   /* Print the declaration for the module */
   fp << "module " << circuit_name << FORMAL_RANDOM_TOP_TESTBENCH_POSTFIX << ";" << std::endl;
@@ -278,7 +279,7 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
                                         const FabricGlobalPortInfo& global_ports,
                                         const PinConstraints& pin_constraints,
                                         const SimulationSetting& simulation_parameters,
-                                        const bool& explicit_port_mapping) {
+                                        const VerilogTestbenchOption &options) {
   std::string timer_message = std::string("Write configuration-skip testbench for FPGA top-level Verilog netlist implemented by '") + circuit_name.c_str() + std::string("'");
 
   /* Start time count */
@@ -299,17 +300,17 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
   std::vector<std::string> clock_port_names = find_atom_netlist_clock_port_names(atom_ctx.nlist, netlist_annotation);
 
   /* Start of testbench */
-  print_verilog_top_random_testbench_ports(fp, circuit_name, clock_port_names, atom_ctx, netlist_annotation);
+  print_verilog_top_random_testbench_ports(fp, circuit_name, clock_port_names, atom_ctx, netlist_annotation, options.default_net_type());
 
   /* Call defined top-level module */
   print_verilog_random_testbench_fpga_instance(fp, circuit_name,
                                                atom_ctx, netlist_annotation,
-                                               explicit_port_mapping);
+                                               options.explicit_port_mapping());
 
   /* Call defined benchmark */
   print_verilog_top_random_testbench_benchmark_instance(fp, circuit_name,
                                                         atom_ctx, netlist_annotation,
-                                                        explicit_port_mapping);
+                                                        options.explicit_port_mapping());
 
   /* Find clock port to be used */
   std::vector<BasicPort> clock_ports = generate_verilog_testbench_clock_port(clock_port_names, std::string(DEFAULT_CLOCK_NAME));

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.h
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.h
@@ -10,6 +10,7 @@
 #include "module_manager.h"
 #include "fabric_global_port_info.h"
 #include "simulation_setting.h"
+#include "verilog_testbench_options.h"
 
 /********************************************************************
  * Function declaration
@@ -26,7 +27,7 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
                                         const FabricGlobalPortInfo& global_ports,
                                         const PinConstraints& pin_constraints,
                                         const SimulationSetting& simulation_parameters,
-                                        const bool& explicit_port_mapping);
+                                        const VerilogTestbenchOption &options);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/fpga_verilog/verilog_preconfig_top_module.cpp
+++ b/openfpga/src/fpga_verilog/verilog_preconfig_top_module.cpp
@@ -442,7 +442,7 @@ int print_verilog_preconfig_top_module(const ModuleManager &module_manager,
                                        const VprNetlistAnnotation &netlist_annotation,
                                        const std::string &circuit_name,
                                        const std::string &verilog_fname,
-                                       const bool &explicit_port_mapping) {
+                                       const VerilogTestbenchOption& options) {
   std::string timer_message = std::string("Write pre-configured FPGA top-level Verilog netlist for design '") + circuit_name + std::string("'");
 
   int status = CMD_EXEC_SUCCESS;
@@ -462,7 +462,7 @@ int print_verilog_preconfig_top_module(const ModuleManager &module_manager,
   print_verilog_file_header(fp, title);
 
   print_verilog_default_net_type_declaration(fp,
-                                             VERILOG_DEFAULT_NET_TYPE_NONE);
+                                             options.default_net_type());
 
   /* Print module declaration and ports */
   print_verilog_preconfig_top_module_ports(fp, circuit_name, atom_ctx, netlist_annotation);
@@ -477,7 +477,7 @@ int print_verilog_preconfig_top_module(const ModuleManager &module_manager,
   /* Instanciate FPGA top-level module */
   print_verilog_testbench_fpga_instance(fp, module_manager, top_module,
                                         std::string(FORMAL_VERIFICATION_TOP_MODULE_UUT_NAME),
-                                        explicit_port_mapping);
+                                        options.explicit_port_mapping());
 
   /* Find clock ports in benchmark */
   std::vector<std::string> benchmark_clock_port_names = find_atom_netlist_clock_port_names(atom_ctx.nlist, netlist_annotation);

--- a/openfpga/src/fpga_verilog/verilog_preconfig_top_module.h
+++ b/openfpga/src/fpga_verilog/verilog_preconfig_top_module.h
@@ -15,6 +15,7 @@
 #include "fabric_global_port_info.h"
 #include "config_protocol.h"
 #include "vpr_netlist_annotation.h"
+#include "verilog_testbench_options.h"
 
 /********************************************************************
  * Function declaration
@@ -35,7 +36,7 @@ int print_verilog_preconfig_top_module(const ModuleManager& module_manager,
                                        const VprNetlistAnnotation& netlist_annotation,
                                        const std::string& circuit_name,
                                        const std::string& verilog_fname,
-                                       const bool& explicit_port_mapping);
+                                       const VerilogTestbenchOption& options);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/fpga_verilog/verilog_testbench_options.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_options.cpp
@@ -23,6 +23,7 @@ VerilogTestbenchOption::VerilogTestbenchOption() {
   explicit_port_mapping_ = false;
   support_icarus_simulator_ = false;
   include_signal_init_ = false;
+  default_net_type_ = VERILOG_DEFAULT_NET_TYPE_NONE;
   verbose_output_ = false;
 }
 
@@ -75,6 +76,10 @@ bool VerilogTestbenchOption::include_signal_init() const {
 
 bool VerilogTestbenchOption::support_icarus_simulator() const {
   return support_icarus_simulator_;
+}
+
+e_verilog_default_net_type VerilogTestbenchOption::default_net_type() const {
+  return default_net_type_;
 }
 
 bool VerilogTestbenchOption::verbose_output() const {
@@ -139,6 +144,20 @@ void VerilogTestbenchOption::set_include_signal_init(const bool& enabled) {
 
 void VerilogTestbenchOption::set_support_icarus_simulator(const bool& enabled) {
   support_icarus_simulator_ = enabled;
+}
+
+void VerilogTestbenchOption::set_default_net_type(const std::string& default_net_type) {
+  /* Decode from net type string */;
+  if (default_net_type == std::string(VERILOG_DEFAULT_NET_TYPE_STRING[VERILOG_DEFAULT_NET_TYPE_NONE])) {
+    default_net_type_ = VERILOG_DEFAULT_NET_TYPE_NONE;
+  } else if (default_net_type == std::string(VERILOG_DEFAULT_NET_TYPE_STRING[VERILOG_DEFAULT_NET_TYPE_WIRE])) {
+    default_net_type_ = VERILOG_DEFAULT_NET_TYPE_WIRE;
+  } else {
+    VTR_LOG_WARN("Invalid default net type: '%s'! Expect ['%s'|'%s']\n",
+                 default_net_type.c_str(),
+                 VERILOG_DEFAULT_NET_TYPE_STRING[VERILOG_DEFAULT_NET_TYPE_NONE],
+                 VERILOG_DEFAULT_NET_TYPE_STRING[VERILOG_DEFAULT_NET_TYPE_WIRE]);
+  }
 }
 
 void VerilogTestbenchOption::set_verbose_output(const bool& enabled) {

--- a/openfpga/src/fpga_verilog/verilog_testbench_options.h
+++ b/openfpga/src/fpga_verilog/verilog_testbench_options.h
@@ -5,6 +5,7 @@
  * Include header files required by the data structure definition
  *******************************************************************/
 #include <string>
+#include "verilog_port_types.h"
 
 /* Begin namespace openfpga */
 namespace openfpga {
@@ -34,6 +35,7 @@ class VerilogTestbenchOption {
     bool explicit_port_mapping() const;
     bool include_signal_init() const;
     bool support_icarus_simulator() const;
+    e_verilog_default_net_type default_net_type() const;
     bool verbose_output() const;
   public: /* Public validator */
     bool validate() const;
@@ -58,6 +60,7 @@ class VerilogTestbenchOption {
     void set_explicit_port_mapping(const bool& enabled);
     void set_include_signal_init(const bool& enabled);
     void set_support_icarus_simulator(const bool& enabled);
+    void set_default_net_type(const std::string& default_net_type);
     void set_verbose_output(const bool& enabled);
   private: /* Internal Data */
     std::string output_directory_;
@@ -72,6 +75,7 @@ class VerilogTestbenchOption {
     bool explicit_port_mapping_;
     bool support_icarus_simulator_;
     bool include_signal_init_;
+    e_verilog_default_net_type default_net_type_;
     bool verbose_output_;
 };
 

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -701,12 +701,13 @@ void print_verilog_top_testbench_ports(std::fstream& fp,
                                        const PinConstraints& pin_constraints,
                                        const SimulationSetting& simulation_parameters,
                                        const ConfigProtocol& config_protocol,
-                                       const std::string& circuit_name){
+                                       const std::string& circuit_name,
+                                       const e_verilog_default_net_type& default_net_type) {
   /* Validate the file stream */
   valid_file_stream(fp);
 
   print_verilog_default_net_type_declaration(fp,
-                                             VERILOG_DEFAULT_NET_TYPE_NONE);
+                                             default_net_type);
 
   /* Print module definition */
   fp << "module " << circuit_name << std::string(AUTOCHECK_TOP_TESTBENCH_VERILOG_MODULE_POSTFIX);
@@ -1923,7 +1924,8 @@ int print_verilog_full_testbench(const ModuleManager& module_manager,
                                     clock_port_names,
                                     pin_constraints,
                                     simulation_parameters, config_protocol,
-                                    circuit_name);
+                                    circuit_name,
+                                    options.default_net_type());
 
   /* Find the clock period */
   float prog_clock_period = (1./simulation_parameters.programming_clock_frequency());

--- a/openfpga_flow/openfpga_shell_scripts/behavioral_verilog_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/behavioral_verilog_example_script.openfpga
@@ -55,8 +55,8 @@ write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --pri
 #  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
 #  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
 #  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
-write_preconfigured_fabric_wrapper --file ./SRC --support_icarus_simulator --explicit_port_mapping
-write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --support_icarus_simulator
+write_preconfigured_fabric_wrapper --file ./SRC --support_icarus_simulator --explicit_port_mapping --default_net_type ${OPENFPGA_VERILOG_DEFAULT_NET_TYPE}
+write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --support_icarus_simulator --default_net_type ${OPENFPGA_VERILOG_DEFAULT_NET_TYPE}
 
 # Finish and exit OpenFPGA
 exit

--- a/openfpga_flow/openfpga_shell_scripts/implicit_verilog_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/implicit_verilog_example_script.openfpga
@@ -55,9 +55,9 @@ write_fabric_verilog --file ./SRC --include_timing --print_user_defined_template
 #  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
 #  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
 #  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
-write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --bitstream fabric_bitstream.bit
-write_preconfigured_fabric_wrapper --file ./SRC --support_icarus_simulator
-write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --support_icarus_simulator
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --bitstream fabric_bitstream.bit --default_net_type ${OPENFPGA_DEFAULT_NET_TYPE}
+write_preconfigured_fabric_wrapper --file ./SRC --support_icarus_simulator --default_net_type ${OPENFPGA_DEFAULT_NET_TYPE}
+write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --support_icarus_simulator --default_net_type ${OPENFPGA_DEFAULT_NET_TYPE}
 
 # Write the SDC files for PnR backend
 #  - Turn on every options here

--- a/openfpga_flow/openfpga_shell_scripts/verilog_default_net_type_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/verilog_default_net_type_example_script.openfpga
@@ -55,9 +55,9 @@ write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --pri
 #  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
 #  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
 #  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
-write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --include_signal_init --bitstream fabric_bitstream.bit
-write_preconfigured_fabric_wrapper --file ./SRC --support_icarus_simulator --explicit_port_mapping
-write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --support_icarus_simulator
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --include_signal_init --bitstream fabric_bitstream.bit --default_net_type ${OPENFPGA_VERILOG_DEFAULT_NET_TYPE} 
+write_preconfigured_fabric_wrapper --file ./SRC --support_icarus_simulator --explicit_port_mapping --default_net_type ${OPENFPGA_VERILOG_DEFAULT_NET_TYPE} 
+write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --support_icarus_simulator --default_net_type ${OPENFPGA_VERILOG_DEFAULT_NET_TYPE} 
 
 # Write the SDC files for PnR backend
 #  - Turn on every options here


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [X] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
-  Verilog testbench generators do **not** support ``default_net_type`` customization. The net type is always set to ``none``. For example,
```
`default_nettype none

module and2_autocheck_top_tb;
```

This has caused some compatibility issues in some HDL simulators, e.g., Modelsim.

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Support ``default_net_type`` customization in command ``write_full_testbench`` with an option ``--default_net_type``
- [x] Support ``default_net_type`` customization in command ``write_preconfigured_fabric_wrapper`` with an option ``--default_net_type``
- [x] Support ``default_net_type`` customization in command ``write_preconfigured_testbench`` with an option ``--default_net_type``
- [x] Documentation has been updated for the newly added options.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [x] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
