### PR TITLE
Now Verilog Testbench Generator has a new option ``--use_relative_path``

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
@@ -94,6 +94,10 @@ write_full_testbench
 
     Do not print time stamp in Verilog netlists
 
+  .. option:: --use_relative_path
+
+    Force to use relative path in netlists when including other netlists. By default, this is off, which means that netlists use absolute paths when including other netlists
+
   .. option:: --verbose
 
     Show verbose log

--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_verilog_commands.rst
@@ -192,6 +192,10 @@ write_preconfigured_testbench
 
     Do not print time stamp in Verilog netlists
 
+  .. option:: --use_relative_path
+
+    Force to use relative path in netlists when including other netlists. By default, this is off, which means that netlists use absolute paths when including other netlists
+
   .. option:: --verbose
 
     Show verbose log

--- a/openfpga/src/base/openfpga_verilog.cpp
+++ b/openfpga/src/base/openfpga_verilog.cpp
@@ -197,6 +197,7 @@ int write_preconfigured_testbench(const OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_explicit_port_mapping = cmd.option("explicit_port_mapping");
   CommandOptionId opt_default_net_type = cmd.option("default_net_type");
   CommandOptionId opt_no_time_stamp = cmd.option("no_time_stamp");
+  CommandOptionId opt_use_relative_path = cmd.option("use_relative_path");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
   /* This is an intermediate data structure which is designed to modularize the FPGA-Verilog
@@ -208,6 +209,7 @@ int write_preconfigured_testbench(const OpenfpgaContext& openfpga_ctx,
   options.set_reference_benchmark_file_path(cmd_context.option_value(cmd, opt_reference_benchmark));
   options.set_explicit_port_mapping(cmd_context.option_enable(cmd, opt_explicit_port_mapping));
   options.set_time_stamp(!cmd_context.option_enable(cmd, opt_no_time_stamp));
+  options.set_use_relative_path(cmd_context.option_enable(cmd, opt_use_relative_path));
   options.set_verbose_output(cmd_context.option_enable(cmd, opt_verbose));
   options.set_print_preconfig_top_testbench(true);
   if (true == cmd_context.option_enable(cmd, opt_default_net_type)) {

--- a/openfpga/src/base/openfpga_verilog.cpp
+++ b/openfpga/src/base/openfpga_verilog.cpp
@@ -85,6 +85,7 @@ int write_full_testbench(const OpenfpgaContext& openfpga_ctx,
   CommandOptionId opt_default_net_type = cmd.option("default_net_type");
   CommandOptionId opt_include_signal_init = cmd.option("include_signal_init");
   CommandOptionId opt_no_time_stamp = cmd.option("no_time_stamp");
+  CommandOptionId opt_use_relative_path = cmd.option("use_relative_path");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
   /* This is an intermediate data structure which is designed to modularize the FPGA-Verilog
@@ -98,6 +99,7 @@ int write_full_testbench(const OpenfpgaContext& openfpga_ctx,
   options.set_explicit_port_mapping(cmd_context.option_enable(cmd, opt_explicit_port_mapping));
   options.set_verbose_output(cmd_context.option_enable(cmd, opt_verbose));
   options.set_time_stamp(!cmd_context.option_enable(cmd, opt_no_time_stamp));
+  options.set_use_relative_path(cmd_context.option_enable(cmd, opt_use_relative_path));
   options.set_print_top_testbench(true);
   options.set_include_signal_init(cmd_context.option_enable(cmd, opt_include_signal_init));
   if (true == cmd_context.option_enable(cmd, opt_default_net_type)) {

--- a/openfpga/src/base/openfpga_verilog_command.cpp
+++ b/openfpga/src/base/openfpga_verilog_command.cpp
@@ -224,6 +224,9 @@ ShellCommandId add_openfpga_write_preconfigured_testbench_command(openfpga::Shel
   /* Add an option '--no_time_stamp' */
   shell_cmd.add_option("no_time_stamp", false, "Do not print a time stamp in the output files");
 
+  /* Add an option '--use_relative_path' */
+  shell_cmd.add_option("use_relative_path", false, "Force to use relative path in netlists when including other netlists");
+
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Enable verbose output");
   

--- a/openfpga/src/base/openfpga_verilog_command.cpp
+++ b/openfpga/src/base/openfpga_verilog_command.cpp
@@ -112,6 +112,9 @@ ShellCommandId add_openfpga_write_full_testbench_command(openfpga::Shell<Openfpg
   /* Add an option '--no_time_stamp' */
   shell_cmd.add_option("no_time_stamp", false, "Do not print a time stamp in the output files");
 
+  /* Add an option '--use_relative_path' */
+  shell_cmd.add_option("use_relative_path", false, "Force to use relative path in netlists when including other netlists");
+
   /* add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "enable verbose output");
   

--- a/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
+++ b/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
@@ -101,10 +101,10 @@ void print_verilog_fabric_include_netlist(const NetlistManager& netlist_manager,
  * that have been generated and user-defined.
  * Some netlists are open to compile under specific preprocessing flags
  *******************************************************************/
-void print_verilog_full_testbench_include_netlists(const std::string& src_dir,
+void print_verilog_full_testbench_include_netlists(const std::string& src_dir_path,
                                                    const std::string& circuit_name,
                                                    const VerilogTestbenchOption& options) {
-  std::string verilog_fname = src_dir + circuit_name + std::string(TOP_VERILOG_TESTBENCH_INCLUDE_NETLIST_FILE_NAME_POSTFIX);
+  std::string verilog_fname = src_dir_path + circuit_name + std::string(TOP_VERILOG_TESTBENCH_INCLUDE_NETLIST_FILE_NAME_POSTFIX);
   std::string fabric_netlist_file = options.fabric_netlist_file_path();
   std::string reference_benchmark_file = options.reference_benchmark_file_path();
   bool no_self_checking = options.no_self_checking();
@@ -118,6 +118,12 @@ void print_verilog_full_testbench_include_netlists(const std::string& src_dir,
 
   /* Print the title */
   print_verilog_file_header(fp, std::string("Netlist Summary"), options.time_stamp()); 
+
+  /* If relative path is forced, we do not include an src_dir_path in the netlist */
+  std::string src_dir = src_dir_path;
+  if (options.use_relative_path()) {
+    src_dir.clear();
+  }
 
   /* Include FPGA top module */
   print_verilog_comment(fp, std::string("------ Include fabric top-level netlists -----"));

--- a/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
+++ b/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.cpp
@@ -154,10 +154,10 @@ void print_verilog_full_testbench_include_netlists(const std::string& src_dir_pa
  * that have been generated and user-defined.
  * Some netlists are open to compile under specific preprocessing flags
  *******************************************************************/
-void print_verilog_preconfigured_testbench_include_netlists(const std::string& src_dir,
+void print_verilog_preconfigured_testbench_include_netlists(const std::string& src_dir_path,
                                                             const std::string& circuit_name,
                                                             const VerilogTestbenchOption& options) {
-  std::string verilog_fname = src_dir + circuit_name + std::string(TOP_VERILOG_TESTBENCH_INCLUDE_NETLIST_FILE_NAME_POSTFIX);
+  std::string verilog_fname = src_dir_path + circuit_name + std::string(TOP_VERILOG_TESTBENCH_INCLUDE_NETLIST_FILE_NAME_POSTFIX);
   std::string fabric_netlist_file = options.fabric_netlist_file_path();
   std::string reference_benchmark_file = options.reference_benchmark_file_path();
   bool no_self_checking = options.no_self_checking();
@@ -171,6 +171,12 @@ void print_verilog_preconfigured_testbench_include_netlists(const std::string& s
 
   /* Print the title */
   print_verilog_file_header(fp, std::string("Netlist Summary"), options.time_stamp()); 
+
+  /* If relative path is forced, we do not include an src_dir_path in the netlist */
+  std::string src_dir = src_dir_path;
+  if (options.use_relative_path()) {
+    src_dir.clear();
+  }
 
   /* Include FPGA top module */
   print_verilog_comment(fp, std::string("------ Include fabric top-level netlists -----"));

--- a/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.h
+++ b/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.h
@@ -23,7 +23,7 @@ void print_verilog_fabric_include_netlist(const NetlistManager& netlist_manager,
                                           const bool& use_relative_path,
                                           const bool& include_time_stamp);
 
-void print_verilog_full_testbench_include_netlists(const std::string& src_dir,
+void print_verilog_full_testbench_include_netlists(const std::string& src_dir_path,
                                                    const std::string& circuit_name,
                                                    const VerilogTestbenchOption& options);
 

--- a/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.h
+++ b/openfpga/src/fpga_verilog/verilog_auxiliary_netlists.h
@@ -27,7 +27,7 @@ void print_verilog_full_testbench_include_netlists(const std::string& src_dir_pa
                                                    const std::string& circuit_name,
                                                    const VerilogTestbenchOption& options);
 
-void print_verilog_preconfigured_testbench_include_netlists(const std::string& src_dir,
+void print_verilog_preconfigured_testbench_include_netlists(const std::string& src_dir_path,
                                                             const std::string& circuit_name,
                                                             const VerilogTestbenchOption& options);
 

--- a/openfpga/src/fpga_verilog/verilog_testbench_options.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_options.cpp
@@ -26,6 +26,7 @@ VerilogTestbenchOption::VerilogTestbenchOption() {
   embedded_bitstream_hdl_type_ = EMBEDDED_BITSTREAM_HDL_MODELSIM;
   time_unit_ = 1E-3;
   time_stamp_ = true;
+  use_relative_path_ = false;
   verbose_output_ = false;
 }
 
@@ -94,6 +95,10 @@ e_embedded_bitstream_hdl_type VerilogTestbenchOption::embedded_bitstream_hdl_typ
 
 bool VerilogTestbenchOption::time_stamp() const {
   return time_stamp_;
+}
+
+bool VerilogTestbenchOption::use_relative_path() const {
+  return use_relative_path_;
 }
 
 bool VerilogTestbenchOption::verbose_output() const {
@@ -191,9 +196,12 @@ void VerilogTestbenchOption::set_time_unit(const float& time_unit) {
   time_unit_ = time_unit;
 }
 
-
 void VerilogTestbenchOption::set_time_stamp(const bool& enabled) {
   time_stamp_ = enabled;
+}
+
+void VerilogTestbenchOption::set_use_relative_path(const bool& enabled) {
+  use_relative_path_ = enabled;
 }
 
 void VerilogTestbenchOption::set_verbose_output(const bool& enabled) {

--- a/openfpga/src/fpga_verilog/verilog_testbench_options.h
+++ b/openfpga/src/fpga_verilog/verilog_testbench_options.h
@@ -48,6 +48,7 @@ class VerilogTestbenchOption {
     e_embedded_bitstream_hdl_type embedded_bitstream_hdl_type() const;
     float time_unit() const;
     bool time_stamp() const;
+    bool use_relative_path() const;
     bool verbose_output() const;
   public: /* Public validator */
     bool validate() const;
@@ -75,6 +76,7 @@ class VerilogTestbenchOption {
     void set_time_unit(const float& time_unit);
     void set_embedded_bitstream_hdl_type(const std::string& embedded_bitstream_hdl_type);
     void set_time_stamp(const bool& enabled);
+    void set_use_relative_path(const bool& enabled);
     void set_verbose_output(const bool& enabled);
   private: /* Internal Data */
     std::string output_directory_;
@@ -92,6 +94,7 @@ class VerilogTestbenchOption {
     e_embedded_bitstream_hdl_type embedded_bitstream_hdl_type_;
     float time_unit_;
     bool time_stamp_;
+    bool use_relative_path_;
     bool verbose_output_;
 };
 

--- a/openfpga_flow/openfpga_shell_scripts/preconfigured_testbench_relative_path_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/preconfigured_testbench_relative_path_example_script.openfpga
@@ -56,7 +56,7 @@ write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --pri
 #  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
 #  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
 write_preconfigured_fabric_wrapper --embed_bitstream iverilog --file ./SRC  --explicit_port_mapping 
-write_preconfigured_testbench --file . --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --use_relative_path --fabric_netlist_file_path ./SRC/fabric_netlists.v 
+write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --use_relative_path #--fabric_netlist_file_path ./SRC/fabric_netlists.v 
 
 # Write the SDC files for PnR backend
 #  - Turn on every options here

--- a/openfpga_flow/openfpga_shell_scripts/preconfigured_testbench_relative_path_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/preconfigured_testbench_relative_path_example_script.openfpga
@@ -1,0 +1,75 @@
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling route
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to clustering nets based on routing results
+pb_pin_fixup --verbose
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enable pin duplication on grid modules
+build_fabric --compress_routing #--verbose
+
+# Write the fabric hierarchy of module graph to a file
+# This is used by hierarchical PnR flows
+write_fabric_hierarchy --file ./fabric_hierarchy.txt
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose
+
+# Write fabric-dependent bitstream
+write_fabric_bitstream --file fabric_bitstream.bit --format plain_text
+
+# Write the Verilog netlist for FPGA fabric
+#  - Enable the use of explicit port mapping in Verilog netlist
+write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --print_user_defined_template --verbose
+
+# Write the Verilog testbench for FPGA fabric
+#  - We suggest the use of same output directory as fabric Verilog netlists
+#  - Must specify the reference benchmark file if you want to output any testbenches
+#  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
+#  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
+#  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
+write_preconfigured_fabric_wrapper --embed_bitstream iverilog --file ./SRC  --explicit_port_mapping 
+write_preconfigured_testbench --file . --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --use_relative_path --fabric_netlist_file_path ./SRC/fabric_netlists.v 
+
+# Write the SDC files for PnR backend
+#  - Turn on every options here
+write_pnr_sdc --file ./SDC
+
+# Write SDC to disable timing for configure ports
+write_sdc_disable_timing_configure_ports --file ./SDC/disable_configure_ports.sdc
+
+# Write the SDC to run timing analysis for a mapped FPGA fabric
+write_analysis_sdc --file ./SDC_analysis
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -146,3 +146,4 @@ run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_modelsim --debug -
 
 echo -e "Testing the netlist generation by forcing the use of relative paths";
 run-task fpga_verilog/verilog_netlist_formats/use_relative_path --debug --show_thread_logs
+run-task fpga_verilog/verilog_netlist_formats/preconfig_testbench_use_relative_path --debug --show_thread_logs

--- a/openfpga_flow/scripts/run_fpga_flow.py
+++ b/openfpga_flow/scripts/run_fpga_flow.py
@@ -842,6 +842,9 @@ def run_netlists_verification(exit_if_fail=True):
         command += [tb_top_formal]
     else:
         command += [tb_top_autochecked]
+    # TODO: This is NOT flexible!!! We should consider to make the include directory customizable through options
+    # Add source directory to the include dir
+    command += ["-I", "./SRC"]
     run_command("iverilog_verification", "iverilog_output.txt", command)
 
     vvp_command = ["vvp", compiled_file]

--- a/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/preconfig_testbench_use_relative_path/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/verilog_netlist_formats/preconfig_testbench_use_relative_path/config/task.conf
@@ -1,0 +1,37 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/preconfigured_testbench_relative_path_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #509 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- The option ``--use_relative_path`` only covers fabric netlist generator
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Add a new option ``--use_relative_path`` to verilog testbench generator
- [x] Update documentation about the new option
- [x] Added a new test case to validate the new feature

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
