### PR TITLE
[Flow] Allows benchmark specific Variable declaration

### DIFF
--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -272,7 +272,7 @@ def generate_each_task_actions(taskname):
         CurrBenchPara["chan_width"] = SynthSection.get(bech_name+"_chan_width",
                                                        fallback=chan_width_common)
         for eachKey, eachValue in SynthSection.items():
-            eachKey = eachKey.replace(bech_name+"_","")
+            eachKey = eachKey.replace(bech_name+"_","").upper()
             CurrBenchPara[eachKey] = eachValue
 
         if GeneralSection.get("fpga_flow") == "vpr_blif":

--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -271,6 +271,9 @@ def generate_each_task_actions(taskname):
                                                       fallback=ys_rewrite_for_task_common)
         CurrBenchPara["chan_width"] = SynthSection.get(bech_name+"_chan_width",
                                                        fallback=chan_width_common)
+        for eachKey, eachValue in SynthSection.items():
+            eachKey = eachKey.replace(bech_name+"_","")
+            CurrBenchPara[eachKey] = eachValue
 
         if GeneralSection.get("fpga_flow") == "vpr_blif":
             # Check if activity file exist
@@ -320,7 +323,7 @@ def generate_each_task_actions(taskname):
                   flow_run_dir = get_flow_rundir(arch, "bench" + str(benchmark_list.index(bench)) + "_" + bench["top_module"], lbl)
                 else:
                   flow_run_dir = get_flow_rundir(arch, bench["top_module"], lbl)
-                  
+
                 command = create_run_command(
                     curr_job_dir=flow_run_dir,
                     archfile=arch,


### PR DESCRIPTION
> ### Motivate of the pull request
Allows benchmark specific variable declaration in the task file
```
[SYNTHESIS_PARAM]
bench0_top = and2
bench0_pin_conf_file = ${TASK_DIR}
```
Makes `PIN_CONF_FILE` variable during openfpgashell run of specific benchmark

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [x] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
