### PR TITLE
Support I/Os in the center of the FPGA fabric

### DIFF
--- a/openfpga/src/fabric/build_fabric_io_location_map.cpp
+++ b/openfpga/src/fabric/build_fabric_io_location_map.cpp
@@ -28,6 +28,8 @@ namespace openfpga {
 /********************************************************************
  * Find all the GPIO ports in the grid module
  * and cache their port/pin index in the top-level module
+ *
+ * .. note:: The I/O sequence(indexing) is already determined in the io_children() list of top-level module. Here we just build a fast lookup from (x, y, z) coordinate to the actual indices
  *******************************************************************/
 IoLocationMap build_fabric_io_location_map(const ModuleManager& module_manager,
                                            const DeviceGrid& grids) {
@@ -37,132 +39,61 @@ IoLocationMap build_fabric_io_location_map(const ModuleManager& module_manager,
 
   std::map<std::string, size_t> io_counter;
 
-  /* Create the coordinate range for each side of FPGA fabric */
-  std::map<e_side, std::vector<vtr::Point<size_t>>> io_coordinates = generate_perimeter_grid_coordinates( grids);
+  std::string top_module_name = generate_fpga_top_module_name();
+  ModuleId top_module = module_manager.find_module(top_module_name);
+  VTR_ASSERT(true == module_manager.valid_module_id(top_module));
 
-  /* Walk through all the grids on the perimeter, which are I/O grids */
-  for (const e_side& io_side : FPGA_SIDES_CLOCKWISE) {
-    for (const vtr::Point<size_t>& io_coordinate : io_coordinates[io_side]) {
-      /* Bypass EMPTY grid */
-      if (true == is_empty_type(grids[io_coordinate.x()][io_coordinate.y()].type)) {
-        continue;
-      } 
+  /* Walk through the I/O child list */
+  for (size_t ichild = 0; ichild < module_manager.io_children(top_module).size(); ++ichild) {
+    ModuleId child = module_manager.io_children(top_module)[ichild];
+    vtr::Point<int> coord = module_manager.io_child_coordinates(top_module)[ichild];
 
-      /* Skip width or height > 1 tiles (mostly heterogeneous blocks) */
-      if ( (0 < grids[io_coordinate.x()][io_coordinate.y()].width_offset)
-        || (0 < grids[io_coordinate.x()][io_coordinate.y()].height_offset)) {
-        continue;
-      }
+    /* Bypass EMPTY grid */
+    if (true == is_empty_type(grids[coord.x()][coord.y()].type)) {
+      continue;
+    } 
 
-      t_physical_tile_type_ptr grid_type = grids[io_coordinate.x()][io_coordinate.y()].type;
-
-      /* Find the module name for this type of grid */
-      std::string grid_module_name_prefix(GRID_MODULE_NAME_PREFIX);
-      std::string grid_module_name = generate_grid_block_module_name(grid_module_name_prefix, std::string(grid_type->name), is_io_type(grid_type), io_side);
-      ModuleId grid_module = module_manager.find_module(grid_module_name);
-      VTR_ASSERT(true == module_manager.valid_module_id(grid_module));
-
-      /* Find all the GPIO ports in the grid module */
-
-      /* MUST DO: register in io location mapping!
-       * I/O location mapping is a critical look-up for testbench generators
-       * As we add the I/O grid instances to top module by following order:
-       * TOP -> RIGHT -> BOTTOM -> LEFT
-       * The I/O index will increase in this way as well.
-       * This organization I/O indices is also consistent to the way 
-       * that GPIOs are wired in function connect_gpio_module()
-       *
-       * Note: if you change the GPIO function, you should update here as well!
-       */
-      for (int z = 0; z < grids[io_coordinate.x()][io_coordinate.y()].type->capacity; ++z) {
-        for (const ModuleManager::e_module_port_type& module_io_port_type : MODULE_IO_PORT_TYPES) {
-          for (const ModulePortId& gpio_port_id : module_manager.module_port_ids_by_type(grid_module, module_io_port_type)) {
-            /* Only care mappable I/O */
-            if (false == module_manager.port_is_mappable_io(grid_module, gpio_port_id)) {
-              continue;
-            }
-
-            const BasicPort& gpio_port = module_manager.module_port(grid_module, gpio_port_id);
-
-            auto curr_io_index = io_counter.find(gpio_port.get_name());
-            /* Index always start from zero */
-            if (curr_io_index == io_counter.end()) {
-              io_counter[gpio_port.get_name()] = 0;
-            }
-            io_location_map.set_io_index(io_coordinate.x(), io_coordinate.y(), z,
-                                         gpio_port.get_name(),
-                                         io_counter[gpio_port.get_name()]);
-            io_counter[gpio_port.get_name()]++;
-          }
-        }
-      }
+    /* Skip width or height > 1 tiles (mostly heterogeneous blocks) */
+    if ( (0 < grids[coord.x()][coord.y()].width_offset)
+      || (0 < grids[coord.x()][coord.y()].height_offset)) {
+      continue;
     }
-  }
 
-  /* Walk through all the center grids, which may include I/O grids */
-  for (size_t ix = 1; ix < grids.width() - 1; ++ix) {
-    for (size_t iy = 1; iy < grids.height() - 1; ++iy) {
-      /* Bypass EMPTY grid */
-      if (true == is_empty_type(grids[ix][iy].type)) {
-        continue;
-      } 
+    VTR_ASSERT_SAFE(true == module_manager.valid_module_id(child));
 
-      /* Skip width or height > 1 tiles (mostly heterogeneous blocks) */
-      if ( (0 < grids[ix][iy].width_offset)
-        || (0 < grids[ix][iy].height_offset)) {
-        continue;
-      }
+    /* Find all the GPIO ports in the grid module */
 
-      t_physical_tile_type_ptr grid_type = grids[ix][iy].type;
+    /* MUST DO: register in io location mapping!
+     * I/O location mapping is a critical look-up for testbench generators
+     */
+    VTR_ASSERT(size_t(grids[coord.x()][coord.y()].type->capacity) == module_manager.io_children(child).size());
+    for (size_t isubchild = 0; isubchild < module_manager.io_children(child).size(); ++isubchild) {
+      vtr::Point<int> subchild_coord = module_manager.io_child_coordinates(child)[isubchild];
 
-      /* Find the module name for this type of grid */
-      std::string grid_module_name_prefix(GRID_MODULE_NAME_PREFIX);
-      std::string grid_module_name = generate_grid_block_module_name(grid_module_name_prefix, std::string(grid_type->name), is_io_type(grid_type), NUM_SIDES);
-      ModuleId grid_module = module_manager.find_module(grid_module_name);
-      VTR_ASSERT(true == module_manager.valid_module_id(grid_module));
-
-      /* Find all the GPIO ports in the grid module */
-
-      /* MUST DO: register in io location mapping!
-       * I/O location mapping is a critical look-up for testbench generators
-       * As we add the I/O grid instances to top module by following order:
-       * TOP -> RIGHT -> BOTTOM -> LEFT
-       * The I/O index will increase in this way as well.
-       * This organization I/O indices is also consistent to the way 
-       * that GPIOs are wired in function connect_gpio_module()
-       *
-       * Note: if you change the GPIO function, you should update here as well!
-       */
-      for (int z = 0; z < grids[ix][iy].type->capacity; ++z) {
-        for (const ModuleManager::e_module_port_type& module_io_port_type : MODULE_IO_PORT_TYPES) {
-          for (const ModulePortId& gpio_port_id : module_manager.module_port_ids_by_type(grid_module, module_io_port_type)) {
-            /* Only care mappable I/O */
-            if (false == module_manager.port_is_mappable_io(grid_module, gpio_port_id)) {
-              continue;
-            }
-
-            const BasicPort& gpio_port = module_manager.module_port(grid_module, gpio_port_id);
-
-            auto curr_io_index = io_counter.find(gpio_port.get_name());
-            /* Index always start from zero */
-            if (curr_io_index == io_counter.end()) {
-              io_counter[gpio_port.get_name()] = 0;
-            }
-            io_location_map.set_io_index(ix, iy, z,
-                                         gpio_port.get_name(),
-                                         io_counter[gpio_port.get_name()]);
-            io_counter[gpio_port.get_name()]++;
+      for (const ModuleManager::e_module_port_type& module_io_port_type : MODULE_IO_PORT_TYPES) {
+        for (const ModulePortId& gpio_port_id : module_manager.module_port_ids_by_type(child, module_io_port_type)) {
+          /* Only care mappable I/O */
+          if (false == module_manager.port_is_mappable_io(child, gpio_port_id)) {
+            continue;
           }
+
+          const BasicPort& gpio_port = module_manager.module_port(child, gpio_port_id);
+
+          auto curr_io_index = io_counter.find(gpio_port.get_name());
+          /* Index always start from zero */
+          if (curr_io_index == io_counter.end()) {
+            io_counter[gpio_port.get_name()] = 0;
+          }
+          io_location_map.set_io_index(coord.x(), coord.y(), subchild_coord.x(),
+                                       gpio_port.get_name(),
+                                       io_counter[gpio_port.get_name()]);
+          io_counter[gpio_port.get_name()]++;
         }
       }
     }
   }
 
   /* Check all the GPIO ports in the top-level module has been mapped */
-  std::string top_module_name = generate_fpga_top_module_name();
-  ModuleId top_module = module_manager.find_module(top_module_name);
-  VTR_ASSERT(true == module_manager.valid_module_id(top_module));
-
   for (const ModuleManager::e_module_port_type& module_io_port_type : MODULE_IO_PORT_TYPES) {
     for (const ModulePortId& gpio_port_id : module_manager.module_port_ids_by_type(top_module, module_io_port_type)) {
       /* Only care mappable I/O */

--- a/openfpga/src/fabric/build_fabric_io_location_map.cpp
+++ b/openfpga/src/fabric/build_fabric_io_location_map.cpp
@@ -66,6 +66,9 @@ IoLocationMap build_fabric_io_location_map(const ModuleManager& module_manager,
     /* MUST DO: register in io location mapping!
      * I/O location mapping is a critical look-up for testbench generators
      */
+    if (size_t(grids[coord.x()][coord.y()].type->capacity) != module_manager.io_children(child).size()) {
+      VTR_LOG("%s[%ld][%ld] capacity: %d while io_child number is %d", grids[coord.x()][coord.y()].type->name, coord.x(), coord.y(), grids[coord.x()][coord.y()].type->capacity, module_manager.io_children(child).size());
+    }
     VTR_ASSERT(size_t(grids[coord.x()][coord.y()].type->capacity) == module_manager.io_children(child).size());
     for (size_t isubchild = 0; isubchild < module_manager.io_children(child).size(); ++isubchild) {
       vtr::Point<int> subchild_coord = module_manager.io_child_coordinates(child)[isubchild];

--- a/openfpga/src/fabric/build_grid_modules.cpp
+++ b/openfpga/src/fabric/build_grid_modules.cpp
@@ -1022,7 +1022,9 @@ void build_physical_tile_module(ModuleManager& module_manager,
 
       /* Add all the sub modules */
       size_t pb_instance_id = module_manager.num_instance(grid_module, pb_module);
-      module_manager.add_child_module(grid_module, pb_module);
+      module_manager.add_child_module(grid_module, pb_module, false);
+      /* Add a custom I/O child with coordinate 'z' */
+      module_manager.add_io_child(grid_module, pb_module, pb_instance_id, vtr::Point<int>(iz, 0));
 
       /* Give the child module with a unique instance name */
       std::string instance_name = generate_physical_block_instance_name(lb_type->pb_graph_head->pb_type, iz);

--- a/openfpga/src/fabric/build_top_module.cpp
+++ b/openfpga/src/fabric/build_top_module.cpp
@@ -50,7 +50,8 @@ size_t add_top_module_grid_instance(ModuleManager& module_manager,
   /* Record the instance id */
   size_t grid_instance = module_manager.num_instance(top_module, grid_module);
   /* Add the module to top_module */ 
-  module_manager.add_child_module(top_module, grid_module);
+  module_manager.add_child_module(top_module, grid_module, false);
+  module_manager.add_io_child(top_module, grid_module, grid_instance, vtr::Point<int>(grid_coord.x(), grid_coord.y()));
   /* Set an unique name to the instance
    * Note: it is your risk to gurantee the name is unique!
    */
@@ -205,7 +206,7 @@ vtr::Matrix<size_t> add_top_module_switch_block_instances(ModuleManager& module_
       /* Record the instance id */
       sb_instance_ids[rr_gsb.get_sb_x()][rr_gsb.get_sb_y()] = module_manager.num_instance(top_module, sb_module);
       /* Add the module to top_module */ 
-      module_manager.add_child_module(top_module, sb_module);
+      module_manager.add_child_module(top_module, sb_module, false);
       /* Set an unique name to the instance
        * Note: it is your risk to gurantee the name is unique!
        */
@@ -261,7 +262,7 @@ vtr::Matrix<size_t> add_top_module_connection_block_instances(ModuleManager& mod
       /* Record the instance id */
       cb_instance_ids[rr_gsb.get_cb_x(cb_type)][rr_gsb.get_cb_y(cb_type)] = module_manager.num_instance(top_module, cb_module);
       /* Add the module to top_module */ 
-      module_manager.add_child_module(top_module, cb_module);
+      module_manager.add_child_module(top_module, cb_module, false);
       /* Set an unique name to the instance
        * Note: it is your risk to gurantee the name is unique!
        */
@@ -354,8 +355,7 @@ int build_top_module(ModuleManager& module_manager,
   }
 
   /* Add GPIO ports from the sub-modules under this Verilog module 
-   * This is a much easier job after adding sub modules (instances), 
-   * we just need to find all the I/O ports from the child modules and build a list of it
+   * For top-level module, we follow a special sequencing for I/O modules. So we rebuild the I/O children list here
    */
   add_module_gpio_ports_from_child_modules(module_manager, top_module);
 

--- a/openfpga/src/fabric/build_top_module_directs.cpp
+++ b/openfpga/src/fabric/build_top_module_directs.cpp
@@ -131,7 +131,7 @@ void add_module_nets_tile_direct_connection(ModuleManager& module_manager,
 
   /* Add a submodule of direct connection module to the top-level module */
   size_t direct_instance_id = module_manager.num_instance(top_module, direct_module);
-  module_manager.add_child_module(top_module, direct_module);
+  module_manager.add_child_module(top_module, direct_module, false);
 
   /* Create the 1st module net */
   ModuleNetId net_direct_src = module_manager.create_module_net(top_module); 

--- a/openfpga/src/fabric/build_top_module_memory.cpp
+++ b/openfpga/src/fabric/build_top_module_memory.cpp
@@ -1055,7 +1055,7 @@ void add_top_module_nets_cmos_memory_bank_config_bus(ModuleManager& module_manag
     }
     VTR_ASSERT(ModuleId::INVALID() != bl_decoder_module);
     size_t curr_bl_decoder_instance_id = module_manager.num_instance(top_module, bl_decoder_module);
-    module_manager.add_child_module(top_module, bl_decoder_module);
+    module_manager.add_child_module(top_module, bl_decoder_module, false);
 
     /************************************************************** 
      * Add the WL decoder module 
@@ -1083,7 +1083,7 @@ void add_top_module_nets_cmos_memory_bank_config_bus(ModuleManager& module_manag
     }
     VTR_ASSERT(ModuleId::INVALID() != wl_decoder_module);
     size_t curr_wl_decoder_instance_id = module_manager.num_instance(top_module, wl_decoder_module);
-    module_manager.add_child_module(top_module, wl_decoder_module);
+    module_manager.add_child_module(top_module, wl_decoder_module, false);
 
     /************************************************************** 
      * Add module nets from the top module to BL decoder's inputs
@@ -1531,7 +1531,7 @@ void add_top_module_nets_cmos_memory_frame_decoder_config_bus(ModuleManager& mod
 
   /* Instanciate the decoder module here */
   size_t decoder_instance = module_manager.num_instance(parent_module, decoder_module);
-  module_manager.add_child_module(parent_module, decoder_module);
+  module_manager.add_child_module(parent_module, decoder_module, false);
 
   /* Connect the enable (EN) port of memory modules under the parent module
    * to the frame decoder inputs

--- a/openfpga/src/fabric/build_top_module_memory_bank.cpp
+++ b/openfpga/src/fabric/build_top_module_memory_bank.cpp
@@ -507,7 +507,7 @@ void add_top_module_nets_cmos_ql_memory_bank_bl_decoder_config_bus(ModuleManager
     }
     VTR_ASSERT(ModuleId::INVALID() != bl_decoder_module);
     size_t curr_bl_decoder_instance_id = module_manager.num_instance(top_module, bl_decoder_module);
-    module_manager.add_child_module(top_module, bl_decoder_module);
+    module_manager.add_child_module(top_module, bl_decoder_module, false);
 
     /************************************************************** 
      * Add module nets from the top module to BL decoder's inputs
@@ -705,7 +705,7 @@ void add_top_module_nets_cmos_ql_memory_bank_wl_decoder_config_bus(ModuleManager
     }
     VTR_ASSERT(ModuleId::INVALID() != wl_decoder_module);
     size_t curr_wl_decoder_instance_id = module_manager.num_instance(top_module, wl_decoder_module);
-    module_manager.add_child_module(top_module, wl_decoder_module);
+    module_manager.add_child_module(top_module, wl_decoder_module, false);
 
     /************************************************************** 
      * Add module nets from the top module to WL decoder's inputs 
@@ -1471,7 +1471,7 @@ void add_top_module_nets_cmos_ql_memory_bank_bl_shift_register_config_bus(Module
       VTR_ASSERT(sr_bank_module);
 
       size_t cur_inst = module_manager.num_instance(top_module, sr_bank_module);
-      module_manager.add_child_module(top_module, sr_bank_module);
+      module_manager.add_child_module(top_module, sr_bank_module, false);
 
       sr_banks.link_bl_shift_register_bank_to_module(config_region, sr_bank, sr_bank_module);
       sr_banks.link_bl_shift_register_bank_to_instance(config_region, sr_bank, cur_inst);
@@ -1565,7 +1565,7 @@ void add_top_module_nets_cmos_ql_memory_bank_wl_shift_register_config_bus(Module
       VTR_ASSERT(sr_bank_module);
 
       size_t cur_inst = module_manager.num_instance(top_module, sr_bank_module);
-      module_manager.add_child_module(top_module, sr_bank_module);
+      module_manager.add_child_module(top_module, sr_bank_module, false);
 
       sr_banks.link_wl_shift_register_bank_to_module(config_region, sr_bank, sr_bank_module);
       sr_banks.link_wl_shift_register_bank_to_instance(config_region, sr_bank, cur_inst);

--- a/openfpga/src/utils/module_manager_utils.cpp
+++ b/openfpga/src/utils/module_manager_utils.cpp
@@ -1802,39 +1802,37 @@ void add_module_io_ports_from_child_modules(ModuleManager& module_manager,
   std::vector<BasicPort> gpio_ports_to_add;
   std::vector<bool> mappable_gpio_ports;
 
-  /* Iterate over the child modules */
-  for (const ModuleId& child : module_manager.child_modules(module_id)) {
-    /* Iterate over the child instances */
-    for (size_t i = 0; i < module_manager.num_instance(module_id, child); ++i) {
-      /* Find all the global ports, whose port type is special */
-      for (const ModulePortId& gpio_port_id : module_manager.module_port_ids_by_type(child, module_port_type)) {
-        const BasicPort& gpio_port = module_manager.module_port(child, gpio_port_id);
-        /* If this port is not mergeable, we update the list */
-        bool is_mergeable = false;
-        for (size_t i_gpio_port_to_add = 0; i_gpio_port_to_add < gpio_ports_to_add.size(); ++i_gpio_port_to_add) {
-          BasicPort& gpio_port_to_add = gpio_ports_to_add[i_gpio_port_to_add];
-          if (false == gpio_port_to_add.mergeable(gpio_port)) {
-            continue;
-          }
-          is_mergeable = true;
-          /* Mappable I/O property must match! Mismatch rarely happened
-           * but should error out avoid silent bugs!
-           */
-          VTR_ASSERT(module_manager.port_is_mappable_io(child, gpio_port_id) == mappable_gpio_ports[i_gpio_port_to_add]);
-          /* For mergeable ports, we combine the port
-           * Note: do NOT use the merge() method!
-           * the GPIO ports should be accumulated by the sizes of ports
-           * not by the LSB/MSB range !!! 
-           */
-          gpio_port_to_add.combine(gpio_port);
-          break;
+  /* Iterate over the child modules and instances */
+  for (size_t i = 0; i < module_manager.io_children(module_id).size(); ++i) {
+    ModuleId child = module_manager.io_children(module_id)[i];
+    /* Find all the global ports, whose port type is special */
+    for (const ModulePortId& gpio_port_id : module_manager.module_port_ids_by_type(child, module_port_type)) {
+      const BasicPort& gpio_port = module_manager.module_port(child, gpio_port_id);
+      /* If this port is not mergeable, we update the list */
+      bool is_mergeable = false;
+      for (size_t i_gpio_port_to_add = 0; i_gpio_port_to_add < gpio_ports_to_add.size(); ++i_gpio_port_to_add) {
+        BasicPort& gpio_port_to_add = gpio_ports_to_add[i_gpio_port_to_add];
+        if (false == gpio_port_to_add.mergeable(gpio_port)) {
+          continue;
         }
-        if (false == is_mergeable) {
-          /* Reach here, this is an unique gpio port, update the list */
-          gpio_ports_to_add.push_back(gpio_port);
-          /* If the gpio port is a mappable I/O, we should herit from the child module */
-          mappable_gpio_ports.push_back(module_manager.port_is_mappable_io(child, gpio_port_id));
-        }
+        is_mergeable = true;
+        /* Mappable I/O property must match! Mismatch rarely happened
+         * but should error out avoid silent bugs!
+         */
+        VTR_ASSERT(module_manager.port_is_mappable_io(child, gpio_port_id) == mappable_gpio_ports[i_gpio_port_to_add]);
+        /* For mergeable ports, we combine the port
+         * Note: do NOT use the merge() method!
+         * the GPIO ports should be accumulated by the sizes of ports
+         * not by the LSB/MSB range !!! 
+         */
+        gpio_port_to_add.combine(gpio_port);
+        break;
+      }
+      if (false == is_mergeable) {
+        /* Reach here, this is an unique gpio port, update the list */
+        gpio_ports_to_add.push_back(gpio_port);
+        /* If the gpio port is a mappable I/O, we should herit from the child module */
+        mappable_gpio_ports.push_back(module_manager.port_is_mappable_io(child, gpio_port_id));
       }
     }
   } 
@@ -1854,49 +1852,47 @@ void add_module_io_ports_from_child_modules(ModuleManager& module_manager,
   /* Set up a counter for each type of GPIO port */
   std::vector<size_t> gpio_port_lsb(gpio_ports_to_add.size(), 0);
   /* Add module nets to connect the GPIOs of the module to the GPIOs of the sub module */
-  for (const ModuleId& child : module_manager.child_modules(module_id)) {
-    /* Iterate over the child instances */
-    for (const size_t& child_instance : module_manager.child_module_instances(module_id, child)) {
-      /* Find all the global ports, whose port type is special */
-      for (ModulePortId child_gpio_port_id : module_manager.module_port_ids_by_type(child, module_port_type)) {
-        BasicPort child_gpio_port = module_manager.module_port(child, child_gpio_port_id);
-        /* Find the port with the same name! */
-        for (size_t iport = 0; iport < gpio_ports_to_add.size(); ++iport) {
-          if (false == gpio_ports_to_add[iport].mergeable(child_gpio_port)) {
-            continue;
-          }
-          /* For each pin of the child port, create a net and do wiring */
-          for (const size_t& pin_id : child_gpio_port.pins()) {
-            /* Reach here, it means this is the port we want, create a net and configure its source and sink */
-            /* - For GPIO and GPIN ports
-             *   the source of the net is the current module 
-             *   the sink of the net is the child module
-             * - For GPOUT ports
-             *   the source of the net is the child module
-             *   the sink of the net is the current module 
-             */
-            if ( (ModuleManager::MODULE_GPIO_PORT == module_port_type)
-              || (ModuleManager::MODULE_GPIN_PORT == module_port_type) ) {
-              ModuleNetId net = create_module_source_pin_net(module_manager, module_id, module_id, 0, gpio_port_ids[iport], gpio_port_lsb[iport]); 
-              module_manager.add_module_net_sink(module_id, net, child, child_instance, child_gpio_port_id, pin_id); 
-            } else {
-              VTR_ASSERT(ModuleManager::MODULE_GPOUT_PORT == module_port_type);
-              ModuleNetId net = create_module_source_pin_net(module_manager, module_id, child, child_instance, child_gpio_port_id, pin_id); 
-              module_manager.add_module_net_sink(module_id, net, module_id, 0, gpio_port_ids[iport], gpio_port_lsb[iport]); 
-            }
-            /* Update the LSB counter */
-            gpio_port_lsb[iport]++;
-          }
-          /* We finish for this child gpio port */
-          break;
+  for (size_t i = 0; i < module_manager.io_children(module_id).size(); ++i) {
+    ModuleId child = module_manager.io_children(module_id)[i];
+    size_t child_instance = module_manager.io_child_instances(module_id)[i];
+    /* Find all the global ports, whose port type is special */
+    for (ModulePortId child_gpio_port_id : module_manager.module_port_ids_by_type(child, module_port_type)) {
+      BasicPort child_gpio_port = module_manager.module_port(child, child_gpio_port_id);
+      /* Find the port with the same name! */
+      for (size_t iport = 0; iport < gpio_ports_to_add.size(); ++iport) {
+        if (false == gpio_ports_to_add[iport].mergeable(child_gpio_port)) {
+          continue;
         }
+        /* For each pin of the child port, create a net and do wiring */
+        for (const size_t& pin_id : child_gpio_port.pins()) {
+          /* Reach here, it means this is the port we want, create a net and configure its source and sink */
+          /* - For GPIO and GPIN ports
+           *   the source of the net is the current module 
+           *   the sink of the net is the child module
+           * - For GPOUT ports
+           *   the source of the net is the child module
+           *   the sink of the net is the current module 
+           */
+          if ( (ModuleManager::MODULE_GPIO_PORT == module_port_type)
+            || (ModuleManager::MODULE_GPIN_PORT == module_port_type) ) {
+            ModuleNetId net = create_module_source_pin_net(module_manager, module_id, module_id, 0, gpio_port_ids[iport], gpio_port_lsb[iport]); 
+            module_manager.add_module_net_sink(module_id, net, child, child_instance, child_gpio_port_id, pin_id); 
+          } else {
+            VTR_ASSERT(ModuleManager::MODULE_GPOUT_PORT == module_port_type);
+            ModuleNetId net = create_module_source_pin_net(module_manager, module_id, child, child_instance, child_gpio_port_id, pin_id); 
+            module_manager.add_module_net_sink(module_id, net, module_id, 0, gpio_port_ids[iport], gpio_port_lsb[iport]); 
+          }
+          /* Update the LSB counter */
+          gpio_port_lsb[iport]++;
+        }
+        /* We finish for this child gpio port */
+        break;
       }
     }
   }
 
   /* Check: all the lsb should now match the size of each GPIO port */
   for (size_t iport = 0; iport < gpio_ports_to_add.size(); ++iport) {
-    if (gpio_ports_to_add[iport].get_width() != gpio_port_lsb[iport]) 
     VTR_ASSERT(gpio_ports_to_add[iport].get_width() == gpio_port_lsb[iport]);
   }
 }

--- a/openfpga/src/utils/module_manager_utils.cpp
+++ b/openfpga/src/utils/module_manager_utils.cpp
@@ -1326,7 +1326,7 @@ void add_module_nets_cmos_memory_frame_decoder_config_bus(ModuleManager& module_
 
   /* Instanciate the decoder module here */
   VTR_ASSERT(0 == module_manager.num_instance(parent_module, decoder_module));
-  module_manager.add_child_module(parent_module, decoder_module);
+  module_manager.add_child_module(parent_module, decoder_module, false);
 
   /* Connect the enable (EN) port of memory modules under the parent module
    * to the frame decoder inputs

--- a/openfpga_flow/tasks/basic_tests/k4_series/k4n4_custom_io_loc/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/k4_series/k4n4_custom_io_loc/config/task.conf
@@ -19,7 +19,7 @@ fpga_flow=vpr_blif
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
-openfpga_vpr_device_layout=--device 2x2
+openfpga_vpr_device_layout=--device 4x4
 openfpga_fast_configuration=
 
 [ARCHITECTURES]

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
@@ -43,7 +43,10 @@
       <output name="inpad" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="bottom">io_top[0:3].inpad io_top[0:7].outpad io_top[4:7].inpad</loc>
+        <loc side="top">io_top[0:1].inpad io_top[0:1].outpad</loc>
+        <loc side="right">io_top[3:2].inpad</loc>
+        <loc side="bottom">io_top[4:5].inpad io_top[2:4].outpad</loc>
+        <loc side="left">io_top[6:7].inpad io_top[5:7].outpad</loc>
       </pinlocations>
     </tile>
     <tile name="io_bottom" capacity="6" area="0">
@@ -54,7 +57,10 @@
       <output name="inpad" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="top">io_bottom[0:1].outpad io_bottom[0:3].inpad io_bottom[2:5].outpad io_bottom[4:5].inpad</loc>
+        <loc side="top">io_bottom[0:1].outpad</loc>
+        <loc side="right">io_bottom[2:2].outpad io_bottom[0:3].inpad</loc>
+        <loc side="bottom">io_bottom[3:3].outpad</loc>
+        <loc side="left">io_bottom[4:5].outpad io_bottom[4:5].inpad</loc>
       </pinlocations>
     </tile>
     <tile name="io_left" capacity="4" area="0">
@@ -65,7 +71,10 @@
       <output name="inpad" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="right">io_left.inpad io_left.outpad</loc>
+        <loc side="top">io_left[1:1].inpad io_left[1:1].outpad</loc>
+        <loc side="right">io_left[0:0].inpad io_left[0:0].outpad</loc>
+        <loc side="bottom">io_left[2:2].inpad io_left[2:2].outpad</loc>
+        <loc side="left">io_left[3:3].inpad io_left[3:3].outpad</loc>
       </pinlocations>
     </tile>
     <tile name="io_right" capacity="2" area="0">
@@ -76,7 +85,10 @@
       <output name="inpad" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="left">io_right[1:1].inpad io_right[1:0].outpad io_right[0:0].inpad</loc>
+        <loc side="top">io_right[0:0].inpad</loc>
+        <loc side="right">io_right[1:1].outpad</loc>
+        <loc side="bottom">io_right[0:0].outpad</loc>
+        <loc side="left">io_right[1:1].inpad</loc>
       </pinlocations>
     </tile>
     <tile name="clb" area="53894">

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
@@ -94,61 +94,85 @@
   <!-- Physical descriptions begin -->
   <layout tileable="true">
     <auto_layout aspect_ratio="1.0">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
+      <row type="io_top" starty="H-2" priority="90"/>
+      <row type="io_bottom" starty="1" priority="91"/>
+      <col type="io_left" startx="1" priority="92"/>
+      <col type="io_right" startx="W-2" priority="93"/>
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <row type="EMPTY" starty="0" priority="102"/>
+      <col type="EMPTY" startx="0" priority="103"/>
+      <col type="EMPTY" startx="W-1" priority="104"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </auto_layout>
     <fixed_layout name="2x2" width="4" height="4">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
+      <row type="io_top" starty="H-2" priority="90"/>
+      <row type="io_bottom" starty="1" priority="91"/>
+      <col type="io_left" startx="1" priority="92"/>
+      <col type="io_right" startx="W-2" priority="93"/>
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <row type="EMPTY" starty="0" priority="102"/>
+      <col type="EMPTY" startx="0" priority="103"/>
+      <col type="EMPTY" startx="W-1" priority="104"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </fixed_layout>
     <fixed_layout name="4x4" width="6" height="6">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
+      <row type="io_top" starty="H-2" priority="90"/>
+      <row type="io_bottom" starty="1" priority="91"/>
+      <col type="io_left" startx="1" priority="92"/>
+      <col type="io_right" startx="W-2" priority="93"/>
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <row type="EMPTY" starty="0" priority="102"/>
+      <col type="EMPTY" startx="0" priority="103"/>
+      <col type="EMPTY" startx="W-1" priority="104"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </fixed_layout>
     <fixed_layout name="48x48" width="50" height="50">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
+      <row type="io_top" starty="H-2" priority="90"/>
+      <row type="io_bottom" starty="1" priority="91"/>
+      <col type="io_left" startx="1" priority="92"/>
+      <col type="io_right" startx="W-2" priority="93"/>
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <row type="EMPTY" starty="0" priority="102"/>
+      <col type="EMPTY" startx="0" priority="103"/>
+      <col type="EMPTY" startx="W-1" priority="104"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </fixed_layout>
     <fixed_layout name="72x72" width="74" height="74">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
+      <row type="io_top" starty="H-2" priority="90"/>
+      <row type="io_bottom" starty="1" priority="91"/>
+      <col type="io_left" startx="1" priority="92"/>
+      <col type="io_right" startx="W-2" priority="93"/>
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <row type="EMPTY" starty="0" priority="102"/>
+      <col type="EMPTY" startx="0" priority="103"/>
+      <col type="EMPTY" startx="W-1" priority="104"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
     </fixed_layout>
     <fixed_layout name="96x96" width="98" height="98">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
+      <row type="io_top" starty="H-2" priority="90"/>
+      <row type="io_bottom" starty="1" priority="91"/>
+      <col type="io_left" startx="1" priority="92"/>
+      <col type="io_right" startx="W-2" priority="93"/>
+      <row type="EMPTY" starty="H-1" priority="101"/>
+      <row type="EMPTY" starty="0" priority="102"/>
+      <col type="EMPTY" startx="0" priority="103"/>
+      <col type="EMPTY" startx="W-1" priority="104"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
@@ -63,20 +63,6 @@
         <loc side="left">io_bottom[4:5].outpad io_bottom[4:5].inpad</loc>
       </pinlocations>
     </tile>
-    <tile name="io_left" capacity="4" area="0">
-      <equivalent_sites>
-        <site pb_type="io"/>
-      </equivalent_sites>
-      <input name="outpad" num_pins="1"/>
-      <output name="inpad" num_pins="1"/>
-      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
-      <pinlocations pattern="custom">
-        <loc side="top">io_left[1:1].inpad io_left[1:1].outpad</loc>
-        <loc side="right">io_left[0:0].inpad io_left[0:0].outpad</loc>
-        <loc side="bottom">io_left[2:2].inpad io_left[2:2].outpad</loc>
-        <loc side="left">io_left[3:3].inpad io_left[3:3].outpad</loc>
-      </pinlocations>
-    </tile>
     <tile name="io_right" capacity="2" area="0">
       <equivalent_sites>
         <site pb_type="io"/>
@@ -106,10 +92,11 @@
   <!-- Physical descriptions begin -->
   <layout tileable="true">
     <auto_layout aspect_ratio="1.0">
-      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring
+        Intend to have no I/Os on the left side, it is to check the correctness of I/O indexing in OpenFPGA
+        -->
       <row type="io_top" starty="H-2" priority="90"/>
       <row type="io_bottom" starty="1" priority="91"/>
-      <col type="io_left" startx="1" priority="92"/>
       <col type="io_right" startx="W-2" priority="93"/>
       <row type="EMPTY" starty="H-1" priority="101"/>
       <row type="EMPTY" starty="0" priority="102"/>
@@ -123,7 +110,6 @@
       <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
       <row type="io_top" starty="H-2" priority="90"/>
       <row type="io_bottom" starty="1" priority="91"/>
-      <col type="io_left" startx="1" priority="92"/>
       <col type="io_right" startx="W-2" priority="93"/>
       <row type="EMPTY" starty="H-1" priority="101"/>
       <row type="EMPTY" starty="0" priority="102"/>
@@ -137,7 +123,6 @@
       <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
       <row type="io_top" starty="H-2" priority="90"/>
       <row type="io_bottom" starty="1" priority="91"/>
-      <col type="io_left" startx="1" priority="92"/>
       <col type="io_right" startx="W-2" priority="93"/>
       <row type="EMPTY" starty="H-1" priority="101"/>
       <row type="EMPTY" starty="0" priority="102"/>
@@ -151,7 +136,6 @@
       <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
       <row type="io_top" starty="H-2" priority="90"/>
       <row type="io_bottom" starty="1" priority="91"/>
-      <col type="io_left" startx="1" priority="92"/>
       <col type="io_right" startx="W-2" priority="93"/>
       <row type="EMPTY" starty="H-1" priority="101"/>
       <row type="EMPTY" starty="0" priority="102"/>
@@ -165,7 +149,6 @@
       <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
       <row type="io_top" starty="H-2" priority="90"/>
       <row type="io_bottom" starty="1" priority="91"/>
-      <col type="io_left" startx="1" priority="92"/>
       <col type="io_right" startx="W-2" priority="93"/>
       <row type="EMPTY" starty="H-1" priority="101"/>
       <row type="EMPTY" starty="0" priority="102"/>
@@ -179,7 +162,6 @@
       <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring -->
       <row type="io_top" starty="H-2" priority="90"/>
       <row type="io_bottom" starty="1" priority="91"/>
-      <col type="io_left" startx="1" priority="92"/>
       <col type="io_right" startx="W-2" priority="93"/>
       <row type="EMPTY" starty="H-1" priority="101"/>
       <row type="EMPTY" starty="0" priority="102"/>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- OpenFPGA only supports I/Os placed on perimeter
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
 This PR improves in the following aspects:
- [x] Now support I/Os in the center of the FPGA fabric. Created APIs to allow developers to customize the I/O indexing when building fabric. Consider to offer a file format to allow customization through external files
- [x] Added an example  architecture with I/Os in the center of the fabric 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
