### PR TITLE
Remove the hardcoded factor when computing simulation timing

### DIFF
--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -41,7 +41,6 @@ constexpr char* BENCHMARK_INSTANCE_NAME = "REF_DUT";
 constexpr char* FPGA_INSTANCE_NAME = "FPGA_DUT";
 constexpr char* ERROR_COUNTER = "nb_error";
 constexpr char* FORMAL_TB_SIM_START_PORT_NAME = "sim_start";
-constexpr int MAGIC_NUMBER_FOR_SIMULATION_TIME = 200;
 
 /********************************************************************
  * Print the module ports for the Verilog testbench 
@@ -354,8 +353,7 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
                                 clock_port_names,
                                 std::string(DEFAULT_CLOCK_NAME));
 
-  float simulation_time = find_operating_phase_simulation_time(MAGIC_NUMBER_FOR_SIMULATION_TIME,
-                                                               simulation_parameters.num_clock_cycles(),
+  float simulation_time = find_operating_phase_simulation_time(simulation_parameters.num_clock_cycles(),
                                                                1./simulation_parameters.default_operating_clock_frequency(),
                                                                VERILOG_SIM_TIMESCALE);
 

--- a/openfpga/src/fpga_verilog/verilog_simulation_info_writer.cpp
+++ b/openfpga/src/fpga_verilog/verilog_simulation_info_writer.cpp
@@ -72,8 +72,7 @@ void print_verilog_simulation_info(const std::string& ini_fname,
                                                          1. / op_clock_freq);
   } else {
     VTR_ASSERT(options.print_preconfig_top_testbench());
-    simulation_time_period = find_operating_phase_simulation_time(1.,
-                                                                  num_operating_clock_cycles,
+    simulation_time_period = find_operating_phase_simulation_time(num_operating_clock_cycles,
                                                                   1. / op_clock_freq,
                                                                   options.time_unit());
   }

--- a/openfpga/src/utils/simulation_utils.cpp
+++ b/openfpga/src/utils/simulation_utils.cpp
@@ -14,14 +14,13 @@ namespace openfpga {
 /********************************************************************
  * Compute the time period for the simulation
  *******************************************************************/
-float find_operating_phase_simulation_time(const int& factor,
-                                           const int& num_op_clock_cycles,
+float find_operating_phase_simulation_time(const int& num_op_clock_cycles,
                                            const float& op_clock_period,
                                            const float& timescale) {
   /* Take into account the prog_reset and reset cycles 
    * 1e9 is to change the unit to ns rather than second 
    */
-  return ((float)factor * (float)num_op_clock_cycles * op_clock_period) / timescale; 
+  return ((float)num_op_clock_cycles * op_clock_period) / timescale; 
 }
 
 /********************************************************************

--- a/openfpga/src/utils/simulation_utils.h
+++ b/openfpga/src/utils/simulation_utils.h
@@ -12,8 +12,7 @@
 /* begin namespace openfpga */
 namespace openfpga {
 
-float find_operating_phase_simulation_time(const int& factor,
-                                           const int& num_op_clock_cycles,
+float find_operating_phase_simulation_time(const int& num_op_clock_cycles,
                                            const float& op_clock_period,
                                            const float& timescale);
 


### PR DESCRIPTION


> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [X] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
- [x] The simulation time for operating time has a hidden factor (=200) which is hard coded in the code base

This caused the simulation time to be inconsistent with what user expect or defined in simulation setting.
There should be no hidden parameters impacting simulation time
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Remove the hidden factor



> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
