### PR TITLE
Accept absolute project paths in the 'run_fpga_task.py' script

### DIFF
--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -168,13 +168,19 @@ def generate_each_task_actions(taskname):
     # Check if task directory exists and consistent
     local_tasks = os.path.join(*(taskname))
     repo_tasks = os.path.join(gc["task_dir"], *(taskname))
+    abs_tasks = os.path.abspath('/' + local_tasks)
     if os.path.isdir(local_tasks):
         os.chdir(local_tasks)
         curr_task_dir = os.path.abspath(os.getcwd())
+    elif os.path.isdir(abs_tasks):
+        curr_task_dir = abs_tasks
     elif os.path.isdir(repo_tasks):
         curr_task_dir = repo_tasks
     else:
-        clean_up_and_exit("Task directory [%s] not found" % taskname + " locally at [%s]" % local_tasks + " or in OpenFPGA task directory [%s]" % repo_tasks)
+        clean_up_and_exit("Task directory [%s] not found" % taskname +
+                          " locally at [%s]" % local_tasks +
+                          ", absolutely at [%s]" % abs_tasks +
+                          ", or in OpenFPGA task directory [%s]" % repo_tasks)
 
     os.chdir(curr_task_dir)
 


### PR DESCRIPTION
> ### Motivation of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: #365 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [X] technical details about limitation  -->
Cannot run tasks which are specified by an absolute filesystem path.
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [X] details about the technical highlight -->
This PR adds an absolute path check for the given project directory.
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [X] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
Should be no impact.
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
