### PR TITLE
Openfpga flow script outputs detailed error message when task directory is not found

### DIFF
--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -174,7 +174,7 @@ def generate_each_task_actions(taskname):
     elif os.path.isdir(repo_tasks):
         curr_task_dir = repo_tasks
     else:
-        clean_up_and_exit("Task directory not found" % taskname + " locally at [%s]" % local_tasks + " or in OpenFPGA task directory [%s]" % repo_tasks)
+        clean_up_and_exit("Task directory [%s] not found" % taskname + " locally at [%s]" % local_tasks + " or in OpenFPGA task directory [%s]" % repo_tasks)
 
     os.chdir(curr_task_dir)
 

--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -174,7 +174,7 @@ def generate_each_task_actions(taskname):
     elif os.path.isdir(repo_tasks):
         curr_task_dir = repo_tasks
     else:
-        clean_up_and_exit("Task directory [%s] not found" % curr_task_dir)
+        clean_up_and_exit("Task directory not found" % taskname + " locally at [%s]" % local_tasks + " or in OpenFPGA task directory [%s]" % repo_tasks)
 
     os.chdir(curr_task_dir)
 


### PR DESCRIPTION

> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
Address issue #330 
Previous python script is buggy when outputting error message when task directory is not found

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->
Patched the script. Here is how the error message look like now.

```
[u6018939@lnissrv4 OpenFPGA]$ python3 openfpga_flow/scripts/run_fpga_task.py aaa
 INFO (     MainThread) - Set up to run 2 Parallel threads
 INFO (     MainThread) - Currently running task aaa
ERROR (     MainThread) - Task directory [['aaa']] not found locally at [aaa] or in OpenFPGA task directory [/research/ece/lnis/USERS/tang/github/OpenFPGA/openfpga_flow/tasks/aaa]
ERROR (     MainThread) - Exiting . . . . . .
```

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [x] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
