### PR TITLE
added in CMakeList.txt to check if yosys binary already exist to avoi…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,10 @@ include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 #
 
+# we will check if yosys already exist. if not then build it
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/yosys/install/bin/yosys)
+    message(STATUS "Yosys pre-build exist so skipping it")
+else ()
 # run makefile provided, we pass-on the options to the local make file 
 add_custom_target(
     yosys ALL 
@@ -248,6 +252,7 @@ add_custom_target(
 )
 
 add_dependencies(yosys-plugins yosys)
+endif()
 
 # run make to extract compiler options, linker options and list of source files
 #add_custom_target(


### PR DESCRIPTION
…d the re-compilation of yosys

> ### Motivate of the pull request
> - [ x] To address an existing issue. If so, please provide a link to the issue: #389 #411
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ x] technical details about limitation  -->

Yosys is recompiled every time when cmake command is run

> <!-- - [x ] more limitations  -->

As currently yosys does not have CMake build process so its compilation can't be cached. To avoid the recompilation of yosys, a simple solution as now OpenFPGA support `make install` will be to check the presence of `yosys` binary, if it exist then do not compile the yosys.

> #### What does this pull request change?

> <!-- This PR improves in the following aspects: -->
> <!-- - [x ] details about the technical highlight -->

In CMakeList.txt, as yosys Makefile is called directly so a condition is added that check if there is a `yosys` binary in `bin` directory then skip the calling of the `yosys Makefile`

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts
> - [ x] Build process

