### PR TITLE
Test reset signal from a global network to drive an LUT input

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/fpga_bitstream_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/fpga_bitstream_commands.rst
@@ -24,6 +24,14 @@ Repack's functionality are in the following aspects:
     See details in :ref:`file_formats_repack_design_constraints`.
   
   .. warning:: Design constraints are designed to help repacker to identify which clock net to be mapped to which pin, so that multi-clock benchmarks can be correctly implemented, in the case that VPR may not have sufficient vision on clock net mapping. **Try not to use design constraints to remap any other types of nets!!!**
+
+  .. option:: --ignore_global_nets_on_pins
+
+    Specify the mapping results of global nets should be ignored on which pins of a ``pb_type``. For example, ``--ignore_global_nets_on_pins clb.I[0:11]``. Once specified, the mapping results on the pins for all the global nets, such as clock, reset *etc.*, are ignored. Routing traces will be appeneded to other pins where the same global nets are mapped to. 
+  
+  .. note:: This option is designed for global nets which are applied to both data path and global networks. For example, a reset signal is mapped to both a LUT input and the reset pin of a FF. Suggest not to use the option in other purposes!
+
+  .. warning:: Users must specify the size/width of the pin. Currently, OpenFPGA cannot infer the pin size from the architecture!!!
      
   .. option:: --verbose 
   

--- a/openfpga/src/base/openfpga_bitstream_command.cpp
+++ b/openfpga/src/base/openfpga_bitstream_command.cpp
@@ -21,9 +21,15 @@ ShellCommandId add_openfpga_repack_command(openfpga::Shell<OpenfpgaContext>& she
                                            const ShellCommandClassId& cmd_class_id,
                                            const std::vector<ShellCommandId>& dependent_cmds) {
   Command shell_cmd("repack");
+
   /* Add an option '--design_constraints' */
   CommandOptionId opt_design_constraints = shell_cmd.add_option("design_constraints", false, "file path to the design constraints");
   shell_cmd.set_option_require_value(opt_design_constraints, openfpga::OPT_STRING);
+
+  /* Add an option '--ignore_global_nets_on_pins' */
+  CommandOptionId opt_ignore_global_nets = shell_cmd.add_option("ignore_global_nets_on_pins", false, "Specify the pins where global nets will be ignored. Routing traces are merged to other pins");
+  shell_cmd.set_option_require_value(opt_ignore_global_nets, openfpga::OPT_STRING);
+
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Enable verbose output");
   

--- a/openfpga/src/repack/repack.h
+++ b/openfpga/src/repack/repack.h
@@ -9,8 +9,8 @@
 #include "vpr_clustering_annotation.h"
 #include "vpr_routing_annotation.h"
 #include "vpr_bitstream_annotation.h"
-#include "repack_design_constraints.h"
 #include "circuit_library.h"
+#include "repack_option.h"
 
 /********************************************************************
  * Function declaration
@@ -25,9 +25,8 @@ void pack_physical_pbs(const DeviceContext& device_ctx,
                        VprDeviceAnnotation& device_annotation,
                        VprClusteringAnnotation& clustering_annotation,
                        const VprBitstreamAnnotation& bitstream_annotation,
-                       const RepackDesignConstraints& design_constraints,
                        const CircuitLibrary& circuit_lib,
-                       const bool& verbose);
+                       const RepackOption& options);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/repack/repack_option.cpp
+++ b/openfpga/src/repack/repack_option.cpp
@@ -1,0 +1,120 @@
+/******************************************************************************
+ * Memember functions for data structure RepackOption
+ ******************************************************************************/
+#include <map>
+#include <array>
+#include "vtr_assert.h"
+#include "vtr_log.h"
+
+#include "repack_option.h"
+#include "openfpga_tokenizer.h"
+#include "openfpga_port_parser.h"
+
+/* begin namespace openfpga */
+namespace openfpga {
+
+/**************************************************
+ * Public Constructors
+ *************************************************/
+RepackOption::RepackOption() {
+  verbose_output_ = false;
+  num_parse_errors_ = 0;
+}
+
+/**************************************************
+ * Public Accessors 
+ *************************************************/
+RepackDesignConstraints RepackOption::design_constraints() const {
+  return design_constraints_;
+}
+
+bool RepackOption::is_pin_ignore_global_nets(const std::string& pb_type_name, const BasicPort& pin) const {
+  auto result = ignore_global_nets_on_pins_.find(pb_type_name);
+  if (result == ignore_global_nets_on_pins_.end()) {
+    /* Not found, return false */
+    return false;
+  } else {
+    /* If the pin is contained by the ignore list, return true */
+    for (BasicPort existing_port : result->second) {
+      if (existing_port.mergeable(pin) && existing_port.contained(pin)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool RepackOption::verbose_output() const {
+  return verbose_output_;
+}
+
+/******************************************************************************
+ * Private Mutators
+ ******************************************************************************/
+void RepackOption::set_design_constraints(const RepackDesignConstraints& design_constraints) {
+  design_constraints_ = design_constraints;
+}
+
+void RepackOption::set_ignore_global_nets_on_pins(const std::string& content) {
+  num_parse_errors_ = 0;
+  /* Split the content using a tokenizer */
+  StringToken tokenizer(content);
+  std::vector<std::string> tokens = tokenizer.split(',');
+
+  /* Parse each token */
+  for (std::string token : tokens) {
+    /* Extract the pb_type name and port name */
+    StringToken pin_tokenizer(token);
+    std::vector<std::string> pin_info = pin_tokenizer.split('.');
+    /* Expect two contents, otherwise error out */
+    if (pin_info.size() != 2) {
+      std::string err_msg = std::string("Invalid content '") + token + std::string("' to skip, expect <pb_type_name>.<pin>");
+      VTR_LOG_ERROR(err_msg.c_str());
+      num_parse_errors_++;
+      continue;
+    }
+    std::string pb_type_name = pin_info[0]; 
+    PortParser port_parser(pin_info[1]);
+    BasicPort curr_port = port_parser.port();
+    if (!curr_port.is_valid()) {
+      std::string err_msg = std::string("Invalid pin definition '") + token + std::string("', expect <pb_type_name>.<pin_name>[int:int]");
+      VTR_LOG_ERROR(err_msg.c_str());
+      num_parse_errors_++;
+      continue;
+    }
+   
+    /* Check if the existing port already in the ignore list or not */
+    auto result = ignore_global_nets_on_pins_.find(pb_type_name);
+    if (result == ignore_global_nets_on_pins_.end()) {
+      /* Not found, push the port */
+      result->second.push_back(curr_port);
+    } else {
+      /* Already a list of ports. Check one by one. 
+       * - It already contained, do nothing but throw a warning. 
+       * - If we can merge, merge it.
+       * - Otherwise, create it */
+      for (BasicPort existing_port : result->second) {
+        if (existing_port.mergeable(curr_port)) {
+          if (!existing_port.contained(curr_port)) {
+            result->second.push_back(curr_port);
+          }
+        } else {
+          result->second.push_back(curr_port);
+        }
+      }
+    }
+  }
+}
+
+void RepackOption::set_verbose_output(const bool& enabled) {
+  verbose_output_ = enabled;
+}
+
+bool RepackOption::valid() const {
+  if (num_parse_errors_) {
+    return false;
+  }
+  return true;
+}
+
+} /* end namespace openfpga */

--- a/openfpga/src/repack/repack_option.h
+++ b/openfpga/src/repack/repack_option.h
@@ -1,0 +1,52 @@
+#ifndef REPACK_OPTION_H
+#define REPACK_OPTION_H
+
+/********************************************************************
+ * Include header files required by the data structure definition
+ *******************************************************************/
+#include <string>
+#include <vector>
+#include "repack_design_constraints.h"
+
+/* Begin namespace openfpga */
+namespace openfpga {
+
+/********************************************************************
+ * Options for RRGSB writer
+ *******************************************************************/
+class RepackOption {
+  public: /* Public constructor */
+    /* Set default options */
+    RepackOption();
+  public: /* Public accessors */
+    RepackDesignConstraints design_constraints() const;
+    /* Identify if a pin should ignore all the global nets */
+    bool is_pin_ignore_global_nets(const std::string& pb_type_name, const BasicPort& pin) const;
+    bool verbose_output() const;
+  public: /* Public mutators */
+    void set_design_constraints(const RepackDesignConstraints& design_constraints);
+    void set_ignore_global_nets_on_pins(const std::string& content); 
+    void set_verbose_output(const bool& enabled);
+  public: /* Public validators */
+    /* Check if the following internal data is valid or not:
+     * - no parsing errors
+     */
+    bool valid() const;
+  private: /* Internal Data */
+    RepackDesignConstraints design_constraints_;
+    /* The pin information on which global nets should be mapped to: [pb_type_name][0..num_ports]
+     * For example: 
+     * - clb.I[0:1], clb.I[5:6] -> ["clb"][BasicPort(I, 0, 1), BasicPort(I, 5, 6)]
+     * - clb.I[0:1], clb.I[2:6] -> ["clb"][BasicPort(I, 0, 6)]
+     */
+    std::map<std::string, std::vector<BasicPort>> ignore_global_nets_on_pins_;
+
+    bool verbose_output_;
+
+    /* A flag to indicate if the data parse is invalid or not */
+    int num_parse_errors_;
+};
+
+} /* End namespace openfpga*/
+
+#endif

--- a/openfpga_flow/benchmarks/micro_benchmark/rst_on_lut/rst_on_lut.v
+++ b/openfpga_flow/benchmarks/micro_benchmark/rst_on_lut/rst_on_lut.v
@@ -1,0 +1,23 @@
+/////////////////////////////////////////
+//  Functionality: A register driven by a combinational logic with reset signal
+//  Author:        Xifan Tang
+////////////////////////////////////////
+`timescale 1ns / 1ps
+
+module rst_on_lut(a, b, out, clk, rst);
+
+input wire rst;
+input wire clk;
+input wire a;
+input wire b;
+output reg out;
+
+always @(rst or posedge clk) begin
+  if (rst) begin
+    out <= 0;
+  end else begin
+    out <= a & b & rst;
+  end
+end
+
+endmodule

--- a/openfpga_flow/benchmarks/micro_benchmark/rst_on_lut/rst_on_lut.v
+++ b/openfpga_flow/benchmarks/micro_benchmark/rst_on_lut/rst_on_lut.v
@@ -4,20 +4,23 @@
 ////////////////////////////////////////
 `timescale 1ns / 1ps
 
-module rst_on_lut(a, b, out, clk, rst);
+module rst_on_lut(a, b, q, out, clk, rst);
 
 input wire rst;
 input wire clk;
 input wire a;
 input wire b;
-output reg out;
+output reg q;
+output wire out;
 
 always @(posedge rst or posedge clk) begin
   if (rst) begin
-    out <= 0;
+    q <= 0;
   end else begin
-    out <= a & b & rst;
+    q <= a;
   end
 end
+
+assign out = b & ~rst;
 
 endmodule

--- a/openfpga_flow/benchmarks/micro_benchmark/rst_on_lut/rst_on_lut.v
+++ b/openfpga_flow/benchmarks/micro_benchmark/rst_on_lut/rst_on_lut.v
@@ -12,7 +12,7 @@ input wire a;
 input wire b;
 output reg out;
 
-always @(rst or posedge clk) begin
+always @(posedge rst or posedge clk) begin
   if (rst) begin
     out <= 0;
   end else begin

--- a/openfpga_flow/openfpga_shell_scripts/ignore_global_nets_on_pins_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/ignore_global_nets_on_pins_example_script.openfpga
@@ -1,0 +1,76 @@
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling ideal
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to clustering nets based on routing results
+pb_pin_fixup --verbose
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enable pin duplication on grid modules
+build_fabric --compress_routing #--verbose
+
+# Write the fabric hierarchy of module graph to a file
+# This is used by hierarchical PnR flows
+write_fabric_hierarchy --file ./fabric_hierarchy.txt
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack --ignore_global_nets_on_pins clb.I #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose
+
+# Write fabric-dependent bitstream
+write_fabric_bitstream --file fabric_bitstream.bit --format plain_text
+
+# Write the Verilog netlist for FPGA fabric
+#  - Enable the use of explicit port mapping in Verilog netlist
+write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --print_user_defined_template --verbose
+
+# Write the Verilog testbench for FPGA fabric
+#  - We suggest the use of same output directory as fabric Verilog netlists
+#  - Must specify the reference benchmark file if you want to output any testbenches
+#  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
+#  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
+#  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --pin_constraints_file ${OPENFPGA_PIN_CONSTRAINTS_FILE} --bitstream fabric_bitstream.bit
+write_preconfigured_fabric_wrapper --embed_bitstream iverilog --file ./SRC  --pin_constraints_file ${OPENFPGA_PIN_CONSTRAINTS_FILE}
+write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --pin_constraints_file ${OPENFPGA_PIN_CONSTRAINTS_FILE} 
+
+# Write the SDC files for PnR backend
+#  - Turn on every options here
+write_pnr_sdc --file ./SDC
+
+# Write SDC to disable timing for configure ports
+write_sdc_disable_timing_configure_ports --file ./SDC/disable_configure_ports.sdc
+
+# Write the SDC to run timing analysis for a mapped FPGA fabric
+write_analysis_sdc --file ./SDC_analysis
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/openfpga_flow/openfpga_shell_scripts/ignore_global_nets_on_pins_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/ignore_global_nets_on_pins_example_script.openfpga
@@ -33,7 +33,7 @@ write_fabric_hierarchy --file ./fabric_hierarchy.txt
 # Repack the netlist to physical pbs
 # This must be done before bitstream generator and testbench generation
 # Strongly recommend it is done after all the fix-up have been applied
-repack --ignore_global_nets_on_pins clb.I #--verbose
+repack --ignore_global_nets_on_pins clb.I[0:11] #--verbose
 
 # Build the bitstream
 #  - Output the fabric-independent bitstream to a file

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -129,6 +129,8 @@ echo -e "Testing K4N5 with pattern based local routing";
 run-task basic_tests/k4_series/k4n5_pattern_local_routing $@
 echo -e "Testing K4N4 with custom I/O location syntax";
 run-task basic_tests/k4_series/k4n4_custom_io_loc $@
+echo -e "Testing K4N4 with a local routing where reset can driven LUT inputs";
+run-task basic_tests/k4_series/k4n4_rstOnLut $@
 
 echo -e "Testing different tile organizations";
 echo -e "Testing tiles with pins only on top and left sides";

--- a/openfpga_flow/tasks/basic_tests/k4_series/k4n4_rstOnLut/config/pin_constraints_reset.xml
+++ b/openfpga_flow/tasks/basic_tests/k4_series/k4n4_rstOnLut/config/pin_constraints_reset.xml
@@ -1,0 +1,7 @@
+<pin_constraints>
+  <!-- For a given .blif file, we want to assign 
+       - the reset signal to the op_reset[0] port of the FPGA fabric
+    -->
+  <set_io pin="op_reset[0]" net="rst"/>
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/k4_series/k4n4_rstOnLut/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/k4_series/k4n4_rstOnLut/config/task.conf
@@ -16,7 +16,7 @@ timeout_each_job = 3*60
 fpga_flow=yosys_vpr
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/example_without_ace_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/ignore_global_nets_on_pins_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_fracff_40nm_cc_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 

--- a/openfpga_flow/tasks/basic_tests/k4_series/k4n4_rstOnLut/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/k4_series/k4n4_rstOnLut/config/task.conf
@@ -1,0 +1,42 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 3*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/example_without_ace_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_fracff_40nm_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_rstOnLut_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/rst_on_lut/rst_on_lut.v
+
+[SYNTHESIS_PARAM]
+# Yosys script parameters
+bench_yosys_cell_sim_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_sim.v
+bench_yosys_dff_map_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_map.v
+bench_read_verilog_options_common = -nolatches
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
+bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys
+
+bench0_top = rst_on_lut
+bench0_openfpga_pin_constraints_file = ${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/vpr_arch/README.md
+++ b/openfpga_flow/vpr_arch/README.md
@@ -22,6 +22,7 @@ Please reveal the following architecture features in the names to help quickly s
 - reduced\_io: If I/Os only appear a certain or multiple sides of FPGAs 
 - registerable\_io: If I/Os are registerable (can be either combinational or sequential)
 - CustomIoLoc: Use OpenFPGA's extended custom I/O location syntax
+- rstOnLut: The reset signal of CLB can feed LUT inputs through a local routing architecture
 - <feature\_size>: The technology node which the delay numbers are extracted from.
 - TileOrgz<Type>: How tile is organized. 
   * Top-left (Tl): the pins of a tile are placed on the top side and left side only

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_rstOnLut_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_rstOnLut_40nm.xml
@@ -1,0 +1,627 @@
+<!-- 
+  Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 4, N = 4, fracturable 4 LUTs (can operate as one 4-LUT or two 3-LUTs with all 3 inputs shared) 
+    with optionally registered outputs
+  - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
+
+  Authors: Xifan Tang
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dff">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+   <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffrn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="RN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+         If you need to register the I/O, define clocks in the circuit models
+         These clocks can be handled in back-end
+     -->
+    <tile name="io" capacity="8" area="0">
+      <equivalent_sites>
+        <site pb_type="io"/>
+      </equivalent_sites>
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+      <pinlocations pattern="custom">
+        <loc side="left">io.outpad io.inpad</loc>
+        <loc side="top">io.outpad io.inpad</loc>
+        <loc side="right">io.outpad io.inpad</loc>
+        <loc side="bottom">io.outpad io.inpad</loc>
+      </pinlocations>
+    </tile>
+    <tile name="clb" area="53894">
+      <equivalent_sites>
+        <site pb_type="clb"/>
+      </equivalent_sites>
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+        <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+      </fc>
+      <pinlocations pattern="spread"/>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	       book area formula. This means the mux transistors are about 5x minimum drive strength.
+	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+	       2.5x when looking up in Jeff's tables.
+	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+           If you need to register the I/O, define clocks in the circuit models
+           These clocks can be handled in back-end
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="reset" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
+             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+             The outputs of the fracturable logic element can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">
+              <input name="D" num_pins="1" port_class="D"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="C" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="C"/>
+              <T_setup value="66e-12" port="ff.R" clock="C"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>
+              <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct4" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <input name="reset" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                           we instead take the average of these numbers to get more stable results
+                      82e-12
+                      173e-12
+                      261e-12
+                      263e-12
+                      398e-12
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  235e-12
+                  235e-12
+                  235e-12
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" num_pb="1">
+                <input name="D" num_pins="1"/>
+                <input name="R" num_pins="1"/>
+                <output name="Q" num_pins="1"/>
+                <clock name="C" num_pins="1"/>
+                <mode name="latch">
+                  <pb_type name="latch" blif_model=".latch" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                  </pb_type> 
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="latch.D"/>
+                    <direct name="direct2" input="ff.C" output="latch.clk"/>
+                    <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dff">
+                  <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dff.D" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                  </pb_type> 
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dff.D"/>
+                    <direct name="direct2" input="ff.C" output="dff.C"/>
+                    <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffr">
+                  <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="R" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                  </pb_type> 
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffr.D"/>
+                    <direct name="direct2" input="ff.C" output="dffr.C"/>
+                    <direct name="direct3" input="ff.R" output="dffr.R"/>
+                    <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffrn">
+                  <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="RN" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                  </pb_type> 
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                    <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                    <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                    <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+              </pb_type> 
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>
+                <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+              <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+            <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  398e-12
+                  397e-12
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                261e-12
+                261e-12
+                261e-12
+                261e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define the flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type> 
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type> 
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type> 
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type> 
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type> 
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.C"/>
+              <direct name="direct4" input="ble4.reset" output="ff.R"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+            <direct name="direct4" input="fle.reset" output="ble4.reset"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+		     The delays below come from Stratix IV. the delay through a connection block
+		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+		     delay within the crossbar is 95 ps. 
+		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out clb.reset" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I clb.reset" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[3:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+               naive specification).
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
+</architecture>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Added a benchmark where reset signal drive both an LUT input and a FF. With this, we can test if the repacker can connect the reset signal from a global network (drive FF reset ports through a dedicated network) to an LUT input through a local routing architecture 
- [x] Added a test case to validate this feature; Deployed the test case to basic regression test
- [x] Now ``repack`` command has a new option ``--ignore_global_nets_on_pin <pin_name>``, to merge the routing traces of global nets on the specified pin, e.g., ``clb.I``, into the routing traces on other pin, .e.g., ``clb.reset``, which is not in the ignore list.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [x] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
