### PR TITLE
add <array> declaration to fix gcc error

### DIFF
--- a/openfpga/src/annotation/rr_gsb_writer_option.cpp
+++ b/openfpga/src/annotation/rr_gsb_writer_option.cpp
@@ -2,6 +2,7 @@
  * Memember functions for data structure RRGSBWriterOption
  ******************************************************************************/
 #include <map>
+#include <array>
 #include "vtr_assert.h"
 #include "vtr_log.h"
 


### PR DESCRIPTION
> ### Motivate of the pull request
Add support for OpenFPGA build on Windows 10/11 with MinGW-w64-g++

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Windows build for OpenFPGA fails only because of the non inclusion of header files, that MinGW gcc cannot automatically pick.
Fixing this will not change Linux behavior, but will enable Windows support as well.

> #### What does this pull request change?
Add header includes where needed.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
This should have no impact on the current code.
