### PR TITLE
New option to bypass version build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,10 @@ jobs:
             cc: gcc-9
             cxx: g++-9
             cmake_flags: "-DOPENFPGA_WITH_TEST=OFF"
+          - name: "Build w/o version number (Ubuntu 20.04)"
+            cc: gcc-9
+            cxx: g++-9
+            cmake_flags: "-DOPENFPGA_WITH_VERSION=OFF"
     # Define the steps to run the build job
     env:
       CC: ${{ matrix.config.cc }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ include(CheckCXXCompilerFlag)
 option(OPENFPGA_WITH_YOSYS "Enable building Yosys" ON)
 option(OPENFPGA_WITH_YOSYS_PLUGIN "Enable building Yosys plugin" ON)
 option(OPENFPGA_WITH_TEST "Enable testing build for codebase. Once enabled, make test can be run" ON)
-option(OPENFPGA_WITH_VERSION_UP_TO_DATE "Enable version always-up-to-date when building codebase. Disable only when you do not care an accurate version number" ON)
+option(OPENFPGA_WITH_VERSION "Enable version always-up-to-date when building codebase. Disable only when you do not care an accurate version number" ON)
 
 # Options pass on to VTR
 set(WITH_ABC ON CACHE BOOL "Enable building ABC in Verilog-to-Routing")
@@ -80,7 +80,7 @@ set(ODIN_SANITIZE OFF CACHE BOOL "Enable building odin with sanitize flags in Ve
 set(WITH_YOSYS OFF CACHE BOOL "Enable building Yosys in Verilog-to-Routing")
 set(ODIN_YOSYS OFF CACHE BOOL "Enable building odin with yosys in Verilog-to-Routing")
 set(YOSYS_SV_UHDM_PLUGIN OFF CACHE BOOL "Enable building and installing Yosys SystemVerilog and UHDM plugins in Verilog-to-Routing")
-set(VTR_ENABLE_VERSION_UP_TO_DATE ${OPENFPGA_WITH_VERSION_UP_TO_DATE} CACHE BOOL "Enable version always-up-to-date when building codebase. Disable only when you do not care an accurate version number")
+set(VTR_ENABLE_VERSION ${OPENFPGA_WITH_VERSION} CACHE BOOL "Enable version always-up-to-date when building codebase. Disable only when you do not care an accurate version number")
 
 #
 # We require c++14 support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ include(CheckCXXCompilerFlag)
 option(OPENFPGA_WITH_YOSYS "Enable building Yosys" ON)
 option(OPENFPGA_WITH_YOSYS_PLUGIN "Enable building Yosys plugin" ON)
 option(OPENFPGA_WITH_TEST "Enable testing build for codebase. Once enabled, make test can be run" ON)
+option(OPENFPGA_WITH_VERSION_UP_TO_DATE "Enable version always-up-to-date when building codebase. Disable only when you do not care an accurate version number" ON)
 
 # Options pass on to VTR
 set(WITH_ABC ON CACHE BOOL "Enable building ABC in Verilog-to-Routing")
@@ -79,6 +80,7 @@ set(ODIN_SANITIZE OFF CACHE BOOL "Enable building odin with sanitize flags in Ve
 set(WITH_YOSYS OFF CACHE BOOL "Enable building Yosys in Verilog-to-Routing")
 set(ODIN_YOSYS OFF CACHE BOOL "Enable building odin with yosys in Verilog-to-Routing")
 set(YOSYS_SV_UHDM_PLUGIN OFF CACHE BOOL "Enable building and installing Yosys SystemVerilog and UHDM plugins in Verilog-to-Routing")
+set(VTR_ENABLE_VERSION_UP_TO_DATE ${OPENFPGA_WITH_VERSION_UP_TO_DATE} CACHE BOOL "Enable version always-up-to-date when building codebase. Disable only when you do not care an accurate version number")
 
 #
 # We require c++14 support

--- a/libs/libopenfpgautil/CMakeLists.txt
+++ b/libs/libopenfpgautil/CMakeLists.txt
@@ -37,23 +37,25 @@ set(OPENFPGA_BUILD_INFO "${OPENFPGA_BUILD_INFO} ASSERT_LEVEL=${VTR_ASSERT_LEVEL}
 # 2) The custom command depends on the touched version input file and generates the processed 
 #    version file, with updated values. The custom command uses the configure_version.cmake 
 #    script to generate the up-to-date openfpga_version.cpp
-add_custom_target(openfpga_version ALL
-    COMMAND ${CMAKE_COMMAND} -E touch ${OPENFPGA_VERSION_FILE_IN})
-
-add_custom_command(OUTPUT ${OPENFPGA_VERSION_FILE_OUT}
-    COMMAND ${CMAKE_COMMAND} 
-                    -D IN_FILE=${OPENFPGA_VERSION_FILE_IN}
-                    -D OUT_FILE=${OPENFPGA_VERSION_FILE_OUT}
-                    -D OPENFPGA_VERSION_MAJOR=${OPENFPGA_VERSION_MAJOR}
-                    -D OPENFPGA_VERSION_MINOR=${OPENFPGA_VERSION_MINOR}
-                    -D OPENFPGA_VERSION_PATCH=${OPENFPGA_VERSION_PATCH}
-                    -D OPENFPGA_VERSION_PRERELEASE=${OPENFPGA_VERSION_PRERELEASE}
-                    -D OPENFPGA_COMPILER_INFO=${OPENFPGA_COMPILER_INFO}
-                    -D OPENFPGA_BUILD_INFO=${OPENFPGA_BUILD_INFO}
-                    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/configure_version.cmake
-    MAIN_DEPENDENCY ${OPENFPGA_VERSION_FILE_IN}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	VERBATIM)
+if (OPENFPGA_WITH_VERSION_UP_TO_DATE) 
+    add_custom_target(openfpga_version ALL
+        COMMAND ${CMAKE_COMMAND} -E touch ${OPENFPGA_VERSION_FILE_IN})
+    
+    add_custom_command(OUTPUT ${OPENFPGA_VERSION_FILE_OUT}
+        COMMAND ${CMAKE_COMMAND} 
+                        -D IN_FILE=${OPENFPGA_VERSION_FILE_IN}
+                        -D OUT_FILE=${OPENFPGA_VERSION_FILE_OUT}
+                        -D OPENFPGA_VERSION_MAJOR=${OPENFPGA_VERSION_MAJOR}
+                        -D OPENFPGA_VERSION_MINOR=${OPENFPGA_VERSION_MINOR}
+                        -D OPENFPGA_VERSION_PATCH=${OPENFPGA_VERSION_PATCH}
+                        -D OPENFPGA_VERSION_PRERELEASE=${OPENFPGA_VERSION_PRERELEASE}
+                        -D OPENFPGA_COMPILER_INFO=${OPENFPGA_COMPILER_INFO}
+                        -D OPENFPGA_BUILD_INFO=${OPENFPGA_BUILD_INFO}
+                        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/configure_version.cmake
+        MAIN_DEPENDENCY ${OPENFPGA_VERSION_FILE_IN}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    	VERBATIM)
+endif()
 
 #file(GLOB_RECURSE EXEC_SOURCES test/main.cpp)
 file(GLOB_RECURSE LIB_SOURCES src/*.cpp)

--- a/libs/libopenfpgautil/CMakeLists.txt
+++ b/libs/libopenfpgautil/CMakeLists.txt
@@ -37,7 +37,7 @@ set(OPENFPGA_BUILD_INFO "${OPENFPGA_BUILD_INFO} ASSERT_LEVEL=${VTR_ASSERT_LEVEL}
 # 2) The custom command depends on the touched version input file and generates the processed 
 #    version file, with updated values. The custom command uses the configure_version.cmake 
 #    script to generate the up-to-date openfpga_version.cpp
-if (OPENFPGA_WITH_VERSION_UP_TO_DATE) 
+if (OPENFPGA_WITH_VERSION) 
     add_custom_target(openfpga_version ALL
         COMMAND ${CMAKE_COMMAND} -E touch ${OPENFPGA_VERSION_FILE_IN})
     
@@ -55,6 +55,9 @@ if (OPENFPGA_WITH_VERSION_UP_TO_DATE)
         MAIN_DEPENDENCY ${OPENFPGA_VERSION_FILE_IN}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     	VERBATIM)
+else()
+# Just copy the input file to output file with version number
+    configure_file(${OPENFPGA_VERSION_FILE_IN} ${OPENFPGA_VERSION_FILE_OUT})
 endif()
 
 #file(GLOB_RECURSE EXEC_SOURCES test/main.cpp)
@@ -76,7 +79,7 @@ target_include_directories(libopenfpgautil PUBLIC ${LIB_INCLUDE_DIRS})
 set_target_properties(libopenfpgautil PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
 #Ensure version is always up to date by requiring version to be run first
-if (OPENFPGA_WITH_VERSION_UP_TO_DATE) 
+if (OPENFPGA_WITH_VERSION) 
     add_dependencies(libopenfpgautil openfpga_version)
 endif()
 

--- a/libs/libopenfpgautil/CMakeLists.txt
+++ b/libs/libopenfpgautil/CMakeLists.txt
@@ -74,7 +74,9 @@ target_include_directories(libopenfpgautil PUBLIC ${LIB_INCLUDE_DIRS})
 set_target_properties(libopenfpgautil PROPERTIES PREFIX "") #Avoid extra 'lib' prefix
 
 #Ensure version is always up to date by requiring version to be run first
-add_dependencies(libopenfpgautil openfpga_version)
+if (OPENFPGA_WITH_VERSION_UP_TO_DATE) 
+    add_dependencies(libopenfpgautil openfpga_version)
+endif()
 
 #Specify link-time dependancies
 target_link_libraries(libopenfpgautil


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
 - version number is always rebuilt during each compilation, as the version number is the dependency of many libraries. This has causes a long build time when using OpenFPGA as a submodule
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] A new option ``OPENFPGA_WITH_VERSION`` is added to top-level CMakefile, which allows users to bypass version number insertion in compilation. **We do not suggest so unless you are a power user!!!** When this option is on, VTR version number build is also skipped. The version number becomes empty:

```
tangxifan@LAPTOP-CVNHOGSN:~/OpenFPGA$ ./build/openfpga/openfpga --version
Version: 
Revision: 
Compiled: 
Compiler: GNU 9.4.0 on Linux-4.4.0-19041-Microsoft x86_64
Build Info: release ASSERT_LEVEL=2
```
- [x] Deployed a new test to validate the options on CI

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
