### PR TITLE
Fix a bug where placer does not call tileable rr-graph generator

### DIFF
--- a/openfpga_flow/tasks/fpga_verilog/lut_design/single_mode/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/lut_design/single_mode/config/task.conf
@@ -16,9 +16,10 @@ timeout_each_job = 20*60
 fpga_flow=vpr_blif
 
 [OpenFPGA_SHELL]
-openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/example_script.openfpga
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_N10_40nm_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=2x2
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml

--- a/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
@@ -69,6 +69,14 @@
          <!--Fill with 'clb'-->   
          <fill type="clb" priority="10"/>   
       </auto_layout>  
+      <fixed_layout name="2x2" width="6" height="6">   
+         <!-- Perimeter of 'EMPTY' blocks -->   
+         <perimeter type="EMPTY" priority="100"/>   
+         <!--Fill with 'io'-->   
+         <fill type="io" priority="10"/>   
+         <!-- Build an inner region of clbs -->   
+         <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/>    
+      </fixed_layout>  
    </layout> 
    <device>  
       <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #694 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- We see inconsistency in some test cases where ``bb_cost_check`` breaks. The root of cause is that placer builds a wire lookahead map using the default routing resource graph generator rather than the tileable routing resource graph.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Now VTR placer considers tileable routing resource graph when building router lookahead map.  

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
