### PR TITLE
fix format_ptc_num() issues

### DIFF
--- a/vpr/src/base/read_route.cpp
+++ b/vpr/src/base/read_route.cpp
@@ -423,7 +423,7 @@ static void format_ptc_num(std::vector<int>& ptc_nums, std::string ptc_str, Clus
     // detect and remove the parenthesis
     openfpga::StringToken tokenizer0(ptc_str);
     std::vector<std::string> tokens0 = tokenizer0.split(',');
-    size_t ptc_count = tokens0.size() + 1;
+    size_t ptc_count = tokens0.size();
     openfpga::StringToken tokenizer1(ptc_count > 1? format_name(ptc_str) : ptc_str);
 
     // now do the real job
@@ -431,6 +431,7 @@ static void format_ptc_num(std::vector<int>& ptc_nums, std::string ptc_str, Clus
     std::stringstream ptc_stream;
     int num;
     for (size_t i = 0; i < tokens1.size(); i++) {
+        ptc_stream.clear();
         ptc_stream << tokens1[i];
         ptc_stream >> num;
         if (ptc_stream.fail()) {


### PR DESCRIPTION

> ### Motivate of the pull request
Fix issues with the reworked format_ptc_num() function:
- off by one error after split with delimiter
- reusing same stringstream for multiple string to int conversions (clear before using again)

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
reworked format_ptc_num() function has some issues.

> #### What does this pull request change?
fix the logic in format_ptc_num() 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] VPR `read_route.cpp`
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
It does not look like it will impact existing cases, but requires review.