### PR TITLE
More tests on Bus support: Validate its correctness on Input buses

### DIFF
--- a/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_explicit_mapping/config/mac4_bus_group.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_explicit_mapping/config/mac4_bus_group.xml
@@ -1,0 +1,26 @@
+<bus_group>
+  <bus name="a[3:0]" big_endian="false">
+    <pin id="0" name="a_0_"/>
+    <pin id="1" name="a_1_"/>
+    <pin id="2" name="a_2_"/>
+    <pin id="3" name="a_3_"/>
+  </bus>
+  <bus name="b[3:0]" big_endian="false">
+    <pin id="0" name="b_0_"/>
+    <pin id="1" name="b_1_"/>
+    <pin id="2" name="b_2_"/>
+    <pin id="3" name="b_3_"/>
+  </bus>
+  <bus name="c[3:0]" big_endian="false">
+    <pin id="0" name="c_0_"/>
+    <pin id="1" name="c_1_"/>
+    <pin id="2" name="c_2_"/>
+    <pin id="3" name="c_3_"/>
+  </bus>
+  <bus name="out[3:0]" big_endian="false">
+    <pin id="0" name="out_0_"/>
+    <pin id="1" name="out_1_"/>
+    <pin id="2" name="out_2_"/>
+    <pin id="3" name="out_3_"/>
+  </bus>
+</bus_group>

--- a/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_explicit_mapping/config/pin_constraints_dummy.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_explicit_mapping/config/pin_constraints_dummy.xml
@@ -1,0 +1,5 @@
+<pin_constraints>
+  <!-- A dummy pin constraints file
+    -->
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_explicit_mapping/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_explicit_mapping/config/task.conf
@@ -20,13 +20,13 @@ openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scrip
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_verilog_port_mapping=--explicit_port_mapping
-openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
 
 [BENCHMARKS]
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_8bit_async_reset/counter.v
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_4/mac_4.v
 
 [SYNTHESIS_PARAM]
 # Yosys script parameters
@@ -42,6 +42,11 @@ bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosy
 
 bench0_top = counter
 bench0_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+bench0_openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
+
+bench1_top = mac_4
+bench1_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_dummy.xml
+bench1_openfpga_bus_group_file=${PATH:TASK_DIR}/config/mac4_bus_group.xml
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
 end_flow_with_test=

--- a/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_implicit_mapping/config/mac4_bus_group.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_implicit_mapping/config/mac4_bus_group.xml
@@ -1,0 +1,26 @@
+<bus_group>
+  <bus name="a[3:0]" big_endian="false">
+    <pin id="0" name="a_0_"/>
+    <pin id="1" name="a_1_"/>
+    <pin id="2" name="a_2_"/>
+    <pin id="3" name="a_3_"/>
+  </bus>
+  <bus name="b[3:0]" big_endian="false">
+    <pin id="0" name="b_0_"/>
+    <pin id="1" name="b_1_"/>
+    <pin id="2" name="b_2_"/>
+    <pin id="3" name="b_3_"/>
+  </bus>
+  <bus name="c[3:0]" big_endian="false">
+    <pin id="0" name="c_0_"/>
+    <pin id="1" name="c_1_"/>
+    <pin id="2" name="c_2_"/>
+    <pin id="3" name="c_3_"/>
+  </bus>
+  <bus name="out[3:0]" big_endian="false">
+    <pin id="0" name="out_0_"/>
+    <pin id="1" name="out_1_"/>
+    <pin id="2" name="out_2_"/>
+    <pin id="3" name="out_3_"/>
+  </bus>
+</bus_group>

--- a/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_implicit_mapping/config/pin_constraints_dummy.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_implicit_mapping/config/pin_constraints_dummy.xml
@@ -1,0 +1,5 @@
+<pin_constraints>
+  <!-- A dummy pin constraints file
+    -->
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_implicit_mapping/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/bus_group/full_testbench_implicit_mapping/config/task.conf
@@ -20,13 +20,13 @@ openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scrip
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_verilog_port_mapping=
-openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
 
 [BENCHMARKS]
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_8bit_async_reset/counter.v
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_4/mac_4.v
 
 [SYNTHESIS_PARAM]
 # Yosys script parameters
@@ -42,6 +42,11 @@ bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosy
 
 bench0_top = counter
 bench0_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+bench0_openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
+
+bench1_top = mac_4
+bench1_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_dummy.xml
+bench1_openfpga_bus_group_file=${PATH:TASK_DIR}/config/mac4_bus_group.xml
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
 end_flow_with_test=

--- a/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/mac4_bus_group.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/mac4_bus_group.xml
@@ -1,0 +1,26 @@
+<bus_group>
+  <bus name="a[3:0]" big_endian="false">
+    <pin id="0" name="a_0_"/>
+    <pin id="1" name="a_1_"/>
+    <pin id="2" name="a_2_"/>
+    <pin id="3" name="a_3_"/>
+  </bus>
+  <bus name="b[3:0]" big_endian="false">
+    <pin id="0" name="b_0_"/>
+    <pin id="1" name="b_1_"/>
+    <pin id="2" name="b_2_"/>
+    <pin id="3" name="b_3_"/>
+  </bus>
+  <bus name="c[3:0]" big_endian="false">
+    <pin id="0" name="c_0_"/>
+    <pin id="1" name="c_1_"/>
+    <pin id="2" name="c_2_"/>
+    <pin id="3" name="c_3_"/>
+  </bus>
+  <bus name="out[3:0]" big_endian="false">
+    <pin id="0" name="out_0_"/>
+    <pin id="1" name="out_1_"/>
+    <pin id="2" name="out_2_"/>
+    <pin id="3" name="out_3_"/>
+  </bus>
+</bus_group>

--- a/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/pin_constraints_dummy.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/pin_constraints_dummy.xml
@@ -1,0 +1,5 @@
+<pin_constraints>
+  <!-- A dummy pin constraints file
+    -->
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/task.conf
@@ -45,7 +45,7 @@ bench0_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_res
 bench0_openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
 
 bench1_top = mac_4
-bench1_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+bench1_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_dummy.xml
 bench1_openfpga_bus_group_file=${PATH:TASK_DIR}/config/mac4_bus_group.xml
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]

--- a/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_explicit_mapping/config/task.conf
@@ -20,13 +20,13 @@ openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scrip
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_verilog_port_mapping=--explicit_port_mapping
-openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
 
 [BENCHMARKS]
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_8bit_async_reset/counter.v
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_4/mac_4.v
 
 [SYNTHESIS_PARAM]
 # Yosys script parameters
@@ -42,6 +42,11 @@ bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosy
 
 bench0_top = counter
 bench0_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+bench0_openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
+
+bench1_top = mac_4
+bench1_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+bench1_openfpga_bus_group_file=${PATH:TASK_DIR}/config/mac4_bus_group.xml
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
 end_flow_with_test=

--- a/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_implicit_mapping/config/mac4_bus_group.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_implicit_mapping/config/mac4_bus_group.xml
@@ -1,0 +1,26 @@
+<bus_group>
+  <bus name="a[3:0]" big_endian="false">
+    <pin id="0" name="a_0_"/>
+    <pin id="1" name="a_1_"/>
+    <pin id="2" name="a_2_"/>
+    <pin id="3" name="a_3_"/>
+  </bus>
+  <bus name="b[3:0]" big_endian="false">
+    <pin id="0" name="b_0_"/>
+    <pin id="1" name="b_1_"/>
+    <pin id="2" name="b_2_"/>
+    <pin id="3" name="b_3_"/>
+  </bus>
+  <bus name="c[3:0]" big_endian="false">
+    <pin id="0" name="c_0_"/>
+    <pin id="1" name="c_1_"/>
+    <pin id="2" name="c_2_"/>
+    <pin id="3" name="c_3_"/>
+  </bus>
+  <bus name="out[3:0]" big_endian="false">
+    <pin id="0" name="out_0_"/>
+    <pin id="1" name="out_1_"/>
+    <pin id="2" name="out_2_"/>
+    <pin id="3" name="out_3_"/>
+  </bus>
+</bus_group>

--- a/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_implicit_mapping/config/pin_constraints_dummy.xml
+++ b/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_implicit_mapping/config/pin_constraints_dummy.xml
@@ -1,0 +1,5 @@
+<pin_constraints>
+  <!-- A dummy pin constraints file
+    -->
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_implicit_mapping/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/bus_group/preconfig_testbench_implicit_mapping/config/task.conf
@@ -20,13 +20,13 @@ openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scrip
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_verilog_port_mapping=
-openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
 
 [BENCHMARKS]
 bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_8bit_async_reset/counter.v
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/mac/mac_4/mac_4.v
 
 [SYNTHESIS_PARAM]
 # Yosys script parameters
@@ -42,6 +42,11 @@ bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosy
 
 bench0_top = counter
 bench0_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+bench0_openfpga_bus_group_file=${PATH:TASK_DIR}/config/counter8_bus_group.xml
+
+bench1_top = mac_4
+bench1_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_dummy.xml
+bench1_openfpga_bus_group_file=${PATH:TASK_DIR}/config/mac4_bus_group.xml
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
 end_flow_with_test=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #360 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
- Only output buses are validated in regression tests
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- Validate input buses are validated in regression tests
- Validate that bus group file can be customized for each benchmark in task configuration file

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
