### PR TITLE
Add support for (MinGW gcc) Windows build

### DIFF
--- a/libopenfpga/libarchopenfpga/src/arch_direct.h
+++ b/libopenfpga/libarchopenfpga/src/arch_direct.h
@@ -2,6 +2,7 @@
 #define ARCH_DIRECT_H
 
 #include <map>
+#include <array>
 
 #include "vtr_vector.h"
 #include "vtr_geometry.h"

--- a/libs/libvtrutil/src/vtr_small_vector.h
+++ b/libs/libvtrutil/src/vtr_small_vector.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <limits>
 #include <cstdint>
+#include <array>
 #include "vtr_assert.h"
 
 namespace vtr {

--- a/vpr/src/place/place.cpp
+++ b/vpr/src/place/place.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <memory>
 #include <fstream>
+#include <cstring>
 
 #include "vtr_assert.h"
 #include "vtr_log.h"


### PR DESCRIPTION
> ### Motivate of the pull request
Add support for OpenFPGA build on Windows 10/11 with MinGW-w64-g++

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Windows build for OpenFPGA fails only because of the non inclusion of header files, that MinGW gcc cannot automatically pick.
Fixing this will not change Linux behavior, but will enable Windows support as well.

> #### What does this pull request change?
Add header includes where needed.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
This should have no impact on the current code.
