### PR TITLE
[WIP] Support custom default value in Pin Constraint File

### DIFF
--- a/docs/source/manual/file_formats/pin_constraints_file.rst
+++ b/docs/source/manual/file_formats/pin_constraints_file.rst
@@ -10,7 +10,7 @@ An example of design constraints is shown as follows.
 .. code-block:: xml
 
   <pin_constraints>
-    <set_io pin="clk[0]" net="clk0"/>
+    <set_io pin="clk[0]" net="clk0" default_value="1"/>
     <set_io pin="clk[1]" net="clk1"/>
     <set_io pin="clk[2]" net="OPEN"/>
     <set_io pin="clk[3]" net="OPEN"/>
@@ -23,3 +23,9 @@ An example of design constraints is shown as follows.
 .. option:: net="<string>"
 
   The net name of the pin to be mapped, which should be consistent with net definition in your ``.blif`` file. The reserved word ``OPEN`` means that no net should be mapped to a given pin. Please ensure that it is not conflicted with any net names in your ``.blif`` file.
+
+.. option:: default_value="<string>"
+
+  The default value of a net to be constrained. This is mainly used when generating testbenches. Valid value is ``0`` or ``1``. If defined as ``1``, the net is be driven by the inversion of its stimuli.
+
+  .. note:: This feature is mainly used to generate the correct stimuli for some pin whose polarity can be configurable. For example, the ``Reset`` pin of an FPGA fabric may be active-low or active-high depending on its configuration.

--- a/docs/source/manual/file_formats/pin_constraints_file.rst
+++ b/docs/source/manual/file_formats/pin_constraints_file.rst
@@ -29,3 +29,5 @@ An example of design constraints is shown as follows.
   The default value of a net to be constrained. This is mainly used when generating testbenches. Valid value is ``0`` or ``1``. If defined as ``1``, the net is be driven by the inversion of its stimuli.
 
   .. note:: This feature is mainly used to generate the correct stimuli for some pin whose polarity can be configurable. For example, the ``Reset`` pin of an FPGA fabric may be active-low or active-high depending on its configuration.
+
+  .. note:: The default value in pin constraint file has a higher priority than the ``default_value`` syntax in the :ref:`circuit_library`.

--- a/libopenfpga/libpcf/src/pin_constraints.cpp
+++ b/libopenfpga/libpcf/src/pin_constraints.cpp
@@ -60,6 +60,36 @@ openfpga::BasicPort PinConstraints::net_pin(const std::string& net) const {
   return constrained_pin;
 } 
 
+PinConstraints::e_logic_level PinConstraints::net_default_value(const std::string& net) const {
+  PinConstraints::e_logic_level logic_level = PinConstraints::NUM_LOGIC_LEVELS;
+  for (const PinConstraintId& pin_constraint : pin_constraints()) {
+    if (net == pin_constraint_nets_[pin_constraint]) {
+      logic_level = pin_constraint_net_default_values_[pin_constraint]; 
+      break;
+    }
+  }
+  return logic_level;
+}
+
+std::string PinConstraints::net_default_value_to_string(const PinConstraintId& pin_constraint) const {
+  VTR_ASSERT(valid_pin_constraint_id(pin_constraint));
+  if (PinConstraints::LOGIC_HIGH == pin_constraint_net_default_values_[pin_constraint]) {
+    return std::string("1");
+  } else if (PinConstraints::LOGIC_LOW == pin_constraint_net_default_values_[pin_constraint]) {
+    return std::string("0");
+  }
+  return std::string();
+} 
+
+size_t PinConstraints::net_default_value_to_int(const std::string& net) const {
+  if (PinConstraints::LOGIC_HIGH == net_default_value(net)) {
+    return 1;
+  } else if (PinConstraints::LOGIC_LOW == net_default_value(net)) {
+    return 0;
+  }
+  return -1;
+} 
+
 bool PinConstraints::empty() const {
   return 0 == pin_constraint_ids_.size();
 }
@@ -71,6 +101,7 @@ void PinConstraints::reserve_pin_constraints(const size_t& num_pin_constraints) 
   pin_constraint_ids_.reserve(num_pin_constraints);
   pin_constraint_pins_.reserve(num_pin_constraints);
   pin_constraint_nets_.reserve(num_pin_constraints);
+  pin_constraint_net_default_values_.reserve(num_pin_constraints);
 }
 
 PinConstraintId PinConstraints::create_pin_constraint(const openfpga::BasicPort& pin,
@@ -81,8 +112,19 @@ PinConstraintId PinConstraints::create_pin_constraint(const openfpga::BasicPort&
   pin_constraint_ids_.push_back(pin_constraint_id);
   pin_constraint_pins_.push_back(pin);
   pin_constraint_nets_.push_back(net);
+  pin_constraint_net_default_values_.push_back(PinConstraints::NUM_LOGIC_LEVELS);
   
   return pin_constraint_id;
+}
+
+void PinConstraints::set_net_default_value(const PinConstraintId& pin_constraint,
+                                           const std::string& default_value) {
+  VTR_ASSERT(valid_pin_constraint_id(pin_constraint));
+  if (default_value == std::string("1")) {
+    pin_constraint_net_default_values_[pin_constraint] = PinConstraints::LOGIC_HIGH;
+  } else if (default_value == std::string("0")) {
+    pin_constraint_net_default_values_[pin_constraint] = PinConstraints::LOGIC_LOW;
+  }
 }
 
 /************************************************************************
@@ -99,4 +141,13 @@ bool PinConstraints::unconstrained_net(const std::string& net) const {
 
 bool PinConstraints::unmapped_net(const std::string& net) const {
   return std::string(PIN_CONSTRAINT_OPEN_NET) == net;
+}
+
+bool PinConstraints::valid_net_default_value(const PinConstraintId& pin_constraint) const {
+  VTR_ASSERT(valid_pin_constraint_id(pin_constraint));
+  return PinConstraints::NUM_LOGIC_LEVELS != pin_constraint_net_default_values_[pin_constraint]; 
+}
+
+bool PinConstraints::valid_net_default_value(const std::string& net) const {
+  return PinConstraints::NUM_LOGIC_LEVELS != net_default_value(net); 
 }

--- a/libopenfpga/libpcf/src/pin_constraints.h
+++ b/libopenfpga/libpcf/src/pin_constraints.h
@@ -41,6 +41,12 @@ class PinConstraints {
     typedef vtr::vector<PinConstraintId, PinConstraintId>::const_iterator pin_constraint_iterator;
     /* Create range */
     typedef vtr::Range<pin_constraint_iterator> pin_constraint_range;
+    /* Logic value */
+    enum e_logic_level {
+      LOGIC_HIGH,
+      LOGIC_LOW,
+      NUM_LOGIC_LEVELS
+    };
   public:  /* Constructors */
     PinConstraints();
   public: /* Accessors: aggregates */
@@ -63,6 +69,21 @@ class PinConstraints {
      */
     openfpga::BasicPort net_pin(const std::string& net) const; 
 
+    /* Find the default value that a net is constrained to
+     * If not found, return an invalid value
+     */
+    e_logic_level net_default_value(const std::string& net) const; 
+
+    /* Generate the string of the default value
+     * If not found, return an empty string
+     */
+    std::string net_default_value_to_string(const PinConstraintId& pin_constraint) const; 
+
+    /* Generate the integer representation of the default value
+     * If not found, return -1
+     */
+    size_t net_default_value_to_int(const std::string& net) const;
+
     /* Check if there are any pin constraints */
     bool empty() const;
 
@@ -73,6 +94,10 @@ class PinConstraints {
     /* Add a pin constraint to storage */
     PinConstraintId create_pin_constraint(const openfpga::BasicPort& pin,
                                           const std::string& net);
+
+    /* Set the default value for the net under a given pin constraint */
+    void set_net_default_value(const PinConstraintId& pin_constraint,
+                               const std::string& default_value);
 
   public: /* Public invalidators/validators */
     /* Show if the pin constraint id is a valid for data queries */
@@ -91,6 +116,16 @@ class PinConstraints {
      * - net()
      */
     bool unmapped_net(const std::string& net) const;
+
+    /* Check if default value is a valid one or not
+     * This is to check if the default value is constrained or not 
+     */
+    bool valid_net_default_value(const PinConstraintId& pin_constraint) const;
+
+    /* Check if default value is a valid one or not
+     * This is to check if the default value is constrained or not 
+     */
+    bool valid_net_default_value(const std::string& net) const;
   private: /* Internal data */
     /* Unique ids for each design constraint */
     vtr::vector<PinConstraintId, PinConstraintId> pin_constraint_ids_;
@@ -100,6 +135,9 @@ class PinConstraints {
 
     /* Nets to constraint */
     vtr::vector<PinConstraintId, std::string> pin_constraint_nets_;
+
+    /* Default value of the nets to constraint */
+    vtr::vector<PinConstraintId, e_logic_level> pin_constraint_net_default_values_;
 };
 
 #endif

--- a/libopenfpga/libpcf/src/read_xml_pin_constraints.cpp
+++ b/libopenfpga/libpcf/src/read_xml_pin_constraints.cpp
@@ -41,6 +41,14 @@ void read_xml_pin_constraint(pugi::xml_node& xml_pin_constraint,
     archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_pin_constraint),
                    "Fail to create pin constraint!\n");
   }
+  
+  /* Set default value if defined */
+  std::string default_value = get_attribute(xml_pin_constraint, "default_value", loc_data, pugiutil::ReqOpt::OPTIONAL).as_string();
+  pin_constraints.set_net_default_value(pin_constraint_id, default_value);
+  if (!default_value.empty() && !pin_constraints.valid_net_default_value(pin_constraint_id)) {
+    archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_pin_constraint),
+                   "Invalid default value for pin constraints. Expect [0|1]!\n");
+  }
 }
 
 /********************************************************************

--- a/libopenfpga/libpcf/src/write_xml_pin_constraints.cpp
+++ b/libopenfpga/libpcf/src/write_xml_pin_constraints.cpp
@@ -44,6 +44,7 @@ int write_xml_pin_constraint(std::fstream& fp,
 
   write_xml_attribute(fp, "pin", generate_xml_port_name(pin_constraints.pin(pin_constraint)).c_str());
   write_xml_attribute(fp, "net", pin_constraints.net(pin_constraint).c_str());
+  write_xml_attribute(fp, "default_value", pin_constraints.net_default_value_to_string(pin_constraint).c_str());
 
   fp << "/>" << "\n";
 

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -213,6 +213,10 @@ void print_verilog_random_testbench_reset_stimuli(std::fstream& fp,
     if (1 == global_ports.global_port_default_value(find_fabric_global_port(global_ports, module_manager,  pin_constraints.net_pin(block_name)))) {
       initial_value = 0;
     }
+    /* Pin constraints has the final decision on the default value */
+    if (pin_constraints.valid_net_default_value(block_name)) {
+      initial_value = pin_constraints.net_default_value_to_int(block_name);
+    }
 
     fp << "initial" << std::endl;
     fp << "\tbegin" << std::endl;

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1789,11 +1789,17 @@ void print_verilog_top_testbench_reset_stimuli(std::fstream& fp,
       continue;
     }
 
+    /* Pin constraints has the final decision on the default value */
+    size_t initial_value = global_ports.global_port_default_value(find_fabric_global_port(global_ports, module_manager, pin_constraints.net_pin(block_name)));
+    if (pin_constraints.valid_net_default_value(block_name)) {
+      initial_value = pin_constraints.net_default_value_to_int(block_name);
+    }
+
     /* Connect stimuli to greset with an optional inversion, depending on the default value */
     BasicPort reset_port(block_name, 1);
     print_verilog_wire_connection(fp, reset_port,
                                   BasicPort(TOP_TB_RESET_PORT_NAME, 1),
-                                  1 == global_ports.global_port_default_value(find_fabric_global_port(global_ports, module_manager, pin_constraints.net_pin(block_name))));
+                                  1 == initial_value);
   }
 }
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->

Address issue #350 
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [X] Added a new syntax ``default_value`` to the pin constraint file, which allows users to customize the polarity of the net when generating stimuli in testbenches
- [ ] Added test cases to CI


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [X] OpenFPGA libraries
> - [X] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
