### PR TITLE
Write io mapping

### DIFF
--- a/libopenfpga/libopenfpgautil/src/openfpga_reserved_words.h
+++ b/libopenfpga/libopenfpgautil/src/openfpga_reserved_words.h
@@ -59,6 +59,9 @@ constexpr char* DEFAULT_LB_DIR_NAME = "lb/";
 constexpr char* DEFAULT_RR_DIR_NAME = "routing/";
 constexpr char* DEFAULT_SUBMODULE_DIR_NAME = "sub_module/";
 
+constexpr char* VPR_BENCHMARK_OUT_PORT_PREFIX = "out:";
+constexpr char* OPENFPGA_BENCHMARK_OUT_PORT_PREFIX = "out_";
+
 } /* end namespace openfpga */
 
 #endif

--- a/openfpga/src/base/openfpga_bitstream.cpp
+++ b/openfpga/src/base/openfpga_bitstream.cpp
@@ -10,6 +10,7 @@
 
 /* Headers from openfpgautil library */
 #include "openfpga_digest.h"
+#include "openfpga_reserved_words.h"
 
 /* Headers from fpgabitstream library */
 #include "read_xml_arch_bitstream.h"
@@ -153,6 +154,11 @@ int write_io_mapping(const OpenfpgaContext& openfpga_ctx,
   ModuleId top_module = openfpga_ctx.module_graph().find_module(top_module_name);
   VTR_ASSERT(true == openfpga_ctx.module_graph().valid_module_id(top_module));
 
+  /* VPR added a prefix to the output ports, remove them here */
+  std::vector<std::string> prefix_to_remove;
+  prefix_to_remove.push_back(std::string(VPR_BENCHMARK_OUT_PORT_PREFIX));
+  prefix_to_remove.push_back(std::string(OPENFPGA_BENCHMARK_OUT_PORT_PREFIX));
+
   IoMap io_map = build_fpga_io_mapping_info(openfpga_ctx.module_graph(),
                                             top_module,
                                             g_vpr_ctx.atom(),
@@ -160,7 +166,8 @@ int write_io_mapping(const OpenfpgaContext& openfpga_ctx,
                                             openfpga_ctx.io_location_map(),
                                             openfpga_ctx.vpr_netlist_annotation(),
                                             std::string(),
-                                            std::string());
+                                            std::string(),
+                                            prefix_to_remove);
 
   status = write_io_mapping_to_xml_file(io_map,
                                         cmd_context.option_value(cmd, opt_file),

--- a/openfpga/src/fabric/build_top_module_connection.cpp
+++ b/openfpga/src/fabric/build_top_module_connection.cpp
@@ -747,6 +747,7 @@ int build_top_module_global_net_for_given_grid_module(ModuleManager& module_mana
   /* Find the port of the grid module according to the tile annotation */
   int grid_pin_start_index = physical_tile->num_pins;
   t_physical_tile_port physical_tile_port;
+  physical_tile_port.num_pins = 0;
   for (const t_physical_tile_port& tile_port : physical_tile->ports) { 
     if (std::string(tile_port.name) == tile_port_to_connect.get_name()) {
       BasicPort ref_tile_port(tile_port.name, tile_port.num_pins);

--- a/openfpga/src/fpga_bitstream/build_io_mapping_info.cpp
+++ b/openfpga/src/fpga_bitstream/build_io_mapping_info.cpp
@@ -37,7 +37,8 @@ IoMap build_fpga_io_mapping_info(const ModuleManager& module_manager,
                                  const IoLocationMap& io_location_map,
                                  const VprNetlistAnnotation& netlist_annotation,
                                  const std::string& io_input_port_name_postfix,
-                                 const std::string& io_output_port_name_postfix) {
+                                 const std::string& io_output_port_name_postfix,
+                                 const std::vector<std::string>& output_port_prefix_to_remove) {
   IoMap io_map;
 
   /* Only mappable i/o ports can be considered */
@@ -129,7 +130,18 @@ IoMap build_fpga_io_mapping_info(const ModuleManager& module_manager,
       benchmark_io_port.set_width(1);
     } else {
       VTR_ASSERT(AtomBlockType::OUTPAD == atom_ctx.nlist.block_type(atom_blk));
-      benchmark_io_port.set_name(std::string(block_name + io_output_port_name_postfix)); 
+      /* VPR may have added a prefix to the output ports, remove them here */
+      std::string output_block_name = block_name;
+      for (const std::string& prefix_to_remove : output_port_prefix_to_remove) {
+        if (!prefix_to_remove.empty()) {
+          if (0 == output_block_name.find(prefix_to_remove)) {
+            output_block_name.erase(0, prefix_to_remove.length());
+            break;
+          }
+        }
+      }
+
+      benchmark_io_port.set_name(std::string(output_block_name + io_output_port_name_postfix)); 
       benchmark_io_port.set_width(1);
     }
 

--- a/openfpga/src/fpga_bitstream/build_io_mapping_info.h
+++ b/openfpga/src/fpga_bitstream/build_io_mapping_info.h
@@ -26,7 +26,8 @@ IoMap build_fpga_io_mapping_info(const ModuleManager& module_manager,
                                  const IoLocationMap& io_location_map,
                                  const VprNetlistAnnotation& netlist_annotation,
                                  const std::string& io_input_port_name_postfix,
-                                 const std::string& io_output_port_name_postfix);
+                                 const std::string& io_output_port_name_postfix,
+                                 const std::vector<std::string>& output_port_prefix_to_remove);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -16,6 +16,7 @@
 /* Headers from openfpgautil library */
 #include "openfpga_port.h"
 #include "openfpga_digest.h"
+#include "openfpga_reserved_words.h"
 
 #include "openfpga_atom_netlist_utils.h"
 #include "simulation_utils.h"

--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.h
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.h
@@ -23,9 +23,6 @@
 /* begin namespace openfpga */
 namespace openfpga {
 
-constexpr char* VPR_BENCHMARK_OUT_PORT_PREFIX = "out:";
-constexpr char* OPENFPGA_BENCHMARK_OUT_PORT_PREFIX = "out_";
-
 void print_verilog_testbench_fpga_instance(std::fstream& fp,
                                            const ModuleManager& module_manager,
                                            const ModuleId& top_module,


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->

Address issue #308 

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [x] Remove the suffix of output ports in I/O mapping XML file which is added by VPR
- [x] Fixed a compiler warning
Example of io_mapping.xml outputted:

```
<!--
	- I/O mapping
	- Version: 1.0.0-dev+fed975c5-dirty
	- Date: Fri Jun 18 16:24:09 2021
-->

<io_mapping>
	<io name="gfpga_pad_GPIO_PAD[6:6]" net="a" dir="input"/>
	<io name="gfpga_pad_GPIO_PAD[1:1]" net="b" dir="input"/>
	<io name="gfpga_pad_GPIO_PAD[9:9]" net="c" dir="output"/>
</io_mapping>

```

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
