### PR TITLE
Now .act file is no longer required in openfpga_flow/task when power analysis option is off

### DIFF
--- a/docs/source/manual/openfpga_flow/run_fpga_task.rst
+++ b/docs/source/manual/openfpga_flow/run_fpga_task.rst
@@ -206,6 +206,8 @@ Synthesis Parameter Sections
     In case of running ``blif_vpr_flow`` this option provides the activity files
     to be used to generate testbench for ``bench_label`` benchmark
 
+.. note:: This file is required only when the ``power_analysis`` option in the general section is enabled. Otherwise, it is optional
+
 .. option:: bench<bench_label>_verilog=<source_verilog_file_path>
 
     In case of running ``blif_vpr_flow`` with verification this option provides

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -88,6 +88,7 @@ run-task basic_tests/custom_fabric_netlist_location $@
 
 echo -e "Testing user-defined simulation settings: clock frequency and number of cycles";
 run-task basic_tests/fixed_simulation_settings/fixed_operating_clock_freq $@
+run-task basic_tests/fixed_simulation_settings/fixed_operating_clock_freq_no_ace $@
 # TODO: This feature is temporarily out of test due to the emergency in delivering netlists for multi-chain shift-register memory bank
 #run-task basic_tests/fixed_simulation_settings/fixed_shift_register_clock_freq $@
 

--- a/openfpga_flow/scripts/run_fpga_flow.py
+++ b/openfpga_flow/scripts/run_fpga_flow.py
@@ -722,7 +722,9 @@ def collect_files_for_vpr():
       if not os.path.isfile(args.activity_file or ""):
           logger.error("Activity File - %s" % args.activity_file)
           clean_up_and_exit("Provided activity file not found")
-      shutil.copy(args.activity_file, args.top_module+"_ace_out.act")
+    else:
+      if os.path.isfile(args.activity_file):
+        shutil.copy(args.activity_file, args.top_module+"_ace_out.act")
 
     # Sanitize provided Benchmark option
     if not os.path.isfile(args.base_verilog or ""):

--- a/openfpga_flow/scripts/run_fpga_flow.py
+++ b/openfpga_flow/scripts/run_fpga_flow.py
@@ -411,8 +411,9 @@ def validate_command_line_arguments():
 
     # Expand run directory to absolute path
     args.run_dir = os.path.abspath(args.run_dir)
-    if args.activity_file:
-        args.activity_file = os.path.abspath(args.activity_file)
+    if args.power:
+      if args.activity_file:
+          args.activity_file = os.path.abspath(args.activity_file)
     if args.base_verilog:
         args.base_verilog = os.path.abspath(args.base_verilog)
 
@@ -717,10 +718,11 @@ def collect_files_for_vpr():
     shutil.copy(args.benchmark_files[0], args.top_module+".blif")
 
     # Sanitize provided Activity file option
-    if not os.path.isfile(args.activity_file or ""):
-        logger.error("Activity File - %s" % args.activity_file)
-        clean_up_and_exit("Provided activity file not found")
-    shutil.copy(args.activity_file, args.top_module+"_ace_out.act")
+    if args.power:
+      if not os.path.isfile(args.activity_file or ""):
+          logger.error("Activity File - %s" % args.activity_file)
+          clean_up_and_exit("Provided activity file not found")
+      shutil.copy(args.activity_file, args.top_module+"_ace_out.act")
 
     # Sanitize provided Benchmark option
     if not os.path.isfile(args.base_verilog or ""):
@@ -736,6 +738,7 @@ def run_openfpga_shell():
                          encoding='utf-8').read())
 
     path_variables = script_env_vars["PATH"]
+    path_variables["TOP_MODULE"] = args.top_module
     path_variables["VPR_ARCH_FILE"] = args.arch_file
     path_variables["OPENFPGA_ARCH_FILE"] = args.openfpga_arch_file
     path_variables["VPR_TESTBENCH_BLIF"] = args.top_module+".blif"

--- a/openfpga_flow/scripts/run_fpga_flow.py
+++ b/openfpga_flow/scripts/run_fpga_flow.py
@@ -722,6 +722,7 @@ def collect_files_for_vpr():
       if not os.path.isfile(args.activity_file or ""):
           logger.error("Activity File - %s" % args.activity_file)
           clean_up_and_exit("Provided activity file not found")
+      shutil.copy(args.activity_file, args.top_module+"_ace_out.act")
     else:
       if os.path.isfile(args.activity_file):
         shutil.copy(args.activity_file, args.top_module+"_ace_out.act")

--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -317,11 +317,15 @@ def generate_each_task_actions(taskname):
                 CurrBenchPara["benchVariable"] += [f"--{param}", value]
 
         if GeneralSection.get("fpga_flow") == "vpr_blif":
-            # Check if activity file exist
-            if not SynthSection.get(bech_name+"_act"):
-                clean_up_and_exit("Missing argument %s" % (bech_name+"_act") +
-                                  "for vpr_blif flow")
-            CurrBenchPara["activity_file"] = SynthSection.get(bech_name+"_act")
+            # Check if activity file exist only when power analysis is required
+            if (GeneralSection.getboolean("power_analysis")):
+                if not SynthSection.get(bech_name+"_act"):
+                    clean_up_and_exit("Missing argument %s" % (bech_name+"_act") +
+                                      "for vpr_blif flow")
+                CurrBenchPara["activity_file"] = SynthSection.get(bech_name+"_act")
+            else:
+                # Send a dummy act
+                CurrBenchPara["activity_file"] = bech_name+"_act"
 
             # Check if base verilog file exists
             if not SynthSection.get(bech_name+"_verilog"):

--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -324,8 +324,11 @@ def generate_each_task_actions(taskname):
                                       "for vpr_blif flow")
                 CurrBenchPara["activity_file"] = SynthSection.get(bech_name+"_act")
             else:
-                # Send a dummy act
-                CurrBenchPara["activity_file"] = bech_name+"_act"
+                # If users defined an acitivity file, we use it otherwise create a dummy act
+                if not SynthSection.get(bech_name+"_act"):
+                  CurrBenchPara["activity_file"] = bech_name+"_act"
+                else:
+                  CurrBenchPara["activity_file"] = SynthSection.get(bech_name+"_act")
 
             # Check if base verilog file exists
             if not SynthSection.get(bech_name+"_verilog"):

--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -324,7 +324,7 @@ def generate_each_task_actions(taskname):
                                       "for vpr_blif flow")
                 CurrBenchPara["activity_file"] = SynthSection.get(bech_name+"_act")
             else:
-                # If users defined an acitivity file, we use it otherwise create a dummy act
+                # If users defined an activity file, we use it otherwise create a dummy act
                 if not SynthSection.get(bech_name+"_act"):
                   CurrBenchPara["activity_file"] = bech_name+"_act"
                 else:

--- a/openfpga_flow/tasks/basic_tests/fixed_simulation_settings/fixed_operating_clock_freq_no_ace/config/pin_constraints.xml
+++ b/openfpga_flow/tasks/basic_tests/fixed_simulation_settings/fixed_operating_clock_freq_no_ace/config/pin_constraints.xml
@@ -1,0 +1,4 @@
+<pin_constraints>
+  <!-- A dummy pin constraints -->
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/fixed_simulation_settings/fixed_operating_clock_freq_no_ace/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/fixed_simulation_settings/fixed_operating_clock_freq_no_ace/config/task.conf
@@ -1,0 +1,36 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/example_without_ace_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_fixed_sim_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #401 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Removed the requirements where .act file is already checked when even power analysis option is off in a task configuration file.
- [x] Now variable ${TOP_MODULE} in template scripts of openfpga shell can be replaced by the top-level module name defined in task configuration file.
- [x] Added a dedicated testcase to validate the correctness

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [x] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
