### PR TITLE
Support benchmarks with same top module names in openfpga flow script

### DIFF
--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -309,7 +309,7 @@ def generate_each_task_actions(taskname):
     for indx, arch in enumerate(archfile_list):
         for bench in benchmark_list:
             for lbl, param in bench["script_params"].items():
-                flow_run_dir = get_flow_rundir(arch, bench["top_module"], lbl)
+                flow_run_dir = get_flow_rundir(arch, benchmark_list.index(bench), bench["top_module"], lbl)
                 command = create_run_command(
                     curr_job_dir=flow_run_dir,
                     archfile=arch,
@@ -330,11 +330,12 @@ def generate_each_task_actions(taskname):
     logger.info('Created total %d jobs' % len(flow_run_cmd_list))
     return flow_run_cmd_list
 
-
-def get_flow_rundir(arch, top_module, flow_params=None):
+# Make the directory name unique by including the benchmark index in the list.
+# This is because benchmarks may share the same top module names
+def get_flow_rundir(arch, bench_index, top_module, flow_params=None):
     path = [
         os.path.basename(arch).replace(".xml", ""),
-        top_module,
+        "bench" + str(bench_index) + "_" + top_module,
         flow_params if flow_params else "common"
     ]
     return os.path.abspath(os.path.join(*path))


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- [x] ``run_fpga_task.py`` uses the top module name of each benchmark when creating the local run directory name. However, benchmarks may share the same top module name. As a result, the local run directory can be overwritten. Therefore, in current task configuration files, we forbidden the use of same top module names for any benchmark to run.

This has been a strong limitation because we should not constrain users when naming their top modules of HDL designs.

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Rework the local run directory naming function in ``run_fpga_task.py`` script. Now benchmark local run directory has a unique name, which includes the benchmark index in the list and the top module name.

Here is an example:
- When define a benchmark top module name:
```
bench0_top = and2
```
- The flow-run script now creates a local run directory:
```
openfpga_flow/tasks/fpga_bitstream/write_io_mapping/run001/k6_frac_N10_tileable_40nm/bench0_and2/MIN_ROUTE_CHAN_WIDTH
```

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [x] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
