### PR TITLE
Options to compile the codebase partially

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          make all BUILD_TYPE=$BUILD_TYPE CMAKE_FLAGS=${{ matrix.config.cmake_flags }}
+          make all BUILD_TYPE=$BUILD_TYPE CMAKE_FLAGS="${{ matrix.config.cmake_flags }}"
 
   docker_distribution:
     name: Build docker image for distribution

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,15 +171,15 @@ jobs:
           - name: "Build w/o Yosys (Ubuntu 20.04)"
             cc: gcc-9
             cxx: g++-9
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS OFF"
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS=OFF"
           - name: "Build w/o Yosys plugin (Ubuntu 20.04)"
             cc: gcc-9
             cxx: g++-9
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS_PLUGIN OFF"
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS_PLUGIN=OFF"
           - name: "Build w/o test (Ubuntu 20.04)"
             cc: gcc-9
             cxx: g++-9
-            cmake_flags: "-DOPENFPGA_WITH_TEST OFF"
+            cmake_flags: "-DOPENFPGA_WITH_TEST=OFF"
     # Define the steps to run the build job
     env:
       CC: ${{ matrix.config.cc }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,63 @@ jobs:
             yosys/install/bin
             openfpga_flow
             openfpga.sh
+
+  linux_build_opt:
+    needs: change_detect
+    if: ${{ fromJSON(needs.change_detect.outputs.source_modified) }}
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-20.04
+    # Note: dependencies are installed in the container. See details about dependency list in docker/Dockerfile.master
+    # Comment the line out when base image is built again
+    #container: ghcr.io/${{ needs.change_detect.outputs.docker_repo }}/openfpga-build-${{ matrix.config.cc}}
+    # Branch on different OS and settings
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Build w/o Yosys (Ubuntu 20.04)"
+            cc: gcc-9
+            cxx: g++-9
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS OFF"
+          - name: "Build w/o Yosys plugin (Ubuntu 20.04)"
+            cc: gcc-9
+            cxx: g++-9
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS_PLUGIN OFF"
+          - name: "Build w/o test (Ubuntu 20.04)"
+            cc: gcc-9
+            cxx: g++-9
+            cmake_flags: "-DOPENFPGA_WITH_TEST OFF"
+    # Define the steps to run the build job
+    env:
+      CC: ${{ matrix.config.cc }}
+      CXX: ${{ matrix.config.cxx }}
+    steps:
+      - name: Cancel previous
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+          
+      - name: Checkout OpenFPGA repo
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install dependencies
+        run: ./.github/workflows/install_dependencies_build.sh
+      
+      - name: Dump tool versions
+        run: |
+          cmake --version
+          ${CC} --version
+          ${CXX} --version
+
+      - uses: hendrikmuhs/ccache-action@v1
+
+      - name: Build
+        shell: bash
+        run: |
+          make all BUILD_TYPE=$BUILD_TYPE CMAKE_FLAGS=${{ matrix.config.cmake_flags }}
+
   docker_distribution:
     name: Build docker image for distribution
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ option(OPENFPGA_WITH_YOSYS_PLUGIN "Enable building Yosys plugin" ON)
 option(OPENFPGA_WITH_TEST "Enable testing build for codebase. Once enabled, make test can be run" ON)
 
 # Options pass on to VTR
-set(WITH_ABC OFF CACHE BOOL "Enable building ABC in Verilog-to-Routing")
+set(WITH_ABC ON CACHE BOOL "Enable building ABC in Verilog-to-Routing")
 set(WITH_ODIN OFF CACHE BOOL "Enable building Odin in Verilog-to-Routing")
 set(ODIN_DEBUG OFF CACHE BOOL "Enable building odin with debug flags in Verilog-to-Routing")
 set(ODIN_WARN OFF CACHE BOOL "Enable building odin with extra warning flags in Verilog-to-Routing")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,24 @@ add_definitions("-DVTR_ASSERT_LEVEL=${VTR_ASSERT_LEVEL}")
 # compiler flag configuration checks
 include(CheckCXXCompilerFlag)
 
+# Options
+## General options
+option(OPENFPGA_WITH_YOSYS "Enable building Yosys" ON)
+option(OPENFPGA_WITH_YOSYS_PLUGIN "Enable building Yosys plugin" ON)
+option(OPENFPGA_WITH_TEST "Enable testing build for codebase. Once enabled, make test can be run" ON)
+
+# Options pass on to VTR
+set(WITH_ABC OFF CACHE BOOL "Enable building ABC in Verilog-to-Routing")
+set(WITH_ODIN OFF CACHE BOOL "Enable building Odin in Verilog-to-Routing")
+set(ODIN_DEBUG OFF CACHE BOOL "Enable building odin with debug flags in Verilog-to-Routing")
+set(ODIN_WARN OFF CACHE BOOL "Enable building odin with extra warning flags in Verilog-to-Routing")
+set(ODIN_COVERAGE OFF CACHE BOOL "Enable building odin with coverage flags in Verilog-to-Routing")
+set(ODIN_TIDY OFF CACHE BOOL "Enable building odin with clang tidy in Verilog-to-Routing")
+set(ODIN_SANITIZE OFF CACHE BOOL "Enable building odin with sanitize flags in Verilog-to-Routing")
+set(WITH_YOSYS OFF CACHE BOOL "Enable building Yosys in Verilog-to-Routing")
+set(ODIN_YOSYS OFF CACHE BOOL "Enable building odin with yosys in Verilog-to-Routing")
+set(YOSYS_SV_UHDM_PLUGIN OFF CACHE BOOL "Enable building and installing Yosys SystemVerilog and UHDM plugins in Verilog-to-Routing")
+
 #
 # We require c++14 support
 #
@@ -204,7 +222,9 @@ message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 # Unit Testing
 #
-enable_testing()
+if (OPENFPGA_WITH_TEST)
+    enable_testing()
+endif()
 
 # 
 # Sub-projects
@@ -251,30 +271,32 @@ include(CheckCXXCompilerFlag)
 #
 
 # we will check if yosys already exist. if not then build it
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/yosys/install/bin/yosys)
-    message(STATUS "Yosys pre-build exist so skipping it")
-else ()
-# run makefile provided, we pass-on the options to the local make file 
-add_custom_target(
-    yosys ALL 
-    COMMAND $(MAKE) config-gcc
-    COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_SOURCE_DIR}/yosys/install
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys
-    COMMENT "Compile Yosys with given Makefile"
-)
+if (OPENFPGA_WITH_YOSYS)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/yosys/install/bin/yosys)
+        message(STATUS "Yosys pre-build exist so skipping it")
+    else ()
+        # run makefile provided, we pass-on the options to the local make file 
+        add_custom_target(
+            yosys ALL 
+            COMMAND $(MAKE) config-gcc
+            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_SOURCE_DIR}/yosys/install
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys
+            COMMENT "Compile Yosys with given Makefile"
+        )
+        # yosys compilation ends
 
-# yosys compilation ends
-
-# yosys-plugins compilation starts
-add_custom_target(
-    yosys-plugins ALL
-    COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_SOURCE_DIR}/yosys/install EXTRA_FLAGS="-DPASS_NAME=synth_ql"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/yosys/install/bin/yosys
-    COMMENT "Compile Yosys-plugins with given Makefile"
-)
-
-add_dependencies(yosys-plugins yosys)
+        # yosys-plugins compilation starts
+        if (OPENFPGA_WITH_YOSYS_PLUGIN)
+            add_custom_target(
+                yosys-plugins ALL
+                COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_SOURCE_DIR}/yosys/install EXTRA_FLAGS="-DPASS_NAME=synth_ql"
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
+                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/yosys/install/bin/yosys
+                COMMENT "Compile Yosys-plugins with given Makefile"
+            )
+            add_dependencies(yosys-plugins yosys)
+        endif()
+    endif()
 endif()
 
 # run make to extract compiler options, linker options and list of source files

--- a/docs/source/tutorials/getting_started/compile.rst
+++ b/docs/source/tutorials/getting_started/compile.rst
@@ -38,6 +38,33 @@ To quickly verify the tool is well compiled, users can run the following command
 
   python3 openfpga_flow/scripts/run_fpga_task.py compilation_verification --debug --show_thread_logs
 
+.. _tutorial_compile_build_options:
+
+Build Options
+~~~~~~~~~~~~~
+
+General build targets are available in the top-level makefile. Call help desk to see details
+
+.. code-block:: shell
+
+  make help
+
+The following options are available for a custom build
+
+.. option:: BUILD_TYPE=<string>
+
+  Specify the type of build. Can be either ``release`` or ``debug``. By default, release mode is selected (full optimization on runtime)
+
+.. option:: CMAKE_FLAGS=<string>
+
+  Force build flags to CMake. The following flags are available
+
+  - ``DOPENFPGA_WITH_TEST=[ON|OFF]``: Enable/Disable the test build
+  - ``DOPENFPGA_WITH_YOSYS=[ON|OFF]``: Enable/Disable the build of yosys. Note that when disabled, the build of yosys-plugin is also disabled
+  - ``DOPENFPGA_WITH_YOSYS_PLUGIN=[ON|OFF]``: Enable/Disable the build of yosys-plugin.
+
+.. warning:: By default, only required modules in *Verilog-to-Routing* (VTR) is enabled. On other words, ``abc``, ``odin``, ``yosys`` and other add-ons inside VTR are not built. If you want to enable them, please look into the dedicated options of CMake scripts.  
+
 .. _tutorial_compile_dependencies:
 
 Dependencies


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- We build all the modules/engines by default. And there are no options to skip any of them. This is not easy for integration, when OpenFPGA is used as a subsystem/submodule by another repo.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [x] Added an option ``OPENFPGA_WITH_TEST`` to bypass test build
- [x] Added an option ``OPENFPGA_WITH_YOSYS`` to bypass yosys build
- [x] Added an option ``OPENFPGA_WITH_YOSYS_PLUGIN`` to bypass yosys-plugin build
- [x] Override options in VTR to bypass yosys, abc, etc. which are not required by OpenFPGA.
- [x] Added these tests to CI 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
