### PR TITLE
Update Simulation Exchangeable Information Writer

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
@@ -177,6 +177,10 @@ write_simulation_task_info
 
     Specify the type of testbenches [``preconfigured_testbench``|``full_testbench``]. By default, it is the ``preconfigured_testbench``.
 
+  .. option:: --time_unit <string>
+      
+    Specify a time unit to be used in SDC files. Acceptable values are string: ``as`` | ``fs`` | ``ps`` | ``ns`` | ``us`` | ``ms`` | ``ks`` | ``Ms``. By default, we will consider second (``ms``).
+
   .. option:: --verbose
 
     Show verbose log

--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
@@ -173,6 +173,10 @@ write_simulation_task_info
 
     Must specify the reference benchmark Verilog file if you want to output any testbenches. For example, ``--reference_benchmark_file_path /temp/benchmark/counter_post_synthesis.v``
 
+  .. option:: --testbench_type <string>
+
+    Specify the type of testbenches [``preconfigured_testbench``|``full_testbench``]. By default, it is the ``preconfigured_testbench``.
+
   .. option:: --verbose
 
     Show verbose log

--- a/openfpga/src/base/openfpga_verilog.cpp
+++ b/openfpga/src/base/openfpga_verilog.cpp
@@ -8,6 +8,9 @@
 /* Headers from openfpgashell library */
 #include "command_exit_codes.h"
 
+/* Headers from openfpgautil library */
+#include "openfpga_scale.h"
+
 #include "verilog_api.h"
 #include "openfpga_verilog.h"
 
@@ -220,6 +223,7 @@ int write_simulation_task_info(const OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_hdl_dir = cmd.option("hdl_dir");
   CommandOptionId opt_reference_benchmark = cmd.option("reference_benchmark_file_path");
   CommandOptionId opt_tb_type = cmd.option("testbench_type");
+  CommandOptionId opt_time_unit = cmd.option("time_unit");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
   /* This is an intermediate data structure which is designed to modularize the FPGA-Verilog
@@ -230,6 +234,10 @@ int write_simulation_task_info(const OpenfpgaContext& openfpga_ctx,
   options.set_reference_benchmark_file_path(cmd_context.option_value(cmd, opt_reference_benchmark));
   options.set_verbose_output(cmd_context.option_enable(cmd, opt_verbose));
   options.set_print_simulation_ini(cmd_context.option_value(cmd, opt_file));
+
+  if (true == cmd_context.option_enable(cmd, opt_time_unit)) {
+    options.set_time_unit(string_to_time_unit(cmd_context.option_value(cmd, opt_time_unit)));
+  }
 
   /* Identify testbench type */
   std::string full_tb_tag("full_testbench");

--- a/openfpga/src/base/openfpga_verilog_command.cpp
+++ b/openfpga/src/base/openfpga_verilog_command.cpp
@@ -247,6 +247,10 @@ ShellCommandId add_openfpga_write_simulation_task_info_command(openfpga::Shell<O
   CommandOptionId tb_type_opt = shell_cmd.add_option("testbench_type", false, "Specify the type of testbenches to be considered. Different testbenches have different simulation parameters.");
   shell_cmd.set_option_require_value(tb_type_opt, openfpga::OPT_STRING);
 
+  /* Add an option '--time_unit' */
+  CommandOptionId time_unit_opt = shell_cmd.add_option("time_unit", false, "Specify the time unit to be used in HDL simulation. Acceptable is [a|f|p|n|u|m|k|M]s");
+  shell_cmd.set_option_require_value(time_unit_opt, openfpga::OPT_STRING);
+
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Enable verbose output");
   

--- a/openfpga/src/base/openfpga_verilog_command.cpp
+++ b/openfpga/src/base/openfpga_verilog_command.cpp
@@ -243,6 +243,10 @@ ShellCommandId add_openfpga_write_simulation_task_info_command(openfpga::Shell<O
   CommandOptionId ref_bm_opt = shell_cmd.add_option("reference_benchmark_file_path", true, "Specify the file path to the reference Verilog netlist");
   shell_cmd.set_option_require_value(ref_bm_opt, openfpga::OPT_STRING);
 
+  /* Add an option '--testbench_type'*/
+  CommandOptionId tb_type_opt = shell_cmd.add_option("testbench_type", false, "Specify the type of testbenches to be considered. Different testbenches have different simulation parameters.");
+  shell_cmd.set_option_require_value(tb_type_opt, openfpga::OPT_STRING);
+
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Enable verbose output");
   

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -323,6 +323,7 @@ int fpga_verilog_simulation_task_info(const ModuleManager &module_manager,
   std::string simulation_ini_file_name = options.simulation_ini_path();
   VTR_ASSERT(true != options.simulation_ini_path().empty());
   print_verilog_simulation_info(simulation_ini_file_name,
+                                options,
                                 netlist_name,
                                 src_dir_path,
                                 atom_ctx, place_ctx, io_location_map,

--- a/openfpga/src/fpga_verilog/verilog_simulation_info_writer.h
+++ b/openfpga/src/fpga_verilog/verilog_simulation_info_writer.h
@@ -9,6 +9,7 @@
 #include "config_protocol.h"
 #include "vpr_context.h"
 #include "io_location_map.h"
+#include "verilog_testbench_options.h"
 
 /********************************************************************
  * Function declaration
@@ -18,6 +19,7 @@
 namespace openfpga {
 
 void print_verilog_simulation_info(const std::string& ini_fname,
+                                   const VerilogTestbenchOption& options,
                                    const std::string& circuit_name,
                                    const std::string& src_dir,
                                    const AtomContext& atom_ctx,

--- a/openfpga/src/fpga_verilog/verilog_testbench_options.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_options.cpp
@@ -24,6 +24,7 @@ VerilogTestbenchOption::VerilogTestbenchOption() {
   support_icarus_simulator_ = false;
   include_signal_init_ = false;
   default_net_type_ = VERILOG_DEFAULT_NET_TYPE_NONE;
+  time_unit_ = 1E-3;
   verbose_output_ = false;
 }
 
@@ -80,6 +81,10 @@ bool VerilogTestbenchOption::support_icarus_simulator() const {
 
 e_verilog_default_net_type VerilogTestbenchOption::default_net_type() const {
   return default_net_type_;
+}
+
+float VerilogTestbenchOption::time_unit() const {
+  return time_unit_;
 }
 
 bool VerilogTestbenchOption::verbose_output() const {
@@ -158,6 +163,10 @@ void VerilogTestbenchOption::set_default_net_type(const std::string& default_net
                  VERILOG_DEFAULT_NET_TYPE_STRING[VERILOG_DEFAULT_NET_TYPE_NONE],
                  VERILOG_DEFAULT_NET_TYPE_STRING[VERILOG_DEFAULT_NET_TYPE_WIRE]);
   }
+}
+
+void VerilogTestbenchOption::set_time_unit(const float& time_unit) {
+  time_unit_ = time_unit;
 }
 
 void VerilogTestbenchOption::set_verbose_output(const bool& enabled) {

--- a/openfpga/src/fpga_verilog/verilog_testbench_options.h
+++ b/openfpga/src/fpga_verilog/verilog_testbench_options.h
@@ -36,6 +36,7 @@ class VerilogTestbenchOption {
     bool include_signal_init() const;
     bool support_icarus_simulator() const;
     e_verilog_default_net_type default_net_type() const;
+    float time_unit() const;
     bool verbose_output() const;
   public: /* Public validator */
     bool validate() const;
@@ -61,6 +62,7 @@ class VerilogTestbenchOption {
     void set_include_signal_init(const bool& enabled);
     void set_support_icarus_simulator(const bool& enabled);
     void set_default_net_type(const std::string& default_net_type);
+    void set_time_unit(const float& time_unit);
     void set_verbose_output(const bool& enabled);
   private: /* Internal Data */
     std::string output_directory_;
@@ -76,6 +78,7 @@ class VerilogTestbenchOption {
     bool support_icarus_simulator_;
     bool include_signal_init_;
     e_verilog_default_net_type default_net_type_;
+    float time_unit_;
     bool verbose_output_;
 };
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [X] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- [X] The simulation ``.ini`` file is exclusively designed for preconfigured testbench. However, as now users can freely output any type of testbenches using different commands (see #326), there is a need that the ``.ini`` file supports full testbench.
- [X] The simulation ``.ini`` file assumes a fixed time unit for simulation periods, which is ``ms``. 
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] The simulation ``.ini`` file allows users to specify the testbench to be used through an option ``--testbench_type``. By default, it remains to use the preconfigured testbench to avoid back compatibility issue.
- [x] The simulation ``.ini`` file allows users to specify the time unit to be used through an option ``--time_unit``. By default, it remains to use the ``ms`` to avoid back compatibility issue.
- [x] Documentation updated

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
