### PR TITLE
fix openfpga_digest functions to work on WIN32(MinGW-w64-g++) 

### DIFF
--- a/libopenfpga/libopenfpgautil/src/openfpga_digest.cpp
+++ b/libopenfpga/libopenfpgautil/src/openfpga_digest.cpp
@@ -49,13 +49,14 @@ void check_file_stream(const char* fname,
 std::string format_dir_path(const std::string& dir_path_to_format) {
   std::string formatted_dir_path = dir_path_to_format;
 
-  char illegal_back_slash = '\\';
-  char legal_back_slash = '/';
 
 #ifdef _WIN32
 /* For windows OS, replace any '/' with '\' */
   char illegal_back_slash = '/';
   char legal_back_slash = '\\';
+#else
+  char illegal_back_slash = '\\';
+  char legal_back_slash = '/';
 #endif
 
   /* Return an empty string if the input is empty */
@@ -81,11 +82,12 @@ std::string format_dir_path(const std::string& dir_path_to_format) {
  ********************************************************************/
 std::string find_path_file_name(const std::string& file_name) {
 
-  char back_slash = '/';
 
 #ifdef _WIN32
 /* For windows OS, replace any '/' with '\' */
   char back_slash = '\\';
+#else
+  char back_slash = '/';
 #endif 
 
   /* Find the last '/' in the string and return the left part */
@@ -104,11 +106,12 @@ std::string find_path_file_name(const std::string& file_name) {
  ********************************************************************/
 std::string find_path_dir_name(const std::string& file_name) {
 
-  char back_slash = '/';
 
 #ifdef _WIN32
 /* For windows OS, replace any '/' with '\' */
   char back_slash = '\\';
+#else
+  char back_slash = '/';
 #endif 
 
   /* Find the last '/' in the string and return the left part */
@@ -133,7 +136,11 @@ bool create_dir_path(const std::string& dir_path,
   }
 
   /* Try to create a directory */
+#ifdef _WIN32
+  int ret = mkdir(dir_path.c_str());
+#else  
   int ret = mkdir(dir_path.c_str(), S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH);
+#endif
 
   /* Analyze the return flag and output status */
   switch (ret) {
@@ -182,11 +189,12 @@ bool rec_create_dir_path(const std::string& dir_path) {
   /* Try to find the positions of all the slashes
    * which are the splitter between directories
    */
-  char back_slash = '/';
 
 #ifdef _WIN32
 /* For windows OS, replace any '/' with '\' */
   char back_slash = '\\';
+#else
+  char back_slash = '/';
 #endif 
 
   std::vector<size_t> slash_pos; 


### PR DESCRIPTION
… as Linux

> ### Motivate of the pull request
Add support for OpenFPGA build on Windows 10 with MinGW-w64-g++
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
Windows build for OpenFPGA fails only because of the redeclaration of variables in libopenfpga/libopenfpgautil/src/openfpga_digest.cpp
Fixing this will not change Linux behavior, but will enable Windows support as well.
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
Add Windows MinGW-w64 build support for OpenFPGA
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

library: `libopenfpga/libopenfpgautil`

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.

This PR should not affect existing use cases, but only serve to add Windows build support.
