### PR TITLE
Fixed port names for mult_36x36

### DIFF
--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_40nm_openfpga.xml
@@ -210,8 +210,8 @@
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-      <port type="input" prefix="A" lib_name="A" size="36"/>
-      <port type="input" prefix="B" lib_name="B" size="36"/>
+      <port type="input" prefix="A" lib_name="a" size="36"/>
+      <port type="input" prefix="B" lib_name="b" size="36"/>
       <port type="output" prefix="Y" lib_name="out" size="72"/>
       <!-- As a fracturable multiplier, it requires 2 configuration bits to operate in 4 different modes -->
       <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
@@ -211,8 +211,8 @@
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-      <port type="input" prefix="A" lib_name="A" size="36"/>
-      <port type="input" prefix="B" lib_name="B" size="36"/>
+      <port type="input" prefix="A" lib_name="a" size="36"/>
+      <port type="input" prefix="B" lib_name="b" size="36"/>
       <port type="output" prefix="Y" lib_name="out" size="72"/>
       <!-- As a fracturable multiplier, it requires 2 configuration bits to operate in 4 different modes -->
       <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_GlobalTile8Clk_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_GlobalTile8Clk_openfpga.xml
@@ -198,9 +198,9 @@
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-      <port type="input" prefix="a" lib_name="A" size="36"/>
-      <port type="input" prefix="b" lib_name="B" size="36"/>
-      <port type="output" prefix="out" size="72"/>
+      <port type="input" prefix="a" lib_name="a" size="36"/>
+      <port type="input" prefix="b" lib_name="b" size="36"/>
+      <port type="output" prefix="out" lib_name="out" size="72"/>
       <!-- As a fracturable multiplier, it requires 2 configuration bits to operate in 4 different modes -->
       <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
     </circuit_model>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
@@ -198,9 +198,9 @@
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-      <port type="input" prefix="a" lib_name="A" size="36"/>
-      <port type="input" prefix="b" lib_name="B" size="36"/>
-      <port type="output" prefix="out" size="72"/>
+      <port type="input" prefix="a" lib_name="a" size="36"/>
+      <port type="input" prefix="b" lib_name="b" size="36"/>
+      <port type="output" prefix="out" lib_name="out" size="72"/>
       <!-- As a fracturable multiplier, it requires 2 configuration bits to operate in 4 different modes -->
       <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
     </circuit_model>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> This changes are syncing vpr_arch and openfpga_arch files in regard to mult_36x36.
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> OpenFpga architecture files which contain mult_36x36
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [x] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
