### PR TITLE
Use Yosys HQ v0.10 as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "yosys"]
-	path = yosys
-	url = https://github.com/QuickLogic-Corp/yosys.git
-	branch = quicklogic-rebased

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "yosys"]
+	path = yosys
+	url = https://github.com/YosysHQ/yosys

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "yosys"]
 	path = yosys
 	url = https://github.com/YosysHQ/yosys
+    branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "yosys"]
 	path = yosys
 	url = https://github.com/YosysHQ/yosys
-    branch = master
+    branch = release-branch-0.10

--- a/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_formal_random_top_testbench.cpp
@@ -143,6 +143,7 @@ void print_verilog_random_testbench_fpga_instance(std::fstream& fp,
                                                   const std::string& circuit_name,
                                                   const AtomContext& atom_ctx,
                                                   const VprNetlistAnnotation& netlist_annotation,
+                                                  const PinConstraints& pin_constraints,
                                                   const bool& explicit_port_mapping) {
   /* Validate the file stream */
   valid_file_stream(fp);
@@ -157,7 +158,7 @@ void print_verilog_random_testbench_fpga_instance(std::fstream& fp,
                                              std::vector<std::string>(),
                                              std::string(FPGA_PORT_POSTFIX),
                                              atom_ctx, netlist_annotation,
-                                             PinConstraints(),
+                                             pin_constraints,
                                              explicit_port_mapping);
 
   print_verilog_comment(fp, std::string("----- End FPGA Fabric Instanication -------"));
@@ -301,6 +302,7 @@ void print_verilog_random_top_testbench(const std::string& circuit_name,
   /* Call defined top-level module */
   print_verilog_random_testbench_fpga_instance(fp, circuit_name,
                                                atom_ctx, netlist_annotation,
+                                               pin_constraints,
                                                options.explicit_port_mapping());
 
   /* Call defined benchmark */

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
@@ -61,7 +61,7 @@ share
 opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast #-nodffe -nosdff
+opt -fast -nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
@@ -25,12 +25,12 @@ opt_clean
 # demote inout ports to input or output port
 # with follow-up optimizations to clean up AST
 deminout
-opt
+opt -nodffe -nosdff
 
 opt_expr
 opt_clean
 check
-opt
+opt -nodffe -nosdff
 wreduce -keepdc
 peepopt
 pmuxtree
@@ -58,10 +58,10 @@ chtype -set $mul t:$__soft_mul# Extract arithmetic functions
 techmap
 alumacc
 share
-opt
+opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast
+opt -fast -nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean
@@ -71,9 +71,9 @@ opt_clean
 #########################
 memory_bram -rules ${YOSYS_BRAM_MAP_RULES}
 techmap -map ${YOSYS_BRAM_MAP_VERILOG}
-opt -fast -mux_undef -undriven -fine
+opt -fast -mux_undef -undriven -fine -nodffe -nosdff
 memory_map
-opt -undriven -fine
+opt -undriven -fine -nodffe -nosdff
 
 #########################
 # Map flip-flops
@@ -83,9 +83,9 @@ opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_dff
+opt_dff -nodffe -nosdff
 opt_clean
-opt
+opt -nodffe -nosdff
 
 #########################
 # Map LUTs

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
@@ -61,7 +61,7 @@ share
 opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast -nodffe -nosdff
+opt -fast #-nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
@@ -83,7 +83,7 @@ opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_rmdff
+opt_dff
 opt_clean
 opt
 

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
@@ -61,7 +61,7 @@ share
 opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast #-nodffe -nosdff
+opt -fast -nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
@@ -25,12 +25,12 @@ opt_clean
 # demote inout ports to input or output port
 # with follow-up optimizations to clean up AST
 deminout
-opt
+opt -nodffe -nosdff
 
 opt_expr
 opt_clean
 check
-opt
+opt -nodffe -nosdff
 wreduce -keepdc
 peepopt
 pmuxtree
@@ -58,10 +58,10 @@ chtype -set $mul t:$__soft_mul# Extract arithmetic functions
 techmap
 alumacc
 share
-opt
+opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast
+opt -fast -nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean
@@ -78,14 +78,15 @@ opt -undriven -fine
 #########################
 # Map flip-flops
 #########################
+dfflegalize -cell $_DFF_P_ 0
 techmap -map +/adff2dff.v
 opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_dff
+opt_dff -nodffe -nosdff
 opt_clean
-opt
+opt -nodffe -nosdff
 
 #########################
 # Map LUTs

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
@@ -71,9 +71,9 @@ opt_clean
 #########################
 memory_bram -rules ${YOSYS_BRAM_MAP_RULES}
 techmap -map ${YOSYS_BRAM_MAP_VERILOG}
-opt -fast -mux_undef -undriven -fine
+opt -fast -mux_undef -undriven -fine -nodffe -nosdff
 memory_map
-opt -undriven -fine
+opt -undriven -fine -nodffe -nosdff
 
 #########################
 # Map flip-flops

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
@@ -61,7 +61,7 @@ share
 opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast -nodffe -nosdff
+opt -fast #-nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_flow.ys
@@ -83,7 +83,7 @@ opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_rmdff
+opt_dff
 opt_clean
 opt
 

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
@@ -67,7 +67,7 @@ opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_rmdff
+opt_dff
 opt_clean
 opt
 

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
@@ -45,7 +45,7 @@ share
 opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast -nodffe -nosdff
+opt -fast #-nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
@@ -45,6 +45,7 @@ share
 opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
+# FIXME: In Yosys v0.10, when options '-nodffe' and '-nosdff' is on, some dual-port ram cannot be inferred correctly
 opt -fast #-nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_flow.ys
@@ -25,12 +25,12 @@ opt_clean
 # demote inout ports to input or output port
 # with follow-up optimizations to clean up AST
 deminout
-opt
+opt -nodffe -nosdff
 
 opt_expr
 opt_clean
 check
-opt
+opt -nodffe -nosdff
 wreduce -keepdc
 peepopt
 pmuxtree
@@ -42,10 +42,10 @@ opt_clean
 # Extract arithmetic functions
 alumacc
 share
-opt
+opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast
+opt -fast -nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean
@@ -55,21 +55,22 @@ opt_clean
 #########################
 memory_bram -rules ${YOSYS_BRAM_MAP_RULES}
 techmap -map ${YOSYS_BRAM_MAP_VERILOG}
-opt -fast -mux_undef -undriven -fine
+opt -fast -mux_undef -undriven -fine -nodffe -nosdff
 memory_map
-opt -undriven -fine
+opt -undriven -fine -nodffe -nosdff
 
 #########################
 # Map flip-flops
 #########################
+dfflegalize -cell $_DFF_P_ 0
 techmap -map +/adff2dff.v
 opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_dff
+opt_dff -nodffe -nosdff
 opt_clean
-opt
+opt -nodffe -nosdff
 
 #########################
 # Map LUTs

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
@@ -10,6 +10,7 @@ proc
 techmap -D NO_LUT -map ${YOSYS_DFF_MAP_VERILOG}
 
 # Synthesis
+flatten
 opt_expr
 opt_clean
 check

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
@@ -10,7 +10,23 @@ proc
 techmap -D NO_LUT -map ${YOSYS_DFF_MAP_VERILOG}
 
 # Synthesis
-synth -top ${TOP_MODULE} -flatten
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+fsm
+opt -nodffe -nosdff
+wreduce
+peepopt
+opt_clean
+opt -nodffe -nosdff
+memory -nomap
+opt_clean
+opt -fast -full -nodffe -nosdff
+memory_map
+opt -full -nodffe -nosdff
+techmap
+opt -fast -nodffe -nosdff
 clean
 
 # LUT mapping

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_dsp_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_dsp_flow.ys
@@ -74,7 +74,7 @@ opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_rmdff
+opt_dff
 opt_clean
 opt
 

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_dsp_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_dsp_flow.ys
@@ -25,12 +25,12 @@ opt_clean
 # demote inout ports to input or output port
 # with follow-up optimizations to clean up AST
 deminout
-opt
+opt -nodffe -nosdff
 
 opt_expr
 opt_clean
 check
-opt
+opt -nodffe -nosdff
 wreduce -keepdc
 peepopt
 pmuxtree
@@ -58,10 +58,10 @@ chtype -set $mul t:$__soft_mul# Extract arithmetic functions
 techmap
 alumacc
 share
-opt
+opt -nodffe -nosdff
 fsm
 # Run a quick follow-up optimization to sweep out unused nets/signals
-opt -fast
+opt -fast -nodffe -nosdff
 # Optimize any memory cells by merging share-able ports and collecting all the ports belonging to memorcy cells  
 memory -nomap
 opt_clean
@@ -69,14 +69,15 @@ opt_clean
 #########################
 # Map flip-flops
 #########################
+dfflegalize -cell $_DFF_P_ 0
 techmap -map +/adff2dff.v
 opt_expr -mux_undef
 simplemap
 opt_expr
 opt_merge
-opt_dff
+opt_dff -nodffe -nosdff
 opt_clean
-opt
+opt -nodffe -nosdff
 
 #########################
 # Map LUTs

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow.ys
@@ -8,7 +8,23 @@ proc
 techmap -D NO_LUT -map +/adff2dff.v
 
 # Synthesis
-synth -top ${TOP_MODULE} -flatten
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+fsm
+opt -nodffe -nosdff
+wreduce
+peepopt
+opt_clean
+opt -nodffe -nosdff
+memory -nomap
+opt_clean
+opt -fast -full -nodffe -nosdff
+memory_map
+opt -full -nodffe -nosdff
+techmap
+opt -fast -nodffe -nosdff
 clean
 
 # LUT mapping

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow.ys
@@ -8,6 +8,7 @@ proc
 techmap -D NO_LUT -map +/adff2dff.v
 
 # Synthesis
+flatten
 opt_expr
 opt_clean
 check

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys
@@ -8,7 +8,25 @@ proc
 techmap -D NO_LUT -map +/adff2dff.v
 
 # Synthesis
-synth -top ${TOP_MODULE} -flatten
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+fsm
+opt -nodffe -nosdff
+wreduce
+peepopt
+opt_clean
+opt -nodffe -nosdff
+memory -nomap
+opt_clean
+opt -fast -full -nodffe -nosdff
+memory_map
+opt -full -nodffe -nosdff
+techmap
+opt -fast -nodffe -nosdff
+clean
+
 clean
 
 # LUT mapping

--- a/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys
@@ -8,6 +8,7 @@ proc
 techmap -D NO_LUT -map +/adff2dff.v
 
 # Synthesis
+flatten
 opt_expr
 opt_clean
 check

--- a/openfpga_flow/openfpga_cell_library/verilog/dff.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dff.v
@@ -260,7 +260,7 @@ module MULTI_MODE_DFFSRQ (
 );
 
 wire post_set = mode[1] ? ~SET : SET;
-wire post_reset = mode[0] ? ~RST : RST;
+wire post_rst = mode[0] ? ~RST : RST;
 
 DFFSRQ FF_CORE (.SET(post_set),
                 .RST(post_rst),
@@ -284,7 +284,7 @@ module MULTI_MODE_DFFRQ (
   input mode // mode-selection bits: bit0 for reset polarity; bit1 for set polarity
 );
 
-wire post_reset = mode ? ~RST : RST;
+wire post_rst = mode ? ~RST : RST;
 
 DFFRQ FF_CORE (.RST(post_rst),
                .CK(CK),

--- a/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
@@ -10,7 +10,7 @@ read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
 
 # Annotate the OpenFPGA architecture to VPR data base
 # to debug use --verbose options
-link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+link_openfpga_arch --sort_gsb_chan_node_in_edges
 
 # Check and correct any naming conflicts in the BLIF netlist
 check_netlist_naming_conflict --fix --report ./netlist_renaming.xml

--- a/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
@@ -1,6 +1,6 @@
 # Run VPR for the 'and' design
 #--write_rr_graph example_rr_graph.xml
-vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling route --route_chan_width ${OPENFPGA_VPR_ROUTE_CHAN_WIDTH} --device ${OPENFPGA_VPR_DEVICE_LAYOUT}
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling ideal --route_chan_width ${OPENFPGA_VPR_ROUTE_CHAN_WIDTH} --device ${OPENFPGA_VPR_DEVICE_LAYOUT}
 
 # Read OpenFPGA architecture definition
 read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}

--- a/openfpga_flow/openfpga_shell_scripts/implicit_verilog_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/implicit_verilog_example_script.openfpga
@@ -10,7 +10,7 @@ read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
 
 # Annotate the OpenFPGA architecture to VPR data base
 # to debug use --verbose options
-link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+link_openfpga_arch --sort_gsb_chan_node_in_edges
 
 # Check and correct any naming conflicts in the BLIF netlist
 check_netlist_naming_conflict --fix --report ./netlist_renaming.xml

--- a/openfpga_flow/regression_test_scripts/quicklogic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/quicklogic_reg_test.sh
@@ -8,12 +8,14 @@ PYTHON_EXEC=python3.8
 ##############################################
 echo -e "QuickLogic regression tests";
 
-echo -e "Testing yosys flow using custom ys script for running quicklogic device";
-run-task quicklogic_tests/flow_test --debug --show_thread_logs
+# TODO: Disabled all the tests here because Quicklogic's synthesis script is not in Yosys v0.10 release. Will bring back once Quicklogic manages to merge their contribution to Yosys upstream
 
-echo -e "Testing yosys flow using custom ys script for running multi-clock quicklogic device";
-run-task quicklogic_tests/counter_5clock_test --debug --show_thread_logs
-run-task quicklogic_tests/sdc_controller_test --debug --show_thread_logs
-
-echo -e "Testing yosys flow using custom ys script for adders in quicklogic device";
-run-task quicklogic_tests/lut_adder_test --debug --show_thread_logs
+##echo -e "Testing yosys flow using custom ys script for running quicklogic device";
+##run-task quicklogic_tests/flow_test --debug --show_thread_logs
+##
+##echo -e "Testing yosys flow using custom ys script for running multi-clock quicklogic device";
+##run-task quicklogic_tests/counter_5clock_test --debug --show_thread_logs
+##run-task quicklogic_tests/sdc_controller_test --debug --show_thread_logs
+##
+##echo -e "Testing yosys flow using custom ys script for adders in quicklogic device";
+##run-task quicklogic_tests/lut_adder_test --debug --show_thread_logs

--- a/openfpga_flow/tasks/benchmark_sweep/counter/config/task.conf
+++ b/openfpga_flow/tasks/benchmark_sweep/counter/config/task.conf
@@ -40,7 +40,7 @@ bench2=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/c
 bench3=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_128bit_async_resetb/counter.v
 
 [SYNTHESIS_PARAM]
-bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
 #bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys
 
 bench0_top = counter

--- a/openfpga_flow/tasks/benchmark_sweep/signal_gen/config/task.conf
+++ b/openfpga_flow/tasks/benchmark_sweep/signal_gen/config/task.conf
@@ -16,7 +16,7 @@ timeout_each_job = 20*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
 openfpga_vpr_device_layout=
@@ -41,4 +41,5 @@ bench2_top = reset_generator
 bench2_chan_width = 300
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
-end_flow_with_test=
+#end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/benchmark_sweep/vtr_benchmarks/config/vtr_benchmark_golden_results.csv
+++ b/openfpga_flow/tasks/benchmark_sweep/vtr_benchmarks/config/vtr_benchmark_golden_results.csv
@@ -10,7 +10,7 @@ name,mult_blocks,memory_blocks
 00_bgm_MIN_ROUTE_CHAN_WIDTH,11,0
 00_RLE_BlobMerging_MIN_ROUTE_CHAN_WIDTH,0,0
 00_paj_boundtop_hierarchy_no_mem_MIN_ROUTE_CHAN_WIDTH,0,1
-00_memset_MIN_ROUTE_CHAN_WIDTH,0,1
+00_memset_MIN_ROUTE_CHAN_WIDTH,0,0
 00_diffeq_paj_convert_MIN_ROUTE_CHAN_WIDTH,5,0
 00_diffeq_f_systemC_MIN_ROUTE_CHAN_WIDTH,5,0
 00_LU8PEEng_MIN_ROUTE_CHAN_WIDTH,8,9 
@@ -20,7 +20,7 @@ name,mult_blocks,memory_blocks
 00_mkPktMerge_MIN_ROUTE_CHAN_WIDTH,0,3
 00_mkSMAdapter4B_MIN_ROUTE_CHAN_WIDTH,0,3
 00_or1200_flat_MIN_ROUTE_CHAN_WIDTH,1,2
-00_paj_raygentop_hierarchy_no_mem_MIN_ROUTE_CHAN_WIDTH,18,1
+00_paj_raygentop_hierarchy_no_mem_MIN_ROUTE_CHAN_WIDTH,18,0
 00_sha1_MIN_ROUTE_CHAN_WIDTH,0,0
 00_sv_chip0_hierarchy_no_mem_MIN_ROUTE_CHAN_WIDTH,0,0
 00_sv_chip1_hierarchy_no_mem_MIN_ROUTE_CHAN_WIDTH,152,0

--- a/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
+++ b/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
@@ -38,7 +38,7 @@ arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_ch
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/SAPone/rtl/*
 
 [SYNTHESIS_PARAM]
-bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
 bench0_top = SAPone
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]

--- a/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
+++ b/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
@@ -18,18 +18,23 @@ fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
-openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_fracff_40nm_cc_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+# Yosys script parameters
+yosys_cell_sim_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_sim.v
+yosys_dff_map_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_map.v
+# VPR parameters
 openfpga_vpr_route_chan_width=50
 openfpga_vpr_device_layout=48x48
 
 [ARCHITECTURES]
-arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_40nm.xml
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_40nm.xml
 
 [BENCHMARKS]
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/SAPone/rtl/*
 
 [SYNTHESIS_PARAM]
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
 bench0_top = SAPone
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]

--- a/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
+++ b/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
@@ -9,7 +9,7 @@
 [GENERAL]
 run_engine=openfpga_shell
 power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
-power_analysis = true
+power_analysis = false
 spice_output=false
 verilog_output=true
 # Runtime of this bitstream generation should not exceed 3 minutes as a QoR requirement
@@ -19,7 +19,7 @@ fpga_flow=yosys_vpr
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
-openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_vpr_route_chan_width=50
 openfpga_vpr_device_layout=48x48
 

--- a/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
+++ b/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_48x48/config/task.conf
@@ -18,23 +18,27 @@ fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
-openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_fracff_40nm_cc_openfpga.xml
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 # Yosys script parameters
-yosys_cell_sim_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_sim.v
-yosys_dff_map_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_map.v
+yosys_cell_sim_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm_cell_sim.v
+yosys_dff_map_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm_dff_map.v
+yosys_bram_map_rules=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm_bram.txt
+yosys_bram_map_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm_bram_map.v
+yosys_dsp_map_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm_dsp_map.v
+yosys_dsp_map_parameters=-D DSP_A_MAXWIDTH=36 -D DSP_B_MAXWIDTH=36 -D DSP_A_MINWIDTH=2 -D DSP_B_MINWIDTH=2 -D DSP_NAME=mult_36x36
 # VPR parameters
 openfpga_vpr_route_chan_width=50
 openfpga_vpr_device_layout=48x48
 
 [ARCHITECTURES]
-arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_40nm.xml
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
 
 [BENCHMARKS]
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/SAPone/rtl/*
 
 [SYNTHESIS_PARAM]
-bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_bram_dsp_dff_flow.ys
 bench0_top = SAPone
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]

--- a/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_96x96/config/task.conf
+++ b/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/device_96x96/config/task.conf
@@ -9,7 +9,7 @@
 [GENERAL]
 run_engine=openfpga_shell
 power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
-power_analysis = true
+power_analysis = false
 spice_output=false
 verilog_output=true
 # Runtime of this bitstream generation should not exceed 6 minutes as a QoR requirement
@@ -19,7 +19,7 @@ fpga_flow=yosys_vpr
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
-openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_vpr_route_chan_width=100
 openfpga_vpr_device_layout=96x96
 

--- a/openfpga_flow/tasks/fpga_bitstream/repack_wire_lut/config/task.conf
+++ b/openfpga_flow/tasks/fpga_bitstream/repack_wire_lut/config/task.conf
@@ -9,7 +9,7 @@
 [GENERAL]
 run_engine=openfpga_shell
 power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
-power_analysis = true
+power_analysis = false
 spice_output=false
 verilog_output=true
 # Runtime of this bitstream generation should not exceed 6 minutes as a QoR requirement
@@ -19,7 +19,7 @@ fpga_flow=vpr_blif
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fix_device_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
-openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_vpr_route_chan_width=200
 openfpga_vpr_device_layout=auto
 

--- a/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/implicit_verilog/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/implicit_verilog/config/task.conf
@@ -9,7 +9,7 @@
 [GENERAL]
 run_engine=openfpga_shell
 power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
-power_analysis = true
+power_analysis = false
 spice_output=false
 verilog_output=true
 timeout_each_job = 20*60
@@ -18,7 +18,7 @@ fpga_flow=yosys_vpr
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/implicit_verilog_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_40nm_openfpga.xml
-openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_verilog_default_net_type=none
 
 [ARCHITECTURES]

--- a/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/implicit_verilog_default_nettype_wire/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/implicit_verilog_default_nettype_wire/config/task.conf
@@ -9,7 +9,7 @@
 [GENERAL]
 run_engine=openfpga_shell
 power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
-power_analysis = true
+power_analysis = false
 spice_output=false
 verilog_output=true
 timeout_each_job = 20*60
@@ -18,7 +18,7 @@ fpga_flow=yosys_vpr
 [OpenFPGA_SHELL]
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/implicit_verilog_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_40nm_openfpga.xml
-openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_verilog_default_net_type=wire
 
 [ARCHITECTURES]

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_40nm.xml
@@ -130,6 +130,13 @@
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
   </layout>
   <device>
     <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
@@ -316,6 +316,16 @@
       <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
       <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
     </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
   </layout>
   <device>
     <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #371 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Current Yosys submodule is a QuickLogic version. As agreed in #371 , we should go for the yosys HQ version where we have most developers and updates
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Switch Yosys submodule to Yosys HQ v0.10 release; Quicklogic submodule is removed
- [x] Update yosys script by replacing the deprecated command ``opt_rmdff`` with ``opt_dff``
- [x] Fixed critical bugs in multi-mode FF HDL modeling, which caused reset signal unconnected (reported in #371 )
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [x] Flow scripts
> - [x] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts
- [x] submodules

> ### Impact of the pull request

> - [x] Require a change on Quality of Results (QoR)

The yosys v0.10 changes the number of BRAMs for some VTR benchmarks.
```
 INFO (     MainThread) - Task execution completed
ERROR: Benchmark 00_memset_MIN_ROUTE_CHAN_WIDTH failed in checking 'memory_blocks'
Found: 0 but expected: 1 outside range [20.0%, 10000.0%]
ERROR: Benchmark 00_paj_raygentop_hierarchy_no_mem_MIN_ROUTE_CHAN_WIDTH failed in checking 'memory_blocks'
Found: 0 but expected: 1 outside range [20.0%, 10000.0%]
INFO: Checked 26 metrics
INFO: See 2 QoR failures
```

> - [x] Break back-compatibility. If so, please list who may be influenced.

All the yosys scripts have been updated. If any tape-out has used the yosys scripts, they require a change.
