### PR TITLE
Fixed a bug in task run when removing previous runs

### DIFF
--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -190,22 +190,23 @@ def generate_each_task_actions(taskname):
         clean_up_and_exit(
             "Missing configuration file for task %s" % curr_task_dir)
 
-    # Create run directory for current task run ./runxxx
-    run_dirs = [int(os.path.basename(x)[-3:]) for x in glob.glob('run*[0-9]')]
-    curr_run_dir = "run%03d" % (max(run_dirs+[0, ])+1)
     if args.remove_run_dir:
         remove_run_dir()
-    try:
-        os.mkdir(curr_run_dir)
-        if os.path.islink('latest') or os.path.exists('latest'):
-            os.remove("latest")
-        os.symlink(curr_run_dir, "latest")
-        logger.info('Created "%s" directory for current task run' %
-                    curr_run_dir)
-    except:
-        logger.exception("")
-        logger.error("Failed to create new run directory in task directory")
-    os.chdir(curr_run_dir)
+    else:
+      # Create run directory for current task run ./runxxx
+      run_dirs = [int(os.path.basename(x)[-3:]) for x in glob.glob('run*[0-9]')]
+      curr_run_dir = "run%03d" % (max(run_dirs+[0, ])+1)
+      try:
+          os.mkdir(curr_run_dir)
+          if os.path.islink('latest') or os.path.exists('latest'):
+              os.remove("latest")
+          os.symlink(curr_run_dir, "latest")
+          logger.info('Created "%s" directory for current task run' %
+                      curr_run_dir)
+      except:
+          logger.exception("")
+          logger.error("Failed to create new run directory in task directory")
+      os.chdir(curr_run_dir)
 
     # Read task configuration file and check consistency
     task_conf = ConfigParser(allow_no_value=True,


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
- When deleting previous run directories, the current script ``openfpga_task.py`` always creates a new directory based on previous run ids

```
~/OpenFPGA$ run-task benchmark_sweep/counter8 --debug --show_thread_logs --remove_run_dir all
 INFO (     MainThread) - Setting loggger in debug mode
 INFO (     MainThread) - Set up to run 2 Parallel threads
 INFO (     MainThread) - Currently running task benchmark_sweep/counter8
 INFO (     MainThread) - Removing run_dir run001
 INFO (     MainThread) - Removing run_dir run002
 INFO (     MainThread) - Removing run_dir latest
 INFO (     MainThread) - Created "run003" directory for current task run
 INFO (     MainThread) - Running "yosys_vpr" flow
 INFO (     MainThread) - Found 1 Architectures 3 Benchmarks & 1 Script Parameters
 INFO (     MainThread) - Created total 3 jobs
 INFO (     MainThread) - Task execution completed
```
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Fixed this bug. Now removing previous runs should only remove directories

```
tangxifan@DESKTOP-HDQJM3M:~/OpenFPGA$ run-task benchmark_sweep/counter8 --debug --show_thread_logs --remove_run_dir all
 INFO (     MainThread) - Setting loggger in debug mode
 INFO (     MainThread) - Set up to run 2 Parallel threads
 INFO (     MainThread) - Currently running task benchmark_sweep/counter8
 INFO (     MainThread) - Removing run_dir run001
 INFO (     MainThread) - Removing run_dir latest
 INFO (     MainThread) - Task execution completed
```

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
