### PR TITLE
Patch the errors in basic regression tests due to ``--no_time_stamp`` support

### DIFF
--- a/libopenfpga/libfpgabitstream/src/report_arch_bitstream_distribution.cpp
+++ b/libopenfpga/libfpgabitstream/src/report_arch_bitstream_distribution.cpp
@@ -33,11 +33,12 @@ void report_architecture_bitstream_distribution_xml_file_head(std::fstream& fp,
  
   fp << "<!-- " << std::endl;
   fp << "\t- Report Architecture Bitstream Distribution" << std::endl;
-  fp << "\t- Version: " << openfpga::VERSION << std::endl;
 
   if (include_time_stamp) {
     auto end = std::chrono::system_clock::now(); 
     std::time_t end_time = std::chrono::system_clock::to_time_t(end);
+    /* Note that version is also a type of time stamp */
+    fp << "\t- Version: " << openfpga::VERSION << std::endl;
     fp << "\t- Date: " << std::ctime(&end_time) ;
   }
 

--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -35,11 +35,12 @@ void write_fabric_bitstream_text_file_head(std::fstream& fp,
   valid_file_stream(fp);
  
   fp << "// Fabric bitstream" << std::endl;
-  fp << "// Version: " << openfpga::VERSION << std::endl;
 
   if (include_time_stamp) {
     auto end = std::chrono::system_clock::now(); 
     std::time_t end_time = std::chrono::system_clock::to_time_t(end);
+    /* Note that version is also a type of time stamp */
+    fp << "// Version: " << openfpga::VERSION << std::endl;
     fp << "// Date: " << std::ctime(&end_time);
   }
 }

--- a/openfpga/src/fpga_bitstream/write_xml_io_mapping.cpp
+++ b/openfpga/src/fpga_bitstream/write_xml_io_mapping.cpp
@@ -35,11 +35,12 @@ void write_io_mapping_xml_file_head(std::fstream& fp,
  
   fp << "<!--" << std::endl;
   fp << "\t- I/O mapping" << std::endl;
-  fp << "\t- Version: " << openfpga::VERSION << std::endl;
 
   if (include_time_stamp) {
     auto end = std::chrono::system_clock::now(); 
     std::time_t end_time = std::chrono::system_clock::to_time_t(end);
+    /* Note that version is also a type of time stamp */
+    fp << "\t- Version: " << openfpga::VERSION << std::endl;
     fp << "\t- Date: " << std::ctime(&end_time) ;
   }
 

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -148,7 +148,7 @@ run-task basic_tests/explicit_multi_verilog_files --debug --show_thread_logs
 echo -e "Testing output files without time stamp";
 run-task basic_tests/no_time_stamp --debug --show_thread_logs
 # Run git-diff to ensure no changes on the golden netlists
-if git diff origin/main HEAD --name-status -- ':openfpga_flow/tasks/basic_tests/no_time_stamp/golden_output_no_time_stamp/**'; then
+if git diff origin/master HEAD --name-status -- ':openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/**'; then
   echo -e "Golden netlist remain unchanged"
 else
   echo -e "Detect changes in golden scripts"; exit 1;

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -148,7 +148,7 @@ run-task basic_tests/explicit_multi_verilog_files --debug --show_thread_logs
 echo -e "Testing output files without time stamp";
 run-task basic_tests/no_time_stamp --debug --show_thread_logs
 # Run git-diff to ensure no changes on the golden netlists
-if git diff origin/master HEAD --name-status -- ':openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/**'; then
+if git diff --name-status -- ':openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/**'; then
   echo -e "Golden netlist remain unchanged"
 else
   echo -e "Detect changes in golden scripts"; exit 1;

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/bitstream_distribution.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/bitstream_distribution.xml
@@ -1,6 +1,6 @@
 <!-- 
 	- Report Architecture Bitstream Distribution
-	- Version: 1.0.3764-dev+dd400579-dirty
+	- Version: 1.0.3764-dev+4a89d175
 --> 
 
 <block name="fpga_top" number_of_bits="527">

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/bitstream_distribution.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/bitstream_distribution.xml
@@ -1,6 +1,5 @@
 <!-- 
 	- Report Architecture Bitstream Distribution
-	- Version: 1.0.3764-dev+4a89d175
 --> 
 
 <block name="fpga_top" number_of_bits="527">

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/fabric_bitstream.bit
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/fabric_bitstream.bit
@@ -1,5 +1,4 @@
 // Fabric bitstream
-// Version: 1.0.3764-dev+4a89d175
 // Bitstream length: 527
 // Bitstream width (LSB -> MSB): 1
 1

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/fabric_bitstream.bit
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/fabric_bitstream.bit
@@ -1,5 +1,5 @@
 // Fabric bitstream
-// Version: 1.0.3764-dev+dd400579-dirty
+// Version: 1.0.3764-dev+4a89d175
 // Bitstream length: 527
 // Bitstream width (LSB -> MSB): 1
 1

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/pin_mapping.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/pin_mapping.xml
@@ -1,6 +1,6 @@
 <!--
 	- I/O mapping
-	- Version: 1.0.3764-dev+dd400579-dirty
+	- Version: 1.0.3764-dev+4a89d175
 -->
 
 <io_mapping>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/pin_mapping.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/golden_outputs_no_time_stamp/pin_mapping.xml
@@ -1,6 +1,5 @@
 <!--
 	- I/O mapping
-	- Version: 1.0.3764-dev+4a89d175
 -->
 
 <io_mapping>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #499 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->
This is a follow-up PR to fix the errors in basic regression tests due to ``--no_time_stamp`` support

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
