### PR TITLE
Bug fix in Preconfigured Fabric Wrapper Generator

### DIFF
--- a/openfpga/src/fpga_verilog/verilog_preconfig_top_module.cpp
+++ b/openfpga/src/fpga_verilog/verilog_preconfig_top_module.cpp
@@ -385,9 +385,8 @@ void print_verilog_preconfig_top_module_load_bitstream(std::fstream &fp,
     print_verilog_preconfig_top_module_assign_bitstream(fp, module_manager, top_module,
                                                         bitstream_manager,
                                                         output_datab_bits);
-  } else {
-    /* Use deposit syntax for other simulators */
-    VTR_ASSERT(EMBEDDED_BITSTREAM_HDL_MODELSIM == embedded_bitstream_hdl_type);
+  /* Use deposit syntax for other simulators */
+  } else if (EMBEDDED_BITSTREAM_HDL_MODELSIM == embedded_bitstream_hdl_type) {
     print_verilog_preconfig_top_module_deposit_bitstream(fp, module_manager, top_module,
                                                          bitstream_manager,
                                                          output_datab_bits);

--- a/openfpga_flow/openfpga_shell_scripts/preconfig_fabric_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/preconfig_fabric_example_script.openfpga
@@ -1,0 +1,57 @@
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling route
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to clustering nets based on routing results
+pb_pin_fixup --verbose
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enable pin duplication on grid modules
+build_fabric --compress_routing #--verbose
+
+# Write the fabric hierarchy of module graph to a file
+# This is used by hierarchical PnR flows
+write_fabric_hierarchy --file ./fabric_hierarchy.txt
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose
+
+# Write the Verilog testbench for FPGA fabric
+#  - We suggest the use of same output directory as fabric Verilog netlists
+#  - Must specify the reference benchmark file if you want to output any testbenches
+#  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
+#  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
+#  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
+write_preconfigured_fabric_wrapper --embed_bitstream ${OPENFPGA_EMBEDDED_BITSTREAM_HDL_TYPE} --file ./SRC  --explicit_port_mapping
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -136,3 +136,7 @@ run-task fpga_verilog/fully_connected_output_crossbar --debug --show_thread_logs
 echo -e "Testing through channels in tileable routing";
 run-task fpga_verilog/thru_channel/thru_narrow_tile --debug --show_thread_logs
 run-task fpga_verilog/thru_channel/thru_wide_tile --debug --show_thread_logs
+
+echo -e "Testing the generation of preconfigured fabric wrapper for different HDL simulators";
+run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_none --debug --show_thread_logs
+run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_modelsim --debug --show_thread_logs

--- a/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/embed_bitstream_modelsim/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/embed_bitstream_modelsim/config/task.conf
@@ -1,0 +1,35 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 1*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/preconfig_fabric_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_behavioral_40nm_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_embedded_bitstream_hdl_type=modelsim
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_act = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.act
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]

--- a/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/embed_bitstream_none/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/embed_bitstream_none/config/task.conf
@@ -1,0 +1,35 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 1*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/preconfig_fabric_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_behavioral_40nm_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_embedded_bitstream_hdl_type=none
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_act = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.act
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [X] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- [x] The option ``--embed_bitstream none`` for command ``write_preconfigured_Fabric_wrapper`` does not work
- [x] There are no tests in CI for the option ``--embed_bitstream none`` and option ``--embed_bitstream modelsim``

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [x] Fix a bug in the FPGA-Verilog which causes  openfpga_flow broken when ``--embed_bitstream none`` is enabled
- [x] Added dedicated test cases for the option ``--embed_bitstream none`` and option ``--embed_bitstream modelsim`` to CI

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
