### PR TITLE
VPR: netlist writer: sdf: don't escape '[' and ']' chars for black boxes

### DIFF
--- a/vpr/src/base/netlist_writer.cpp
+++ b/vpr/src/base/netlist_writer.cpp
@@ -696,12 +696,12 @@ class BlackBoxInst : public Instance {
                     os << indent(depth + 3) << "(IOPATH ";
                     os << escape_sdf_identifier(arc.source_name());
                     if (find_port_size(arc.source_name()) > 1) {
-                        os << "\\[" << arc.source_ipin() << "\\]";
+                        os << "[" << arc.source_ipin() << "]";
                     }
                     os << " ";
                     os << escape_sdf_identifier(arc.sink_name());
                     if (find_port_size(arc.sink_name()) > 1) {
-                        os << "\\[" << arc.sink_ipin() << "\\]";
+                        os << "[" << arc.sink_ipin() << "]";
                     }
                     os << " ";
                     os << delay_triple.str();


### PR DESCRIPTION
Signed-off-by: Pawel Czarnecki <pczarnecki@antmicro.com>

> ### Motivate of the pull request
> - [x] To address an existing issue.

In https://github.com/lnis-uofu/OpenFPGA/pull/700 I accidentally introduced unnecessary escapes to SDF writer for black box module instances. This caused inconsistency between simulation models and generated sdf files in simulations.

This PR fixes this by removing escapes.

> ### Which part of the code base require a change
> - [x] VPR
