### PR TITLE
Use ``force`` in preconfigured testbenches to avoid instrusive code modification on flip-flop HDL

### DIFF
--- a/openfpga_flow/openfpga_cell_library/verilog/dff.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dff.v
@@ -20,12 +20,7 @@ always @ (posedge CK) begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-`else
-  assign Q = 1'bZ;
-`endif
+assign Q = q_reg;
 
 endmodule //End Of Module
 
@@ -46,14 +41,8 @@ always @ (posedge CK) begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-  assign QN = ~q_reg;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = ~q_reg;
 
 endmodule //End Of Module
 
@@ -79,12 +68,7 @@ end else begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-`else
-  assign Q = 1'bZ;
-`endif
+assign Q = q_reg;
 
 endmodule //End Of Module
 
@@ -111,14 +95,8 @@ end else begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-  assign QN = ~q_reg;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = ~q_reg;
 
 endmodule //End Of Module
 
@@ -144,14 +122,8 @@ end else begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-  assign QN = ~q_reg;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = ~q_reg;
 
 endmodule //End Of Module
 
@@ -178,14 +150,8 @@ end else begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-  assign QN = ~q_reg;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = ~q_reg;
 
 endmodule //End Of Module
 
@@ -211,14 +177,8 @@ end else begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-  assign QN = ~q_reg;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = ~q_reg;
 
 endmodule //End Of Module
 
@@ -249,14 +209,8 @@ end else begin
   q_reg <= D;
 end
 
-// Wire q_reg to Q
-`ifndef ENABLE_FORMAL_VERIFICATION
-  assign Q = q_reg;
-  assign QN = ~q_reg;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = ~q_reg;
 
 endmodule //End Of Module
 
@@ -349,14 +303,8 @@ end else begin
   q_reg <= D;
 end
 
-`ifndef ENABLE_FORMAL_VERIFICATION
-// Wire q_reg to Q
-  assign Q = q_reg;
-  assign QN = !Q;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = !Q;
 
 endmodule //End Of Module
 
@@ -462,13 +410,7 @@ end
 assign CFGQ = CFGE ? Q : 1'b0;
 assign CFGQN = CFGE ? QN : 1'b1;
 
-`ifndef ENABLE_FORMAL_VERIFICATION
-// Wire q_reg to Q
-  assign Q = q_reg;
-  assign QN = !Q;
-`else
-  assign Q = 1'bZ;
-  assign QN = !Q;
-`endif
+assign Q = q_reg;
+assign QN = !Q;
 
 endmodule //End Of Module


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: #346 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
To address issue #346 
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [ ] Use the standard ``force`` syntax in preconfigured testbench generation for iVerilog; For modelsim, we still use ``$deposit`` which is not a standard but should be reworked later.
- [ ] Removed all the modification on flip-flop HDL codes which was required by preconfigured testbench

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [X] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [X] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
