### PR TITLE
New test case: DSP block with input and output registers

### DIFF
--- a/openfpga_flow/benchmarks/micro_benchmark/mult/mult_2_pipelined/mult_2_pipelined.v
+++ b/openfpga_flow/benchmarks/micro_benchmark/mult/mult_2_pipelined/mult_2_pipelined.v
@@ -1,0 +1,32 @@
+//-------------------------------------------------------
+//  Functionality: A 2-bit multiply circuit with pipelines
+//  Author:        Xifan Tang
+//-------------------------------------------------------
+
+module mult_2_pipelined(clk, a, b, out);
+parameter DATA_WIDTH = 2;  /* declare a parameter. default required */
+input [DATA_WIDTH - 1 : 0] a, b;
+input clk;
+output [DATA_WIDTH - 1 : 0] out;
+
+reg [DATA_WIDTH - 1 : 0] a_reg;
+reg [DATA_WIDTH - 1 : 0] b_reg;
+reg [DATA_WIDTH - 1 : 0] out_reg;
+
+always @(posedge clk) begin
+  a_reg <= a;
+  b_reg <= b;
+  out_reg <= a_reg * b_reg;
+  out = out_reg;
+end
+
+endmodule
+
+
+
+
+
+
+
+
+

--- a/openfpga_flow/openfpga_arch/README.md
+++ b/openfpga_flow/openfpga_arch/README.md
@@ -10,6 +10,10 @@ Note that an OpenFPGA architecture can be applied to multiple VPR architecture f
 - adder\_chain: If hard adder/carry chain is used inside CLBs
 - register\_chain: If shift register chain is used inside CLBs
 - scan\_chain: If scan chain testing infrastructure is used inside CLBs
+- <wide>\_<frac>\_dsp<dsp\_size>reg: If Digital Signal Processor (DSP) is used or not. If used, the input size should be clarified here.
+  - The keyword 'wide' is to specify if the DSP spans more than 1 column. 
+  - The keyword 'frac' is to specify if the DSP is fracturable to operate in different modes.
+  - The keyword 'reg' is to specify if the DSP has input and output registers. If only input or output registers are used, the keyword will be 'regin' or 'regout' respectively.
 - mem<mem\_size>: If block RAM (BRAM) is used or not. If used, the memory size should be clarified here. The keyword wide is to specify if the BRAM spanns more than 1 column.
 - aib: If the Advanced Interface Bus (AIB) is used in place of some I/Os.
 - <bank\|cc\|frame\|standalone>: specify the type of configuration protocol used in the architecture.

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_dsp8reg_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_dsp8reg_cc_openfpga.xml
@@ -1,0 +1,205 @@
+<!-- Architecture annotation for OpenFPGA framework
+     This annotation supports the k6_N10_40nm.xml 
+     - General purpose logic block
+       - K = 6, N = 10, I = 40
+       - Single mode
+     - Routing architecture
+       - L = 4, fc_in = 0.15, fc_out = 0.1
+  -->
+<openfpga_architecture>
+  <technology_library>
+    <device_library>
+      <device_model name="logic" type="transistor">
+        <lib type="industry" corner="TOP_TT" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="0.9" pn_ratio="2"/>
+        <pmos name="pch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+        <nmos name="nch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+      </device_model>
+      <device_model name="io" type="transistor">
+        <lib type="academia" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="2.5" pn_ratio="3"/>
+        <pmos name="pch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+        <nmos name="nch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+      </device_model>
+    </device_library>
+    <variation_library>
+      <variation name="logic_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+      <variation name="io_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+    </variation_library>
+  </technology_library>
+  <circuit_library>
+    <circuit_model type="inv_buf" name="INVTX1" prefix="INVTX1" is_default="true">
+      <design_technology type="cmos" topology="inverter" size="1"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="buf4" prefix="buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="2" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="tap_buf4" prefix="tap_buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="3" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="pass_gate" name="TGATE" prefix="TGATE" is_default="true">
+      <design_technology type="cmos" topology="transmission_gate" nmos_size="1" pmos_size="2"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="input" prefix="sel" size="1"/>
+      <port type="input" prefix="selb" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="chan_wire" name="chan_segment" prefix="track_seg" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+    </circuit_model>
+    <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+    </circuit_model>
+    <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_tree_tapbuf" prefix="mux_tree_tapbuf" is_default="true" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+       <design_technology type="cmos"/>
+       <input_buffer exist="true" circuit_model_name="INVTX1"/>
+       <output_buffer exist="true" circuit_model_name="INVTX1"/>
+       <port type="input" prefix="D" size="1"/>
+       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+       <port type="output" prefix="Q" size="1"/>
+       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+    </circuit_model>
+    <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_inverter exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_buffer exist="true" circuit_model_name="buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="4"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="16"/>
+    </circuit_model>
+    <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+       <design_technology type="cmos"/>
+       <input_buffer exist="true" circuit_model_name="INVTX1"/>
+       <output_buffer exist="true" circuit_model_name="INVTX1"/>
+       <port type="input" prefix="D" size="1"/>
+       <port type="output" prefix="Q" size="1"/>
+       <port type="output" prefix="QN" size="1"/>
+       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true" is_data_io="true"/>
+      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="DFF" default_val="1"/>
+      <port type="input" prefix="outpad" lib_name="A" size="1"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
+    <circuit_model type="hard_logic" name="mult_8x8" prefix="mult_8x8" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/mult_8x8.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/mult_8x8.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="A" lib_name="A" size="8"/>
+      <port type="input" prefix="B" lib_name="B" size="8"/>
+      <port type="output" prefix="Y" lib_name="Y" size="16"/>
+    </circuit_model>
+  </circuit_library>
+  <configuration_protocol>
+    <organization type="scan_chain" circuit_model_name="DFF"/>
+  </configuration_protocol>
+  <connection_block>
+    <switch name="ipin_cblock" circuit_model_name="mux_tree_tapbuf"/>
+  </connection_block>
+  <switch_block>
+    <switch name="0" circuit_model_name="mux_tree_tapbuf"/>
+  </switch_block>
+  <routing_segment>
+    <segment name="L4" circuit_model_name="chan_segment"/>
+  </routing_segment>
+  <pb_type_annotations>
+    <!-- physical pb_type binding in complex block IO -->
+    <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <!-- End physical pb_type binding in complex block IO -->
+
+    <!-- physical pb_type binding in complex block CLB -->
+    <!-- physical mode will be the default mode if not specified -->
+    <pb_type name="clb">
+      <!-- Binding interconnect to circuit models as their physical implementation, if not defined, we use the default model -->
+      <interconnect name="crossbar" circuit_model_name="mux_tree"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.lut4" circuit_model_name="lut4"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff" circuit_model_name="DFFSRQ"/>
+    <!-- End physical pb_type binding in complex block IO -->
+
+    <!-- physical pb_type binding in complex block dsp -->
+    <pb_type name="mult_8" physical_mode_name="mult_8x8" idle_mode_name="mult_8x8"/>
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <pb_type name="mult_8[mult_8x8].mult_8x8_slice.mult_8x8" circuit_model_name="mult_8x8"/>
+    <pb_type name="mult_8[mult_8x8].mult_8x8_slice.ff_A" circuit_model_name="DFFSRQ"/>
+    <pb_type name="mult_8[mult_8x8].mult_8x8_slice.ff_B" circuit_model_name="DFFSRQ"/>
+    <pb_type name="mult_8[mult_8x8].mult_8x8_slice.ff_Y" circuit_model_name="DFFSRQ"/>
+  </pb_type_annotations>
+</openfpga_architecture>

--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -53,6 +53,9 @@ run-task fpga_verilog/dsp/multi_mode_mult_16x16 --debug --show_thread_logs
 echo -e "Testing Verilog generation with heterogeneous fabric using multi-width 16-bit multi-mode multipliers ";
 run-task fpga_verilog/dsp/wide_multi_mode_mult_16x16 --debug --show_thread_logs
 
+echo -e "Testing Verilog generation with heterogeneous fabric using 8-bit single-mode registerable multipliers ";
+run-task fpga_verilog/dsp/single_mode_mult_8x8_reg --debug --show_thread_logs
+
 echo -e "Testing Verilog generation with different I/O capacities on each side of an FPGA ";
 run-task fpga_verilog/io/multi_io_capacity --debug --show_thread_logs
 

--- a/openfpga_flow/tasks/fpga_verilog/dsp/single_mode_mult_8x8_reg/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/dsp/single_mode_mult_8x8_reg/config/task.conf
@@ -1,0 +1,43 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_heterogeneous_device_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_dsp8reg_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+# Yosys script parameters
+yosys_cell_sim_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k4_frac_N8_tileable_reset_softadder_register_scan_chain_dsp8_nonLR_caravel_io_skywater130nm_cell_sim.v
+yosys_dsp_map_verilog=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k4_frac_N8_tileable_reset_softadder_register_scan_chain_dsp8_nonLR_caravel_io_skywater130nm_dsp_map.v
+yosys_dsp_map_parameters=-D DSP_A_MAXWIDTH=8 -D DSP_B_MAXWIDTH=8 -D DSP_A_MINWIDTH=2 -D DSP_B_MINWIDTH=2 -D DSP_NAME=mult_8x8
+# VPR parameter
+openfpga_vpr_device_layout=3x2
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_2_pipelined/mac_2_pipelined.v
+
+[SYNTHESIS_PARAM]
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dsp_flow.ys
+bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys
+
+bench0_top = mac_2_pipelined
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/fpga_verilog/dsp/single_mode_mult_8x8_reg/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/dsp/single_mode_mult_8x8_reg/config/task.conf
@@ -30,13 +30,13 @@ openfpga_vpr_device_layout=3x2
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
 
 [BENCHMARKS]
-bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_2_pipelined/mac_2_pipelined.v
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mult/mult_2_pipelined/mult_2_pipelined.v
 
 [SYNTHESIS_PARAM]
 bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dsp_flow.ys
 bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys
 
-bench0_top = mac_2_pipelined
+bench0_top = mult_2_pipelined
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
 end_flow_with_test=

--- a/openfpga_flow/vpr_arch/README.md
+++ b/openfpga_flow/vpr_arch/README.md
@@ -16,6 +16,7 @@ Please reveal the following architecture features in the names to help quickly s
   - The keyword 'wide' is to specify if the DSP spans more than 1 column. 
   - The keyword 'frac' is to specify if the DSP is fracturable to operate in different modes.
   - The keyword 'reg' is to specify if the DSP has input and output registers. If only input or output registers are used, the keyword will be 'regin' or 'regout' respectively.
+- mem<mem\_size>: If block RAM (BRAM) is used or not. If used, the memory size should be clarified here. The keyword wide is to specify if the BRAM spanns more than 1 column.
 - aib: If the Advanced Interface Bus (AIB) is used in place of some I/Os.
 - multi\_io\_capacity: If I/O capacity is different on each side of FPGAs.
 - reduced\_io: If I/Os only appear a certain or multiple sides of FPGAs 

--- a/openfpga_flow/vpr_arch/README.md
+++ b/openfpga_flow/vpr_arch/README.md
@@ -12,7 +12,10 @@ Please reveal the following architecture features in the names to help quickly s
 - register\_chain: If shift register chain is used inside CLBs
 - scan\_chain: If scan chain testing infrastructure is used inside CLBs
 - <wide>\_<frac>\_mem<mem\_size>: If block RAM (BRAM) is used or not. If used, the memory size should be clarified here. The keyword 'wide' is to specify if the BRAM spans more than 1 column. The keyword 'frac' is to specify if the BRAM is fracturable to operate in different modes.
-- <wide>\_<frac>\_dsp<dsp\_size>: If Digital Signal Processor (DSP) is used or not. If used, the input size should be clarified here. The keyword 'wide' is to specify if the DSP spans more than 1 column. The keyword 'frac' is to specify if the DSP is fracturable to operate in different modes.
+- <wide>\_<frac>\_dsp<dsp\_size>reg: If Digital Signal Processor (DSP) is used or not. If used, the input size should be clarified here.
+  - The keyword 'wide' is to specify if the DSP spans more than 1 column. 
+  - The keyword 'frac' is to specify if the DSP is fracturable to operate in different modes.
+  - The keyword 'reg' is to specify if the DSP has input and output registers. If only input or output registers are used, the keyword will be 'regin' or 'regout' respectively.
 - aib: If the Advanced Interface Bus (AIB) is used in place of some I/Os.
 - multi\_io\_capacity: If I/O capacity is different on each side of FPGAs.
 - reduced\_io: If I/Os only appear a certain or multiple sides of FPGAs 

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
@@ -376,9 +376,11 @@
             </direct>
             <mux name="b2b" input="mult_8x8_slice.B_cfg ff_b.Q" output="mult_8x8.B">
             </mux>
-            <direct name="a2ff" input="mult_8x8_slice.B_cfg" output="ff_B.D">
+            <direct name="b2ff" input="mult_8x8_slice.B_cfg" output="ff_B.D">
             </direct>
-            <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
+            <mux name="out2out" input="mult_8x8.Y ff_Y.Q" output="mult_8x8_slice.OUT_cfg">
+            </mux>
+            <direct name="out2ff" input="mult_8x8.Y" output="ff_Y.D">
             </direct>
             <complete name="clk_ff_A" input="mult_8x8.clk" output="ff_A.clk"/>
             <complete name="clk_ff_B" input="mult_8x8.clk" output="ff_B.clk"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
@@ -348,21 +348,21 @@
             <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
             <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
           </pb_type>
-          <pb_type name="ff_A" blif_model=".latch" num_pb="1" class="flipflop">
+          <pb_type name="ff_A" blif_model=".latch" num_pb="8" class="flipflop">
             <input name="D" num_pins="1" port_class="D"/>
             <output name="Q" num_pins="1" port_class="Q"/>
             <clock name="clk" num_pins="1" port_class="clock"/>
             <T_setup value="66e-12" port="ff_A.D" clock="clk"/>
             <T_clock_to_Q max="124e-12" port="ff_A.Q" clock="clk"/>
           </pb_type>
-          <pb_type name="ff_B" blif_model=".latch" num_pb="1" class="flipflop">
+          <pb_type name="ff_B" blif_model=".latch" num_pb="8" class="flipflop">
             <input name="D" num_pins="1" port_class="D"/>
             <output name="Q" num_pins="1" port_class="Q"/>
             <clock name="clk" num_pins="1" port_class="clock"/>
             <T_setup value="66e-12" port="ff_B.D" clock="clk"/>
             <T_clock_to_Q max="124e-12" port="ff_B.Q" clock="clk"/>
           </pb_type>
-          <pb_type name="ff_Y" blif_model=".latch" num_pb="1" class="flipflop">
+          <pb_type name="ff_Y" blif_model=".latch" num_pb="16" class="flipflop">
             <input name="D" num_pins="1" port_class="D"/>
             <output name="Q" num_pins="1" port_class="Q"/>
             <clock name="clk" num_pins="1" port_class="clock"/>
@@ -370,21 +370,44 @@
             <T_clock_to_Q max="124e-12" port="ff_Y.Q" clock="clk"/>
           </pb_type>
           <interconnect>
-            <mux name="a2a" input="mult_8x8_slice.A_cfg ff_A.Q" output="mult_8x8.A">
-            </mux>
-            <direct name="a2ff" input="mult_8x8_slice.A_cfg" output="ff_A.D">
-            </direct>
-            <mux name="b2b" input="mult_8x8_slice.B_cfg ff_b.Q" output="mult_8x8.B">
-            </mux>
-            <direct name="b2ff" input="mult_8x8_slice.B_cfg" output="ff_B.D">
-            </direct>
-            <mux name="out2out" input="mult_8x8.Y ff_Y.Q" output="mult_8x8_slice.OUT_cfg">
-            </mux>
-            <direct name="out2ff" input="mult_8x8.Y" output="ff_Y.D">
-            </direct>
-            <complete name="clk_ff_A" input="mult_8x8.clk" output="ff_A.clk"/>
-            <complete name="clk_ff_B" input="mult_8x8.clk" output="ff_B.clk"/>
-            <complete name="clk_ff_Y" input="mult_8x8.clk" output="ff_Y.clk"/>
+            <mux name="a2a0" input="mult_8x8_slice.A_cfg[0] ff_A[0].Q" output="mult_8x8.A[0]"/>
+            <mux name="a2a1" input="mult_8x8_slice.A_cfg[1] ff_A[1].Q" output="mult_8x8.A[1]"/>
+            <mux name="a2a2" input="mult_8x8_slice.A_cfg[2] ff_A[2].Q" output="mult_8x8.A[2]"/>
+            <mux name="a2a3" input="mult_8x8_slice.A_cfg[3] ff_A[3].Q" output="mult_8x8.A[3]"/>
+            <mux name="a2a4" input="mult_8x8_slice.A_cfg[4] ff_A[4].Q" output="mult_8x8.A[4]"/>
+            <mux name="a2a5" input="mult_8x8_slice.A_cfg[5] ff_A[5].Q" output="mult_8x8.A[5]"/>
+            <mux name="a2a6" input="mult_8x8_slice.A_cfg[6] ff_A[6].Q" output="mult_8x8.A[6]"/>
+            <mux name="a2a7" input="mult_8x8_slice.A_cfg[7] ff_A[7].Q" output="mult_8x8.A[7]"/>
+            <direct name="a2ff" input="mult_8x8_slice.A_cfg[7:0]" output="ff_A[7:0].D"/>
+            <mux name="b2b0" input="mult_8x8_slice.B_cfg[0] ff_B[0].Q" output="mult_8x8.B[0]"/>
+            <mux name="b2b1" input="mult_8x8_slice.B_cfg[1] ff_B[1].Q" output="mult_8x8.B[1]"/>
+            <mux name="b2b2" input="mult_8x8_slice.B_cfg[2] ff_B[2].Q" output="mult_8x8.B[2]"/>
+            <mux name="b2b3" input="mult_8x8_slice.B_cfg[3] ff_B[3].Q" output="mult_8x8.B[3]"/>
+            <mux name="b2b4" input="mult_8x8_slice.B_cfg[4] ff_B[4].Q" output="mult_8x8.B[4]"/>
+            <mux name="b2b5" input="mult_8x8_slice.B_cfg[5] ff_B[5].Q" output="mult_8x8.B[5]"/>
+            <mux name="b2b6" input="mult_8x8_slice.B_cfg[6] ff_B[6].Q" output="mult_8x8.B[6]"/>
+            <mux name="b2b7" input="mult_8x8_slice.B_cfg[7] ff_B[7].Q" output="mult_8x8.B[7]"/>
+            <direct name="b2ff" input="mult_8x8_slice.B_cfg[7:0]" output="ff_B[7:0].D"/>
+            <mux name="out2out0" input="mult_8x8.Y[0] ff_Y[0].Q" output="mult_8x8_slice.OUT_cfg[0]"/>
+            <mux name="out2out1" input="mult_8x8.Y[1] ff_Y[1].Q" output="mult_8x8_slice.OUT_cfg[1]"/>
+            <mux name="out2out2" input="mult_8x8.Y[2] ff_Y[2].Q" output="mult_8x8_slice.OUT_cfg[2]"/>
+            <mux name="out2out3" input="mult_8x8.Y[3] ff_Y[3].Q" output="mult_8x8_slice.OUT_cfg[3]"/>
+            <mux name="out2out4" input="mult_8x8.Y[4] ff_Y[4].Q" output="mult_8x8_slice.OUT_cfg[4]"/>
+            <mux name="out2out5" input="mult_8x8.Y[5] ff_Y[5].Q" output="mult_8x8_slice.OUT_cfg[5]"/>
+            <mux name="out2out6" input="mult_8x8.Y[6] ff_Y[6].Q" output="mult_8x8_slice.OUT_cfg[6]"/>
+            <mux name="out2out7" input="mult_8x8.Y[7] ff_Y[7].Q" output="mult_8x8_slice.OUT_cfg[7]"/>
+            <mux name="out2out8" input="mult_8x8.Y[8] ff_Y[8].Q" output="mult_8x8_slice.OUT_cfg[8]"/>
+            <mux name="out2out9" input="mult_8x8.Y[9] ff_Y[9].Q" output="mult_8x8_slice.OUT_cfg[9]"/>
+            <mux name="out2out10" input="mult_8x8.Y[10] ff_Y[10].Q" output="mult_8x8_slice.OUT_cfg[10]"/>
+            <mux name="out2out11" input="mult_8x8.Y[11] ff_Y[11].Q" output="mult_8x8_slice.OUT_cfg[11]"/>
+            <mux name="out2out12" input="mult_8x8.Y[12] ff_Y[12].Q" output="mult_8x8_slice.OUT_cfg[12]"/>
+            <mux name="out2out13" input="mult_8x8.Y[13] ff_Y[13].Q" output="mult_8x8_slice.OUT_cfg[13]"/>
+            <mux name="out2out14" input="mult_8x8.Y[14] ff_Y[14].Q" output="mult_8x8_slice.OUT_cfg[14]"/>
+            <mux name="out2out15" input="mult_8x8.Y[15] ff_Y[15].Q" output="mult_8x8_slice.OUT_cfg[15]"/>
+            <direct name="out2ff" input="mult_8x8.Y[15:0]" output="ff_Y[15:0].D"/>
+            <complete name="clk_ff_A" input="mult_8x8_slice.clk" output="ff_A.clk"/>
+            <complete name="clk_ff_B" input="mult_8x8_slice.clk" output="ff_B.clk"/>
+            <complete name="clk_ff_Y" input="mult_8x8_slice.clk" output="ff_Y.clk"/>
           </interconnect>
           <power method="pin-toggle">
             <port name="A_cfg" energy_per_toggle="2.13e-12"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
@@ -83,8 +83,8 @@
       <!--  Highly recommand to customize pin location when direct connection is used!!! -->
       <!-- pinlocations are designed to spread pin on 4 sides evenly -->
       <pinlocations pattern="custom">
-        <loc side="left">mult_8.a[0:3] mult_8.a[0:3] mult_8.out[0:7]</loc>
-        <loc side="top"></loc>
+        <loc side="left">mult_8.a[0:3] mult_8.b[0:3] mult_8.out[0:7]</loc>
+        <loc side="top">mult_8.clk</loc>
         <loc side="right">mult_8.a[4:7] mult_8.b[4:7] mult_8.out[8:15]</loc>
         <loc side="bottom"></loc>
       </pinlocations>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
@@ -342,9 +342,9 @@
           <output name="OUT_cfg" num_pins="16"/>
           <clock name="clk" num_pins="1"/>
           <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">
-            <input name="A" num_pins="36"/>
-            <input name="B" num_pins="36"/>
-            <output name="Y" num_pins="72"/>
+            <input name="A" num_pins="8"/>
+            <input name="B" num_pins="8"/>
+            <output name="Y" num_pins="16"/>
             <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
             <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
           </pb_type>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
@@ -1,0 +1,417 @@
+<!-- 
+  Architecture with no fracturable LUTs
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 4, N = 4
+  - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
+  - DSP block
+    - 8-bit multiplier
+    - input and output registers
+
+  Details on Modelling:
+
+  Based on flagship k6_frac_N10_mem32K_40nm.xml architecture.  This architecture has no fracturable LUTs nor any heterogeneous blocks.
+
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="mult_8">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" capacity="8" area="0">
+      <equivalent_sites>
+        <site pb_type="io"/>
+      </equivalent_sites>
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="custom">
+        <loc side="left">io.outpad io.inpad</loc>
+        <loc side="top">io.outpad io.inpad</loc>
+        <loc side="right">io.outpad io.inpad</loc>
+        <loc side="bottom">io.outpad io.inpad</loc>
+      </pinlocations>
+    </tile>
+    <tile name="clb" area="53894">
+      <equivalent_sites>
+        <site pb_type="clb"/>
+      </equivalent_sites>
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="spread"/>
+    </tile>
+    <tile name="mult_8" height="2" area="396000">
+      <equivalent_sites>
+        <site pb_type="mult_8" pin_mapping="direct"/>
+      </equivalent_sites>
+      <input name="a" num_pins="8"/>
+      <input name="b" num_pins="8"/>
+      <output name="out" num_pins="16"/>
+      <clock name="clk" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+      <!-- pinlocations are designed to spread pin on 4 sides evenly -->
+      <pinlocations pattern="custom">
+        <loc side="left">mult_8.a[0:3] mult_8.a[0:3] mult_8.out[0:7]</loc>
+        <loc side="top"></loc>
+        <loc side="right">mult_8.a[4:7] mult_8.b[4:7] mult_8.out[8:15]</loc>
+        <loc side="bottom"></loc>
+      </pinlocations>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	       book area formula. This means the mux transistors are about 5x minimum drive strength.
+	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+	       2.5x when looking up in Jeff's tables.
+	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
+             Each basic logic element has a 4-LUT that can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                261e-12
+                261e-12
+                261e-12
+                261e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+		     The delays below come from Stratix IV. the delay through a connection block
+		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+		     delay within the crossbar is 95 ps. 
+		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+               naive specification).
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define 8-bit multiplier with input and output registers begin -->
+    <pb_type name="mult_8">
+      <input name="a" num_pins="8"/>
+      <input name="b" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <output name="out" num_pins="16"/>
+      <mode name="mult_8x8">
+        <pb_type name="mult_8x8_slice" num_pb="1">
+          <input name="A_cfg" num_pins="8"/>
+          <input name="B_cfg" num_pins="8"/>
+          <output name="OUT_cfg" num_pins="16"/>
+          <clock name="clk" num_pins="1"/>
+          <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">
+            <input name="A" num_pins="36"/>
+            <input name="B" num_pins="36"/>
+            <output name="Y" num_pins="72"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
+          </pb_type>
+          <pb_type name="ff_A" blif_model=".latch" num_pb="1" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff_A.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_A.Q" clock="clk"/>
+          </pb_type>
+          <pb_type name="ff_B" blif_model=".latch" num_pb="1" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff_B.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_B.Q" clock="clk"/>
+          </pb_type>
+          <pb_type name="ff_Y" blif_model=".latch" num_pb="1" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff_Y.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_Y.Q" clock="clk"/>
+          </pb_type>
+          <interconnect>
+            <mux name="a2a" input="mult_8x8_slice.A_cfg ff_A.Q" output="mult_8x8.A">
+            </mux>
+            <direct name="a2ff" input="mult_8x8_slice.A_cfg" output="ff_A.D">
+            </direct>
+            <mux name="b2b" input="mult_8x8_slice.B_cfg ff_b.Q" output="mult_8x8.B">
+            </mux>
+            <direct name="a2ff" input="mult_8x8_slice.B_cfg" output="ff_B.D">
+            </direct>
+            <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
+            </direct>
+            <complete name="clk_ff_A" input="mult_8x8.clk" output="ff_A.clk">
+            <complete name="clk_ff_B" input="mult_8x8.clk" output="ff_B.clk">
+            <complete name="clk_ff_Y" input="mult_8x8.clk" output="ff_Y.clk">
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
+		   to a 134 ps delay.
+				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
+              -->
+          <direct name="a2a" input="mult_8.a" output="mult_8x8_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_8.a" out_port="mult_8x8_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_8.b" output="mult_8x8_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_8.b" out_port="mult_8x8_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_8x8_slice.OUT_cfg" output="mult_8.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice.OUT_cfg" out_port="mult_8.out"/>
+          </direct>
+          <complete name="clk" input="mult_8.clk" output="mult_8x8_slice.clk">
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+
+  </complexblocklist>
+</architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
@@ -380,9 +380,9 @@
             </direct>
             <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
             </direct>
-            <complete name="clk_ff_A" input="mult_8x8.clk" output="ff_A.clk">
-            <complete name="clk_ff_B" input="mult_8x8.clk" output="ff_B.clk">
-            <complete name="clk_ff_Y" input="mult_8x8.clk" output="ff_Y.clk">
+            <complete name="clk_ff_A" input="mult_8x8.clk" output="ff_A.clk"/>
+            <complete name="clk_ff_B" input="mult_8x8.clk" output="ff_B.clk"/>
+            <complete name="clk_ff_Y" input="mult_8x8.clk" output="ff_Y.clk"/>
           </interconnect>
           <power method="pin-toggle">
             <port name="A_cfg" energy_per_toggle="2.13e-12"/>
@@ -405,7 +405,7 @@
           <direct name="out2out" input="mult_8x8_slice.OUT_cfg" output="mult_8.out">
             <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice.OUT_cfg" out_port="mult_8.out"/>
           </direct>
-          <complete name="clk" input="mult_8.clk" output="mult_8x8_slice.clk">
+          <complete name="clk" input="mult_8.clk" output="mult_8x8_slice.clk"/>
         </interconnect>
       </mode>
       <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- DSP blocks are too simple, which only contain multipliers.
- Modern DSP blocks contain input and output registers to properly pipeline datapath.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Added new VPR and OpenFPGA architecture XML examples to show how to design DSP blocks with input and output registers
- [x] Added a new benchmark: mult_2_pipelined, which are designed to test the DSP blocks
- [x] Added a new test case to validate the correctness of the architecture & benchmarks (deployed to CI)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [x] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
