### PR TITLE
Now CI tests will cancel previous runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
       sha_short: ${{ steps.changes.outputs.sha_short }}
       docker_repo: ${{ steps.changes.outputs.docker_repo }}
     steps:
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+          
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v2
         with:
@@ -100,6 +105,11 @@ jobs:
       CCACHE_LOGFILE: ccache_log
       CCACHE_DIR: /__w/OpenFPGA/.ccache
     steps:
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+          
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v2
         with:
@@ -179,6 +189,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux_build, change_detect]
     steps:
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+          
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v2
       - name: Download a built artifacts
@@ -224,6 +239,11 @@ jobs:
           - name: vtr_benchmark_reg_test
           - name: iwls_benchmark_reg_test
     steps:
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+    
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v2
       - name: Download a built artifacts
@@ -272,6 +292,11 @@ jobs:
           - name: vtr_benchmark_reg_test
           - name: iwls_benchmark_reg_test
     steps:
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+          
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #398 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- CI will run on all the pushes in a PR. This will jam CI runners (CI runs on out-of-date commits in a PR)
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Enable cancel previous feature in CI workflow. Now CI of out-of-date commits will be cancelled automatically once a new commit is in.  
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
