### PR TITLE
re-enable counter_5clock,sdc_controller, lut_adder tests

### DIFF
--- a/openfpga_flow/regression_test_scripts/quicklogic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/quicklogic_reg_test.sh
@@ -8,14 +8,12 @@ PYTHON_EXEC=python3.8
 ##############################################
 echo -e "QuickLogic regression tests";
 
-# TODO: Disabled all the tests here because Quicklogic's synthesis script is not in Yosys v0.10 release. Will bring back once Quicklogic manages to merge their contribution to Yosys upstream
-
 echo -e "Testing yosys flow using custom ys script for running quicklogic device";
 run-task quicklogic_tests/flow_test --debug --show_thread_logs
 
-##echo -e "Testing yosys flow using custom ys script for running multi-clock quicklogic device";
-##run-task quicklogic_tests/counter_5clock_test --debug --show_thread_logs
-##run-task quicklogic_tests/sdc_controller_test --debug --show_thread_logs
-##
-##echo -e "Testing yosys flow using custom ys script for adders in quicklogic device";
-##run-task quicklogic_tests/lut_adder_test --debug --show_thread_logs
+echo -e "Testing yosys flow using custom ys script for running multi-clock quicklogic device";
+run-task quicklogic_tests/counter_5clock_test --debug --show_thread_logs
+run-task quicklogic_tests/sdc_controller_test --debug --show_thread_logs
+
+echo -e "Testing yosys flow using custom ys script for adders in quicklogic device";
+run-task quicklogic_tests/lut_adder_test --debug --show_thread_logs

--- a/openfpga_flow/tasks/quicklogic_tests/counter_5clock_test/config/task.conf
+++ b/openfpga_flow/tasks/quicklogic_tests/counter_5clock_test/config/task.conf
@@ -23,7 +23,6 @@ openfpga_repack_design_constraints_file=${PATH:OPENFPGA_PATH}/openfpga_flow/task
 openfpga_pin_constraints_file=${PATH:OPENFPGA_PATH}/openfpga_flow/tasks/quicklogic_tests/counter_5clock_test/config/pin_constraints.xml
 yosys_args = -no_adder -family qlf_k4n8 -no_ff_map
 
-
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile8Clk_40nm.xml
 

--- a/openfpga_flow/tasks/quicklogic_tests/counter_5clock_test/config/task.conf
+++ b/openfpga_flow/tasks/quicklogic_tests/counter_5clock_test/config/task.conf
@@ -23,6 +23,7 @@ openfpga_repack_design_constraints_file=${PATH:OPENFPGA_PATH}/openfpga_flow/task
 openfpga_pin_constraints_file=${PATH:OPENFPGA_PATH}/openfpga_flow/tasks/quicklogic_tests/counter_5clock_test/config/pin_constraints.xml
 yosys_args = -no_adder -family qlf_k4n8 -no_ff_map
 
+
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile8Clk_40nm.xml
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

Re-Enable remaining advanced quiicklogic regression tests: counter_5clock,sdc_controller, lut_adder tests

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->


> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
