### PR TITLE
[FPGA-Verilog] Now have a new option ``--use_relative_path``

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
@@ -23,6 +23,10 @@ write_fabric_verilog
   .. option:: --include_timing
 
     Output timing information to Verilog netlists for primitive modules
+
+  .. option:: --use_relative_path
+
+    Force to use relative path in netlists when including other netlists. By default, this is off, which means that netlists use absolute paths when including other netlists
  
   .. option:: --print_user_defined_template
 

--- a/openfpga/src/base/openfpga_verilog.cpp
+++ b/openfpga/src/base/openfpga_verilog.cpp
@@ -35,6 +35,7 @@ int write_fabric_verilog(OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_print_user_defined_template = cmd.option("print_user_defined_template");
   CommandOptionId opt_default_net_type = cmd.option("default_net_type");
   CommandOptionId opt_no_time_stamp = cmd.option("no_time_stamp");
+  CommandOptionId opt_use_relative_path = cmd.option("use_relative_path");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
   /* This is an intermediate data structure which is designed to modularize the FPGA-Verilog
@@ -45,6 +46,7 @@ int write_fabric_verilog(OpenfpgaContext& openfpga_ctx,
   options.set_explicit_port_mapping(cmd_context.option_enable(cmd, opt_explicit_port_mapping));
   options.set_include_timing(cmd_context.option_enable(cmd, opt_include_timing));
   options.set_time_stamp(!cmd_context.option_enable(cmd, opt_no_time_stamp));
+  options.set_use_relative_path(cmd_context.option_enable(cmd, opt_use_relative_path));
   options.set_print_user_defined_template(cmd_context.option_enable(cmd, opt_print_user_defined_template));
   if (true == cmd_context.option_enable(cmd, opt_default_net_type)) {
     options.set_default_net_type(cmd_context.option_value(cmd, opt_default_net_type));

--- a/openfpga/src/base/openfpga_verilog_command.cpp
+++ b/openfpga/src/base/openfpga_verilog_command.cpp
@@ -43,6 +43,9 @@ ShellCommandId add_openfpga_write_fabric_verilog_command(openfpga::Shell<Openfpg
   /* Add an option '--no_time_stamp' */
   shell_cmd.add_option("no_time_stamp", false, "Do not print a time stamp in the output files");
 
+  /* Add an option '--use_relative_path' */
+  shell_cmd.add_option("use_relative_path", false, "Force to use relative path in netlists when including other netlists");
+
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Enable verbose output");
   

--- a/openfpga/src/fpga_verilog/fabric_verilog_options.cpp
+++ b/openfpga/src/fpga_verilog/fabric_verilog_options.cpp
@@ -20,6 +20,7 @@ FabricVerilogOption::FabricVerilogOption() {
   print_user_defined_template_ = false;
   default_net_type_ = VERILOG_DEFAULT_NET_TYPE_NONE;
   time_stamp_ = true;
+  use_relative_path_ = false;
   verbose_output_ = false;
 }
 
@@ -36,6 +37,10 @@ bool FabricVerilogOption::include_timing() const {
 
 bool FabricVerilogOption::time_stamp() const {
   return time_stamp_;
+}
+
+bool FabricVerilogOption::use_relative_path() const {
+  return use_relative_path_;
 }
 
 bool FabricVerilogOption::explicit_port_mapping() const {
@@ -67,6 +72,10 @@ void FabricVerilogOption::set_output_directory(const std::string& output_dir) {
 
 void FabricVerilogOption::set_include_timing(const bool& enabled) {
   include_timing_ = enabled;
+}
+
+void FabricVerilogOption::set_use_relative_path(const bool& enabled) {
+  use_relative_path_ = enabled;
 }
 
 void FabricVerilogOption::set_time_stamp(const bool& enabled) {

--- a/openfpga/src/fpga_verilog/fabric_verilog_options.h
+++ b/openfpga/src/fpga_verilog/fabric_verilog_options.h
@@ -20,6 +20,7 @@ class FabricVerilogOption {
   public: /* Public accessors */
     std::string output_directory() const;
     bool time_stamp() const;
+    bool use_relative_path() const;
     bool include_timing() const;
     bool explicit_port_mapping() const;
     bool compress_routing() const;
@@ -28,6 +29,7 @@ class FabricVerilogOption {
     bool verbose_output() const;
   public: /* Public mutators */
     void set_output_directory(const std::string& output_dir);
+    void set_use_relative_path(const bool& enabled);
     void set_time_stamp(const bool& enabled);
     void set_include_timing(const bool& enabled);
     void set_explicit_port_mapping(const bool& enabled);
@@ -43,6 +45,7 @@ class FabricVerilogOption {
     bool print_user_defined_template_;
     e_verilog_default_net_type default_net_type_;
     bool time_stamp_;
+    bool use_relative_path_;
     bool verbose_output_;
 };
 

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -98,6 +98,7 @@ void fpga_fabric_verilog(ModuleManager &module_manager,
                           blwl_sr_banks,
                           mux_lib, decoder_lib, circuit_lib,
                           submodule_dir_path,
+                          std::string(DEFAULT_SUBMODULE_DIR_NAME),
                           options);
 
   /* Generate routing blocks */
@@ -106,6 +107,7 @@ void fpga_fabric_verilog(ModuleManager &module_manager,
                                          const_cast<const ModuleManager &>(module_manager),
                                          device_rr_gsb,
                                          rr_dir_path,
+                                         std::string(DEFAULT_RR_DIR_NAME),
                                          options);
   } else {
     VTR_ASSERT(false == options.compress_routing());
@@ -113,6 +115,7 @@ void fpga_fabric_verilog(ModuleManager &module_manager,
                                           const_cast<const ModuleManager &>(module_manager),
                                           device_rr_gsb,
                                           rr_dir_path,
+                                          std::string(DEFAULT_RR_DIR_NAME),
                                           options);
   }
 
@@ -121,6 +124,7 @@ void fpga_fabric_verilog(ModuleManager &module_manager,
                       const_cast<const ModuleManager &>(module_manager),
                       device_ctx, device_annotation,
                       lb_dir_path,
+                      std::string(DEFAULT_LB_DIR_NAME),
                       options,
                       options.verbose_output());
 
@@ -134,6 +138,7 @@ void fpga_fabric_verilog(ModuleManager &module_manager,
   print_verilog_fabric_include_netlist(const_cast<const NetlistManager &>(netlist_manager),
                                        src_dir_path,
                                        circuit_lib,
+                                       options.use_relative_path(),
                                        options.time_stamp());
 
   /* Given a brief stats on how many Verilog modules have been written to files */

--- a/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
+++ b/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
@@ -31,9 +31,15 @@ namespace openfpga {
  * Some netlists are open to compile under specific preprocessing flags
  *******************************************************************/
 void print_verilog_fabric_include_netlist(const NetlistManager& netlist_manager,
-                                          const std::string& src_dir,
+                                          const std::string& src_dir_path,
                                           const CircuitLibrary& circuit_lib,
+                                          const bool& use_relative_path,
                                           const bool& include_time_stamp) {
+  /* If we force the use of relative path, the src dir path should NOT be included in any output */
+  std::string src_dir = src_dir_path;
+  if (use_relative_path) {
+    src_dir.clear();
+  }
   std::string verilog_fname = src_dir + std::string(FABRIC_INCLUDE_VERILOG_NETLIST_FILE_NAME);
 
   /* Create the file stream */

--- a/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
+++ b/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
@@ -40,14 +40,14 @@ void print_verilog_fabric_include_netlist(const NetlistManager& netlist_manager,
   if (use_relative_path) {
     src_dir.clear();
   }
-  std::string verilog_fname = src_dir + std::string(FABRIC_INCLUDE_VERILOG_NETLIST_FILE_NAME);
+  std::string verilog_fpath = src_dir_path + std::string(FABRIC_INCLUDE_VERILOG_NETLIST_FILE_NAME);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
   /* Validate the file stream */
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print the title */
   print_verilog_file_header(fp, std::string("Fabric Netlist Summary"), include_time_stamp); 

--- a/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.h
+++ b/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.h
@@ -18,8 +18,9 @@
 namespace openfpga {
 
 void print_verilog_fabric_include_netlist(const NetlistManager& netlist_manager,
-                                          const std::string& src_dir,
+                                          const std::string& src_dir_path,
                                           const CircuitLibrary& circuit_lib,
+                                          const bool& use_relative_path,
                                           const bool& include_time_stamp);
 
 void print_verilog_full_testbench_include_netlists(const std::string& src_dir,

--- a/openfpga/src/fpga_verilog/verilog_decoders.cpp
+++ b/openfpga/src/fpga_verilog/verilog_decoders.cpp
@@ -166,18 +166,20 @@ void print_verilog_submodule_mux_local_decoders(const ModuleManager& module_mana
                                                 const MuxLibrary& mux_lib,
                                                 const CircuitLibrary& circuit_lib,
                                                 const std::string& submodule_dir,
+                                                const std::string& submodule_dir_name,
                                                 const FabricVerilogOption& options) {
-  std::string verilog_fname(submodule_dir + std::string(LOCAL_ENCODER_VERILOG_FILE_NAME));
+  std::string verilog_fname(LOCAL_ENCODER_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print out debugging information for if the file is not opened/created properly */
   VTR_LOG("Writing Verilog netlist for local decoders for multiplexers '%s'...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Local Decoders for Multiplexers", options.time_stamp()); 
 
@@ -221,8 +223,13 @@ void print_verilog_submodule_mux_local_decoders(const ModuleManager& module_mana
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");
@@ -648,18 +655,20 @@ void print_verilog_submodule_arch_decoders(const ModuleManager& module_manager,
                                            NetlistManager& netlist_manager,
                                            const DecoderLibrary& decoder_lib,
                                            const std::string& submodule_dir,
+                                           const std::string& submodule_dir_name,
                                            const FabricVerilogOption& options) {
-  std::string verilog_fname(submodule_dir + std::string(ARCH_ENCODER_VERILOG_FILE_NAME));
+  std::string verilog_fname(ARCH_ENCODER_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print out debugging information for if the file is not opened/created properly */
   VTR_LOG("Writing Verilog netlist for configuration decoders '%s'...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Decoders for fabric configuration protocol", options.time_stamp()); 
 
@@ -676,8 +685,13 @@ void print_verilog_submodule_arch_decoders(const ModuleManager& module_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");

--- a/openfpga/src/fpga_verilog/verilog_decoders.cpp
+++ b/openfpga/src/fpga_verilog/verilog_decoders.cpp
@@ -225,9 +225,9 @@ void print_verilog_submodule_mux_local_decoders(const ModuleManager& module_mana
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
@@ -687,9 +687,9 @@ void print_verilog_submodule_arch_decoders(const ModuleManager& module_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_decoders.h
+++ b/openfpga/src/fpga_verilog/verilog_decoders.h
@@ -29,12 +29,14 @@ void print_verilog_submodule_mux_local_decoders(const ModuleManager& module_mana
                                                 const MuxLibrary& mux_lib,
                                                 const CircuitLibrary& circuit_lib,
                                                 const std::string& submodule_dir,
+                                                const std::string& submodule_dir_name,
                                                 const FabricVerilogOption& options);
 
 void print_verilog_submodule_arch_decoders(const ModuleManager& module_manager,
                                            NetlistManager& netlist_manager,
                                            const DecoderLibrary& decoder_lib,
                                            const std::string& submodule_dir,
+                                           const std::string& submodule_dir_name,
                                            const FabricVerilogOption& options);
 
 

--- a/openfpga/src/fpga_verilog/verilog_essential_gates.cpp
+++ b/openfpga/src/fpga_verilog/verilog_essential_gates.cpp
@@ -504,21 +504,22 @@ void print_verilog_constant_generator_module(const ModuleManager& module_manager
 void print_verilog_submodule_essentials(const ModuleManager& module_manager, 
                                         NetlistManager& netlist_manager,
                                         const std::string& submodule_dir,
+                                        const std::string& submodule_dir_name,
                                         const CircuitLibrary& circuit_lib,
                                         const FabricVerilogOption& options) { 
-  /* TODO: remove .bak when this part is completed and tested */
-  std::string verilog_fname = submodule_dir + std::string(ESSENTIALS_VERILOG_FILE_NAME);
+  std::string verilog_fname(ESSENTIALS_VERILOG_FILE_NAME);
+  std::string verilog_fpath = submodule_dir + verilog_fname;
 
   std::fstream fp;
 
   /* Create the file stream */
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
   /* Check if the file stream if valid or not */
-  check_file_stream(verilog_fname.c_str(), fp); 
+  check_file_stream(verilog_fpath.c_str(), fp); 
 
   /* Create file */
   VTR_LOG("Generating Verilog netlist '%s' for essential gates...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Essential gates", options.time_stamp());
 
@@ -551,8 +552,13 @@ void print_verilog_submodule_essentials(const ModuleManager& module_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");

--- a/openfpga/src/fpga_verilog/verilog_essential_gates.cpp
+++ b/openfpga/src/fpga_verilog/verilog_essential_gates.cpp
@@ -554,9 +554,9 @@ void print_verilog_submodule_essentials(const ModuleManager& module_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_essential_gates.h
+++ b/openfpga/src/fpga_verilog/verilog_essential_gates.h
@@ -21,6 +21,7 @@ namespace openfpga {
 void print_verilog_submodule_essentials(const ModuleManager& module_manager, 
                                         NetlistManager& netlist_manager,
                                         const std::string& submodule_dir,
+                                        const std::string& submodule_dir_name,
                                         const CircuitLibrary& circuit_lib,
                                         const FabricVerilogOption& options);
 

--- a/openfpga/src/fpga_verilog/verilog_grid.cpp
+++ b/openfpga/src/fpga_verilog/verilog_grid.cpp
@@ -212,7 +212,7 @@ void rec_print_verilog_logical_tile(NetlistManager& netlist_manager,
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
   check_file_stream(verilog_fpath.c_str(), fp);
 

--- a/openfpga/src/fpga_verilog/verilog_grid.cpp
+++ b/openfpga/src/fpga_verilog/verilog_grid.cpp
@@ -124,9 +124,9 @@ void print_verilog_primitive_block(NetlistManager& netlist_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::LOGIC_BLOCK_NETLIST);
@@ -249,9 +249,9 @@ void rec_print_verilog_logical_tile(NetlistManager& netlist_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::LOGIC_BLOCK_NETLIST);
@@ -368,9 +368,9 @@ void print_verilog_physical_tile_netlist(NetlistManager& netlist_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::LOGIC_BLOCK_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_grid.cpp
+++ b/openfpga/src/fpga_verilog/verilog_grid.cpp
@@ -69,6 +69,7 @@ static
 void print_verilog_primitive_block(NetlistManager& netlist_manager,
                                    const ModuleManager& module_manager,
                                    const std::string& subckt_dir,
+                                   const std::string& subckt_dir_name,
                                    t_pb_graph_node* primitive_pb_graph_node,
                                    const FabricVerilogOption& options,
                                    const bool& verbose) {
@@ -80,20 +81,19 @@ void print_verilog_primitive_block(NetlistManager& netlist_manager,
   }
 
   /* Give a name to the Verilog netlist */
+  std::string verilog_fname(generate_logical_tile_netlist_name(std::string(), primitive_pb_graph_node, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
   /* Create the file name for Verilog */
-  std::string verilog_fname(subckt_dir 
-                          + generate_logical_tile_netlist_name(std::string(), primitive_pb_graph_node, std::string(VERILOG_NETLIST_FILE_POSTFIX))
-                           );
+  std::string verilog_fpath(subckt_dir + verilog_fname);
 
   VTR_LOG("Writing Verilog netlist '%s' for primitive pb_type '%s' ...",
-          verilog_fname.c_str(), primitive_pb_graph_node->pb_type->name);
+          verilog_fpath.c_str(), primitive_pb_graph_node->pb_type->name);
   VTR_LOGV(verbose, "\n");
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   print_verilog_file_header(fp,
                             std::string("Verilog modules for primitive pb_type: " + std::string(primitive_pb_graph_node->pb_type->name)),
@@ -122,8 +122,13 @@ void print_verilog_primitive_block(NetlistManager& netlist_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::LOGIC_BLOCK_NETLIST);
 
   VTR_LOGV(verbose, "Done\n");
@@ -149,6 +154,7 @@ void rec_print_verilog_logical_tile(NetlistManager& netlist_manager,
                                     const ModuleManager& module_manager,
                                     const VprDeviceAnnotation& device_annotation,
                                     const std::string& subckt_dir,
+                                    const std::string& subckt_dir_name,
                                     t_pb_graph_node* physical_pb_graph_node,
                                     const FabricVerilogOption& options,
                                     const bool& verbose) {
@@ -175,6 +181,7 @@ void rec_print_verilog_logical_tile(NetlistManager& netlist_manager,
       rec_print_verilog_logical_tile(netlist_manager,
                                      module_manager, device_annotation,
                                      subckt_dir, 
+                                     subckt_dir_name, 
                                      &(physical_pb_graph_node->child_pb_graph_nodes[physical_mode->index][ipb][0]),
                                      options,
                                      verbose);
@@ -186,6 +193,7 @@ void rec_print_verilog_logical_tile(NetlistManager& netlist_manager,
     print_verilog_primitive_block(netlist_manager,
                                   module_manager,
                                   subckt_dir,
+                                  subckt_dir_name,
                                   physical_pb_graph_node, 
                                   options, 
                                   verbose);
@@ -195,19 +203,18 @@ void rec_print_verilog_logical_tile(NetlistManager& netlist_manager,
 
   /* Give a name to the Verilog netlist */
   /* Create the file name for Verilog */
-  std::string verilog_fname(subckt_dir 
-                          + generate_logical_tile_netlist_name(std::string(), physical_pb_graph_node, std::string(VERILOG_NETLIST_FILE_POSTFIX))
-                           );
+  std::string verilog_fname(generate_logical_tile_netlist_name(std::string(), physical_pb_graph_node, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fpath(subckt_dir + verilog_fname);
 
   VTR_LOG("Writing Verilog netlist '%s' for pb_type '%s' ...",
-          verilog_fname.c_str(), physical_pb_type->name);
+          verilog_fpath.c_str(), physical_pb_type->name);
   VTR_LOGV(verbose, "\n");
 
   /* Create the file stream */
   std::fstream fp;
   fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   print_verilog_file_header(fp,
                             std::string("Verilog modules for pb_type: " + std::string(physical_pb_type->name)),
@@ -240,8 +247,13 @@ void rec_print_verilog_logical_tile(NetlistManager& netlist_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::LOGIC_BLOCK_NETLIST);
 
   VTR_LOGV(verbose, "Done\n");
@@ -256,6 +268,7 @@ void print_verilog_logical_tile_netlist(NetlistManager& netlist_manager,
                                         const ModuleManager& module_manager,
                                         const VprDeviceAnnotation& device_annotation,
                                         const std::string& subckt_dir,
+                                        const std::string& subckt_dir_name,
                                         t_pb_graph_node* pb_graph_head,
                                         const FabricVerilogOption& options,
                                         const bool& verbose) {
@@ -275,6 +288,7 @@ void print_verilog_logical_tile_netlist(NetlistManager& netlist_manager,
                                  module_manager,
                                  device_annotation, 
                                  subckt_dir,
+                                 subckt_dir_name,
                                  pb_graph_head,
                                  options,
                                  verbose);
@@ -295,34 +309,36 @@ static
 void print_verilog_physical_tile_netlist(NetlistManager& netlist_manager,
                                          const ModuleManager& module_manager,
                                          const std::string& subckt_dir,
+                                         const std::string& subckt_dir_name,
                                          t_physical_tile_type_ptr phy_block_type,
                                          const e_side& border_side,
                                          const FabricVerilogOption& options) {
   /* Give a name to the Verilog netlist */
-  /* Create the file name for Verilog */
-  std::string verilog_fname(subckt_dir 
-                          + generate_grid_block_netlist_name(std::string(GRID_MODULE_NAME_PREFIX) + std::string(phy_block_type->name), 
+  std::string verilog_fname(generate_grid_block_netlist_name(std::string(GRID_MODULE_NAME_PREFIX) + std::string(phy_block_type->name), 
                                                              is_io_type(phy_block_type), 
                                                              border_side, 
                                                              std::string(VERILOG_NETLIST_FILE_POSTFIX))
                            );
 
+  /* Create the file name for Verilog */
+  std::string verilog_fpath(subckt_dir + verilog_fname);
+
   /* Echo status */
   if (true == is_io_type(phy_block_type)) {
     SideManager side_manager(border_side);
     VTR_LOG("Writing Verilog Netlist '%s' for physical tile '%s' at %s side ...",
-            verilog_fname.c_str(), phy_block_type->name, 
+            verilog_fpath.c_str(), phy_block_type->name, 
             side_manager.c_str());
   } else { 
     VTR_LOG("Writing Verilog Netlist '%s' for physical_tile '%s'...",
-            verilog_fname.c_str(), phy_block_type->name);
+            verilog_fpath.c_str(), phy_block_type->name);
   }
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   print_verilog_file_header(fp,
                             std::string("Verilog modules for physical tile: " + std::string(phy_block_type->name) + "]"),
@@ -350,8 +366,13 @@ void print_verilog_physical_tile_netlist(NetlistManager& netlist_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::LOGIC_BLOCK_NETLIST);
 
   VTR_LOG("Done\n");
@@ -368,6 +389,7 @@ void print_verilog_grids(NetlistManager& netlist_manager,
                          const DeviceContext& device_ctx,
                          const VprDeviceAnnotation& device_annotation,
                          const std::string& subckt_dir,
+                         const std::string& subckt_dir_name,
                          const FabricVerilogOption& options,
                          const bool& verbose) {
   /* Create a vector to contain all the Verilog netlist names that have been generated in this function */
@@ -391,6 +413,7 @@ void print_verilog_grids(NetlistManager& netlist_manager,
                                        module_manager,
                                        device_annotation,
                                        subckt_dir,
+                                       subckt_dir_name,
                                        logical_tile.pb_graph_head,
                                        options,
                                        verbose);
@@ -424,6 +447,7 @@ void print_verilog_grids(NetlistManager& netlist_manager,
         print_verilog_physical_tile_netlist(netlist_manager,
                                             module_manager,
                                             subckt_dir, 
+                                            subckt_dir_name, 
                                             &physical_tile,
                                             io_type_side,
                                             options);
@@ -434,6 +458,7 @@ void print_verilog_grids(NetlistManager& netlist_manager,
       print_verilog_physical_tile_netlist(netlist_manager,
                                           module_manager,
                                           subckt_dir, 
+                                          subckt_dir_name, 
                                           &physical_tile,
                                           NUM_SIDES,
                                           options);
@@ -442,17 +467,6 @@ void print_verilog_grids(NetlistManager& netlist_manager,
   VTR_LOG("Building physical tiles...");
   VTR_LOG("Done\n");
   VTR_LOG("\n");
-
-  /* Output a header file for all the logic blocks */
-  /*
-  std::string grid_verilog_fname(LOGIC_BLOCK_VERILOG_FILE_NAME);
-  VTR_LOG("Writing header file for grid Verilog modules '%s' ...",
-          grid_verilog_fname.c_str());
-  print_verilog_netlist_include_header_file(netlist_names,
-                                            subckt_dir.c_str(),
-                                            grid_verilog_fname.c_str());
-  VTR_LOG("Done\n");
-   */
 }
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_grid.h
+++ b/openfpga/src/fpga_verilog/verilog_grid.h
@@ -23,6 +23,7 @@ void print_verilog_grids(NetlistManager& netlist_manager,
                          const DeviceContext& device_ctx,
                          const VprDeviceAnnotation& device_annotation,
                          const std::string& subckt_dir,
+                         const std::string& subckt_dir_name,
                          const FabricVerilogOption& options,
                          const bool& verbose);
 

--- a/openfpga/src/fpga_verilog/verilog_lut.cpp
+++ b/openfpga/src/fpga_verilog/verilog_lut.cpp
@@ -72,9 +72,9 @@ void print_verilog_submodule_luts(const ModuleManager& module_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_lut.cpp
+++ b/openfpga/src/fpga_verilog/verilog_lut.cpp
@@ -33,19 +33,21 @@ void print_verilog_submodule_luts(const ModuleManager& module_manager,
                                   NetlistManager& netlist_manager,
                                   const CircuitLibrary& circuit_lib,
                                   const std::string& submodule_dir,
+                                  const std::string& submodule_dir_name,
                                   const FabricVerilogOption& options) {
-  std::string verilog_fname = submodule_dir + std::string(LUTS_VERILOG_FILE_NAME);
+  std::string verilog_fname(LUTS_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   std::fstream fp;
 
   /* Create the file stream */
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
   /* Check if the file stream if valid or not */
-  check_file_stream(verilog_fname.c_str(), fp); 
+  check_file_stream(verilog_fpath.c_str(), fp); 
 
   /* Create file */
   VTR_LOG("Writing Verilog netlist for LUTs '%s'...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Look-Up Tables", options.time_stamp()); 
 
@@ -68,8 +70,13 @@ void print_verilog_submodule_luts(const ModuleManager& module_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");

--- a/openfpga/src/fpga_verilog/verilog_lut.h
+++ b/openfpga/src/fpga_verilog/verilog_lut.h
@@ -23,6 +23,7 @@ void print_verilog_submodule_luts(const ModuleManager& module_manager,
                                   NetlistManager& netlist_manager,
                                   const CircuitLibrary& circuit_lib,
                                   const std::string& submodule_dir,
+                                  const std::string& submodule_dir_name,
                                   const FabricVerilogOption& options);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_memory.cpp
+++ b/openfpga/src/fpga_verilog/verilog_memory.cpp
@@ -195,9 +195,9 @@ void print_verilog_submodule_memories(const ModuleManager& module_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_memory.cpp
+++ b/openfpga/src/fpga_verilog/verilog_memory.cpp
@@ -102,19 +102,21 @@ void print_verilog_submodule_memories(const ModuleManager& module_manager,
                                       const MuxLibrary& mux_lib,
                                       const CircuitLibrary& circuit_lib,
                                       const std::string& submodule_dir,
+                                      const std::string& submodule_dir_name,
                                       const FabricVerilogOption& options) {
   /* Plug in with the mux subckt */
-  std::string verilog_fname(submodule_dir + std::string(MEMORIES_VERILOG_FILE_NAME));
+  std::string verilog_fname(MEMORIES_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print out debugging information for if the file is not opened/created properly */
   VTR_LOG("Writing Verilog netlist for memories '%s' ...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Memories used in FPGA", options.time_stamp()); 
 
@@ -191,8 +193,13 @@ void print_verilog_submodule_memories(const ModuleManager& module_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");

--- a/openfpga/src/fpga_verilog/verilog_memory.h
+++ b/openfpga/src/fpga_verilog/verilog_memory.h
@@ -25,6 +25,7 @@ void print_verilog_submodule_memories(const ModuleManager& module_manager,
                                       const MuxLibrary& mux_lib,
                                       const CircuitLibrary& circuit_lib,
                                       const std::string& submodule_dir,
+                                      const std::string& submodule_dir_name,
                                       const FabricVerilogOption& options);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_mux.cpp
+++ b/openfpga/src/fpga_verilog/verilog_mux.cpp
@@ -1260,19 +1260,21 @@ void print_verilog_submodule_mux_primitives(ModuleManager& module_manager,
                                             const MuxLibrary& mux_lib,
                                             const CircuitLibrary& circuit_lib,
                                             const std::string& submodule_dir,
+                                            const std::string& submodule_dir_name,
                                             const FabricVerilogOption& options) {
   /* Output primitive cells for MUX modules */ 
-  std::string verilog_fname(submodule_dir + std::string(MUX_PRIMITIVES_VERILOG_FILE_NAME));
+  std::string verilog_fname(MUX_PRIMITIVES_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print out debugging information for if the file is not opened/created properly */
   VTR_LOG("Writing Verilog netlist for Multiplexer primitives '%s' ...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Multiplexer primitives", options.time_stamp()); 
 
@@ -1301,8 +1303,13 @@ void print_verilog_submodule_mux_primitives(ModuleManager& module_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");
@@ -1318,19 +1325,21 @@ void print_verilog_submodule_mux_top_modules(ModuleManager& module_manager,
                                              const MuxLibrary& mux_lib,
                                              const CircuitLibrary& circuit_lib,
                                              const std::string& submodule_dir,
+                                             const std::string& submodule_dir_name,
                                              const FabricVerilogOption& options) {
   /* Output top-level MUX modules */ 
-  std::string verilog_fname(submodule_dir + std::string(MUXES_VERILOG_FILE_NAME));
+  std::string verilog_fname(MUXES_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print out debugging information for if the file is not opened/created properly */
   VTR_LOG("Writing Verilog netlist for Multiplexers '%s' ...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Multiplexers", options.time_stamp()); 
 
@@ -1352,8 +1361,13 @@ void print_verilog_submodule_mux_top_modules(ModuleManager& module_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");
@@ -1373,12 +1387,14 @@ void print_verilog_submodule_muxes(ModuleManager& module_manager,
                                    const MuxLibrary& mux_lib,
                                    const CircuitLibrary& circuit_lib,
                                    const std::string& submodule_dir,
+                                   const std::string& submodule_dir_name,
                                    const FabricVerilogOption& options) {
   print_verilog_submodule_mux_primitives(module_manager,
                                          netlist_manager,
                                          mux_lib,
                                          circuit_lib,
                                          submodule_dir,
+                                         submodule_dir_name,
                                          options);
 
   print_verilog_submodule_mux_top_modules(module_manager,
@@ -1386,6 +1402,7 @@ void print_verilog_submodule_muxes(ModuleManager& module_manager,
                                           mux_lib,
                                           circuit_lib,
                                           submodule_dir,
+                                          submodule_dir_name,
                                           options);
 }
 

--- a/openfpga/src/fpga_verilog/verilog_mux.cpp
+++ b/openfpga/src/fpga_verilog/verilog_mux.cpp
@@ -1305,9 +1305,9 @@ void print_verilog_submodule_mux_primitives(ModuleManager& module_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
@@ -1363,9 +1363,9 @@ void print_verilog_submodule_mux_top_modules(ModuleManager& module_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_mux.h
+++ b/openfpga/src/fpga_verilog/verilog_mux.h
@@ -26,6 +26,7 @@ void print_verilog_submodule_muxes(ModuleManager& module_manager,
                                    const MuxLibrary& mux_lib,
                                    const CircuitLibrary& circuit_lib,
                                    const std::string& submodule_dir,
+                                   const std::string& submodule_dir_name,
                                    const FabricVerilogOption& options);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_routing.cpp
+++ b/openfpga/src/fpga_verilog/verilog_routing.cpp
@@ -78,18 +78,20 @@ static
 void print_verilog_routing_connection_box_unique_module(NetlistManager& netlist_manager,
                                                         const ModuleManager& module_manager, 
                                                         const std::string& subckt_dir, 
+                                                        const std::string& subckt_dir_name, 
                                                         const RRGSB& rr_gsb,
                                                         const t_rr_type& cb_type,
                                                         const FabricVerilogOption& options) {
   /* Create the netlist */
   vtr::Point<size_t> gsb_coordinate(rr_gsb.get_cb_x(cb_type), rr_gsb.get_cb_y(cb_type));
-  std::string verilog_fname(subckt_dir + generate_connection_block_netlist_name(cb_type, gsb_coordinate, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fname(generate_connection_block_netlist_name(cb_type, gsb_coordinate, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fpath(subckt_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   print_verilog_file_header(fp,
                             std::string("Verilog modules for Unique Connection Blocks[" + std::to_string(rr_gsb.get_cb_x(cb_type)) + "]["+ std::to_string(rr_gsb.get_cb_y(cb_type)) + "]"),
@@ -112,8 +114,13 @@ void print_verilog_routing_connection_box_unique_module(NetlistManager& netlist_
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::ROUTING_MODULE_NETLIST);
 }
 
@@ -184,17 +191,19 @@ static
 void print_verilog_routing_switch_box_unique_module(NetlistManager& netlist_manager,
                                                     const ModuleManager& module_manager, 
                                                     const std::string& subckt_dir, 
+                                                    const std::string& subckt_dir_name, 
                                                     const RRGSB& rr_gsb,
                                                     const FabricVerilogOption& options) {
   /* Create the netlist */
   vtr::Point<size_t> gsb_coordinate(rr_gsb.get_sb_x(), rr_gsb.get_sb_y());
-  std::string verilog_fname(subckt_dir + generate_routing_block_netlist_name(SB_VERILOG_FILE_NAME_PREFIX, gsb_coordinate, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fname(generate_routing_block_netlist_name(SB_VERILOG_FILE_NAME_PREFIX, gsb_coordinate, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fpath(subckt_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   print_verilog_file_header(fp,
                             std::string("Verilog modules for Unique Switch Blocks[" + std::to_string(rr_gsb.get_sb_x()) + "]["+ std::to_string(rr_gsb.get_sb_y()) + "]"),
@@ -215,8 +224,13 @@ void print_verilog_routing_switch_box_unique_module(NetlistManager& netlist_mana
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::ROUTING_MODULE_NETLIST);
 }
 
@@ -229,6 +243,7 @@ void print_verilog_flatten_connection_block_modules(NetlistManager& netlist_mana
                                                     const ModuleManager& module_manager, 
                                                     const DeviceRRGSB& device_rr_gsb,
                                                     const std::string& subckt_dir,
+                                                    const std::string& subckt_dir_name,
                                                     const t_rr_type& cb_type,
                                                     const FabricVerilogOption& options) {
   /* Build unique X-direction connection block modules */
@@ -247,6 +262,7 @@ void print_verilog_flatten_connection_block_modules(NetlistManager& netlist_mana
       print_verilog_routing_connection_box_unique_module(netlist_manager, 
                                                          module_manager,
                                                          subckt_dir, 
+                                                         subckt_dir_name, 
                                                          rr_gsb, cb_type,  
                                                          options);
     }
@@ -266,6 +282,7 @@ void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
                                            const ModuleManager& module_manager,
                                            const DeviceRRGSB& device_rr_gsb,
                                            const std::string& subckt_dir,
+                                           const std::string& subckt_dir_name,
                                            const FabricVerilogOption& options) {
   /* Create a vector to contain all the Verilog netlist names that have been generated in this function */
   std::vector<std::string> netlist_names;
@@ -282,6 +299,7 @@ void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
       print_verilog_routing_switch_box_unique_module(netlist_manager,
                                                      module_manager, 
                                                      subckt_dir, 
+                                                     subckt_dir_name, 
                                                      rr_gsb, 
                                                      options);
     }
@@ -291,6 +309,7 @@ void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
                                                  module_manager,
                                                  device_rr_gsb,
                                                  subckt_dir,
+                                                 subckt_dir_name,
                                                  CHANX,
                                                  options);
 
@@ -298,18 +317,9 @@ void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
                                                  module_manager,
                                                  device_rr_gsb,
                                                  subckt_dir,
+                                                 subckt_dir_name,
                                                  CHANY,
                                                  options);
-
-  /*
-  VTR_LOG("Writing header file for routing submodules '%s'...",
-          ROUTING_VERILOG_FILE_NAME);
-  print_verilog_netlist_include_header_file(netlist_names,
-                                            subckt_dir.c_str(),
-                                            ROUTING_VERILOG_FILE_NAME);
-  VTR_LOG("Done\n");
-  VTR_LOG("\n");
-   */
 }
 
 
@@ -327,6 +337,7 @@ void print_verilog_unique_routing_modules(NetlistManager& netlist_manager,
                                           const ModuleManager& module_manager,
                                           const DeviceRRGSB& device_rr_gsb,
                                           const std::string& subckt_dir,
+                                          const std::string& subckt_dir_name,
                                           const FabricVerilogOption& options) {
   /* Create a vector to contain all the Verilog netlist names that have been generated in this function */
   std::vector<std::string> netlist_names;
@@ -337,6 +348,7 @@ void print_verilog_unique_routing_modules(NetlistManager& netlist_manager,
     print_verilog_routing_switch_box_unique_module(netlist_manager,
                                                    module_manager,
                                                    subckt_dir, 
+                                                   subckt_dir_name, 
                                                    unique_mirror, 
                                                    options);
   }
@@ -348,6 +360,7 @@ void print_verilog_unique_routing_modules(NetlistManager& netlist_manager,
     print_verilog_routing_connection_box_unique_module(netlist_manager,
                                                        module_manager,
                                                        subckt_dir, 
+                                                       subckt_dir_name, 
                                                        unique_mirror, CHANX,  
                                                        options);
   }
@@ -359,18 +372,11 @@ void print_verilog_unique_routing_modules(NetlistManager& netlist_manager,
     print_verilog_routing_connection_box_unique_module(netlist_manager, 
                                                        module_manager,
                                                        subckt_dir, 
+                                                       subckt_dir_name, 
                                                        unique_mirror, CHANY,  
                                                        options);
   }
 
-  /*
-  VTR_LOG("Writing header file for routing submodules '%s'...",
-          ROUTING_VERILOG_FILE_NAME);
-  print_verilog_netlist_include_header_file(netlist_names,
-                                            subckt_dir.c_str(),
-                                            ROUTING_VERILOG_FILE_NAME);
-  VTR_LOG("Done\n");
-   */
   VTR_LOG("\n");
 }
 

--- a/openfpga/src/fpga_verilog/verilog_routing.cpp
+++ b/openfpga/src/fpga_verilog/verilog_routing.cpp
@@ -116,9 +116,9 @@ void print_verilog_routing_connection_box_unique_module(NetlistManager& netlist_
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::ROUTING_MODULE_NETLIST);
@@ -226,9 +226,9 @@ void print_verilog_routing_switch_box_unique_module(NetlistManager& netlist_mana
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(subckt_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::ROUTING_MODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_routing.h
+++ b/openfpga/src/fpga_verilog/verilog_routing.h
@@ -22,12 +22,14 @@ void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
                                            const ModuleManager& module_manager,
                                            const DeviceRRGSB& device_rr_gsb,
                                            const std::string& subckt_dir,
+                                           const std::string& subckt_dir_name,
                                            const FabricVerilogOption& options);
 
 void print_verilog_unique_routing_modules(NetlistManager& netlist_manager,
                                           const ModuleManager& module_manager,
                                           const DeviceRRGSB& device_rr_gsb,
                                           const std::string& subckt_dir,
+                                          const std::string& subckt_dir_name,
                                           const FabricVerilogOption& options);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_shift_register_banks.cpp
+++ b/openfpga/src/fpga_verilog/verilog_shift_register_banks.cpp
@@ -84,9 +84,9 @@ void print_verilog_submodule_shift_register_banks(const ModuleManager& module_ma
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_shift_register_banks.cpp
+++ b/openfpga/src/fpga_verilog/verilog_shift_register_banks.cpp
@@ -36,20 +36,22 @@ void print_verilog_submodule_shift_register_banks(const ModuleManager& module_ma
                                                   NetlistManager& netlist_manager,
                                                   const MemoryBankShiftRegisterBanks& blwl_sr_banks,
                                                   const std::string& submodule_dir,
+                                                  const std::string& submodule_dir_name,
                                                   const FabricVerilogOption& options) {
 
   /* Plug in with the mux subckt */
-  std::string verilog_fname(submodule_dir + std::string(SHIFT_REGISTER_BANKS_VERILOG_FILE_NAME));
+  std::string verilog_fname(SHIFT_REGISTER_BANKS_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print out debugging information for if the file is not opened/created properly */
   VTR_LOG("Writing Verilog netlist for shift register banks '%s' ...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Shift register banks used in FPGA", options.time_stamp()); 
 
@@ -80,8 +82,13 @@ void print_verilog_submodule_shift_register_banks(const ModuleManager& module_ma
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");

--- a/openfpga/src/fpga_verilog/verilog_shift_register_banks.h
+++ b/openfpga/src/fpga_verilog/verilog_shift_register_banks.h
@@ -22,6 +22,7 @@ void print_verilog_submodule_shift_register_banks(const ModuleManager& module_ma
                                                   NetlistManager& netlist_manager,
                                                   const MemoryBankShiftRegisterBanks& blwl_sr_banks,
                                                   const std::string& submodule_dir,
+                                                  const std::string& submodule_dir_name,
                                                   const FabricVerilogOption& options);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_submodule.cpp
+++ b/openfpga/src/fpga_verilog/verilog_submodule.cpp
@@ -39,17 +39,13 @@ void print_verilog_submodule(ModuleManager& module_manager,
                              const DecoderLibrary& decoder_lib,
                              const CircuitLibrary& circuit_lib, 
                              const std::string& submodule_dir, 
+                             const std::string& submodule_dir_name, 
                              const FabricVerilogOption& fpga_verilog_opts) {
-
-  /* Register all the user-defined modules in the module manager
-   * This should be done prior to other steps in this function, 
-   * because they will be instanciated by other primitive modules 
-   */
-  //add_user_defined_verilog_modules(module_manager, circuit_lib);
 
   print_verilog_submodule_essentials(const_cast<const ModuleManager&>(module_manager), 
                                      netlist_manager,
                                      submodule_dir,
+                                     submodule_dir_name,
                                      circuit_lib,
                                      fpga_verilog_opts);
 
@@ -58,6 +54,7 @@ void print_verilog_submodule(ModuleManager& module_manager,
                                         netlist_manager, 
                                         decoder_lib, 
                                         submodule_dir,
+                                        submodule_dir_name,
                                         fpga_verilog_opts);
 
   /* Routing multiplexers */
@@ -68,22 +65,25 @@ void print_verilog_submodule(ModuleManager& module_manager,
                                              netlist_manager, 
                                              mux_lib, circuit_lib, 
                                              submodule_dir,
+                                             submodule_dir_name,
                                              fpga_verilog_opts);
   print_verilog_submodule_muxes(module_manager, netlist_manager, mux_lib, circuit_lib,
                                 submodule_dir,
+                                submodule_dir_name,
                                 fpga_verilog_opts);
-
  
   /* LUTes */
   print_verilog_submodule_luts(const_cast<const ModuleManager&>(module_manager),
                                netlist_manager, circuit_lib,
                                submodule_dir,
+                               submodule_dir_name,
                                fpga_verilog_opts);
 
   /* Hard wires */
   print_verilog_submodule_wires(const_cast<const ModuleManager&>(module_manager),
                                 netlist_manager, circuit_lib,
                                 submodule_dir,
+                                submodule_dir_name,
                                 fpga_verilog_opts);
 
   /* Memories */
@@ -91,6 +91,7 @@ void print_verilog_submodule(ModuleManager& module_manager,
                                    netlist_manager,
                                    mux_lib, circuit_lib, 
                                    submodule_dir,
+                                   submodule_dir_name,
                                    fpga_verilog_opts);
 
   /* Shift register banks */
@@ -98,6 +99,7 @@ void print_verilog_submodule(ModuleManager& module_manager,
                                                netlist_manager,
                                                blwl_sr_banks, 
                                                submodule_dir,
+                                               submodule_dir_name,
                                                fpga_verilog_opts);
 
 
@@ -108,13 +110,6 @@ void print_verilog_submodule(ModuleManager& module_manager,
                                       submodule_dir,
                                       fpga_verilog_opts);
   }
-
-  /* Create a header file to include all the subckts */
-  /*
-  print_verilog_netlist_include_header_file(netlist_manager,
-                                            submodule_dir.c_str(),
-                                            SUBMODULE_VERILOG_FILE_NAME);
-   */
 }
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_submodule.h
+++ b/openfpga/src/fpga_verilog/verilog_submodule.h
@@ -25,6 +25,7 @@ void print_verilog_submodule(ModuleManager& module_manager,
                              const DecoderLibrary& decoder_lib,
                              const CircuitLibrary& circuit_lib, 
                              const std::string& submodule_dir, 
+                             const std::string& submodule_dir_name, 
                              const FabricVerilogOption& fpga_verilog_opts);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fpga_verilog/verilog_top_module.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_module.cpp
@@ -53,9 +53,9 @@ void print_verilog_top_module(NetlistManager& netlist_manager,
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   print_verilog_file_header(fp,
                             std::string("Top-level Verilog module for FPGA"),

--- a/openfpga/src/fpga_verilog/verilog_top_module.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_module.cpp
@@ -45,10 +45,11 @@ void print_verilog_top_module(NetlistManager& netlist_manager,
 
   /* Start printing out Verilog netlists */
   /* Create the file name for Verilog netlist */
-  std::string verilog_fname(verilog_dir + generate_fpga_top_netlist_name(std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fname(generate_fpga_top_netlist_name(std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fpath(verilog_dir + verilog_fname);
 
   VTR_LOG("Writing Verilog netlist for top-level module of FPGA fabric '%s'...",
-          verilog_fname.c_str());
+          verilog_fpath.c_str());
 
   /* Create the file stream */
   std::fstream fp;
@@ -74,8 +75,13 @@ void print_verilog_top_module(NetlistManager& netlist_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    nlist_id = netlist_manager.add_netlist(verilog_fname);
+  } else {
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::TOP_MODULE_NETLIST);
 
   VTR_LOG("Done\n");

--- a/openfpga/src/fpga_verilog/verilog_wire.cpp
+++ b/openfpga/src/fpga_verilog/verilog_wire.cpp
@@ -131,9 +131,9 @@ void print_verilog_submodule_wires(const ModuleManager& module_manager,
   /* Add fname to the netlist name list */
   NetlistId nlist_id = NetlistId::INVALID();
   if (options.use_relative_path()) {
-    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+    nlist_id = netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
   } else {
-    netlist_manager.add_netlist(verilog_fpath);
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
   }
   VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);

--- a/openfpga/src/fpga_verilog/verilog_wire.cpp
+++ b/openfpga/src/fpga_verilog/verilog_wire.cpp
@@ -97,18 +97,20 @@ void print_verilog_submodule_wires(const ModuleManager& module_manager,
                                    NetlistManager& netlist_manager,
                                    const CircuitLibrary& circuit_lib,
                                    const std::string& submodule_dir,
+                                   const std::string& submodule_dir_name,
                                    const FabricVerilogOption& options) {
-  std::string verilog_fname(submodule_dir + std::string(WIRES_VERILOG_FILE_NAME));
+  std::string verilog_fname(WIRES_VERILOG_FILE_NAME);
+  std::string verilog_fpath(submodule_dir + verilog_fname);
 
   /* Create the file stream */
   std::fstream fp;
-  fp.open(verilog_fname, std::fstream::out | std::fstream::trunc);
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
 
-  check_file_stream(verilog_fname.c_str(), fp);
+  check_file_stream(verilog_fpath.c_str(), fp);
 
   /* Print out debugging information for if the file is not opened/created properly */
   VTR_LOG("Writing Verilog netlist for wires '%s'...",
-          verilog_fname.c_str()); 
+          verilog_fpath.c_str()); 
 
   print_verilog_file_header(fp, "Wires", options.time_stamp()); 
 
@@ -127,8 +129,13 @@ void print_verilog_submodule_wires(const ModuleManager& module_manager,
   fp.close();
 
   /* Add fname to the netlist name list */
-  NetlistId nlist_id = netlist_manager.add_netlist(verilog_fname);
-  VTR_ASSERT(NetlistId::INVALID() != nlist_id);
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    netlist_manager.add_netlist(submodule_dir_name + verilog_fname);
+  } else {
+    netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
   netlist_manager.set_netlist_type(nlist_id, NetlistManager::SUBMODULE_NETLIST);
 
   VTR_LOG("Done\n");

--- a/openfpga/src/fpga_verilog/verilog_wire.h
+++ b/openfpga/src/fpga_verilog/verilog_wire.h
@@ -24,6 +24,7 @@ void print_verilog_submodule_wires(const ModuleManager& module_manager,
                                    NetlistManager& netlist_manager,
                                    const CircuitLibrary& circuit_lib,
                                    const std::string& submodule_dir,
+                                   const std::string& submodule_dir_name,
                                    const FabricVerilogOption& options);
 
 } /* end namespace openfpga */

--- a/openfpga_flow/openfpga_shell_scripts/write_full_testbench_relative_path_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/write_full_testbench_relative_path_example_script.openfpga
@@ -47,7 +47,7 @@ write_fabric_bitstream --file fabric_bitstream.bit --format plain_text ${OPENFPG
 
 # Write the Verilog netlist for FPGA fabric
 #  - Enable the use of explicit port mapping in Verilog netlist
-write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --print_user_defined_template --verbose --use_relative_path
+write_fabric_verilog --file . --explicit_port_mapping --include_timing --print_user_defined_template --verbose --use_relative_path
 
 # Write the Verilog testbench for FPGA fabric
 #  - We suggest the use of same output directory as fabric Verilog netlists
@@ -55,7 +55,7 @@ write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --pri
 #  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
 #  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
 #  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
-write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --explicit_port_mapping --bitstream fabric_bitstream.bit ${OPENFPGA_FAST_CONFIGURATION}
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --explicit_port_mapping --bitstream fabric_bitstream.bit ${OPENFPGA_FAST_CONFIGURATION} --fabric_netlist_file_path fabric_netlists.v
 
 # Write the SDC files for PnR backend
 #  - Turn on every options here

--- a/openfpga_flow/openfpga_shell_scripts/write_full_testbench_relative_path_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/write_full_testbench_relative_path_example_script.openfpga
@@ -1,0 +1,74 @@
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling route ${OPENFPGA_VPR_DEVICE_LAYOUT}
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to clustering nets based on routing results
+pb_pin_fixup --verbose
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enable pin duplication on grid modules
+build_fabric --compress_routing #--verbose
+
+# Write the fabric hierarchy of module graph to a file
+# This is used by hierarchical PnR flows
+write_fabric_hierarchy --file ./fabric_hierarchy.txt
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose
+
+# Write fabric-dependent bitstream
+write_fabric_bitstream --file fabric_bitstream.bit --format plain_text ${OPENFPGA_FAST_CONFIGURATION}
+
+# Write the Verilog netlist for FPGA fabric
+#  - Enable the use of explicit port mapping in Verilog netlist
+write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --print_user_defined_template --verbose --use_relative_path
+
+# Write the Verilog testbench for FPGA fabric
+#  - We suggest the use of same output directory as fabric Verilog netlists
+#  - Must specify the reference benchmark file if you want to output any testbenches
+#  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
+#  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
+#  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --explicit_port_mapping --bitstream fabric_bitstream.bit ${OPENFPGA_FAST_CONFIGURATION}
+
+# Write the SDC files for PnR backend
+#  - Turn on every options here
+write_pnr_sdc --file ./SDC
+
+# Write SDC to disable timing for configure ports
+write_sdc_disable_timing_configure_ports --file ./SDC/disable_configure_ports.sdc
+
+# Write the SDC to run timing analysis for a mapped FPGA fabric
+write_analysis_sdc --file ./SDC_analysis
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -143,3 +143,6 @@ run-task fpga_verilog/thru_channel/thru_wide_tile --debug --show_thread_logs
 echo -e "Testing the generation of preconfigured fabric wrapper for different HDL simulators";
 run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_none --debug --show_thread_logs
 run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_modelsim --debug --show_thread_logs
+
+echo -e "Testing the netlist generation by forcing the use of relative paths";
+run-task fpga_verilog/verilog_netlist_formats/use_relative_path--debug --show_thread_logs

--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -145,4 +145,4 @@ run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_none --debug --sho
 run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_modelsim --debug --show_thread_logs
 
 echo -e "Testing the netlist generation by forcing the use of relative paths";
-run-task fpga_verilog/verilog_netlist_formats/use_relative_path--debug --show_thread_logs
+run-task fpga_verilog/verilog_netlist_formats/use_relative_path --debug --show_thread_logs

--- a/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/use_relative_path/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/use_relative_path/config/task.conf
@@ -1,0 +1,36 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_relative_path_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
- In fabric netlists, users have limited choices in the file paths when including other netlists. Most of the time, absolute paths are forced. Users can specify ``.`` in output paths to use relative paths but at the cost of placing the netlists deep in hierarchy when calling openfpga flow scripts.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [x] Added a new option ``--use_relative_path`` to ``write_fabric_verilog`` command. When enabled, all the netlists in the ``fabric_netlist.v`` will contain only relative paths
- [x] Updated documentation
- [ ] Added a new test case to validate the feature and deploy to CI

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
