### PR TITLE
Update k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml

### DIFF
--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
@@ -288,18 +288,18 @@
          of the input/output of the 36x36 multiplier
       -->
     <pb_type name="mult_36[two_divisible_mult_18x18].divisible_mult_18x18[two_mult_9x9].mult_9x9_slice.mult_9x9" physical_pb_type_name="mult_36[mult_36x36].mult_36x36_slice.mult_36x36" mode_bits="01" physical_pb_type_index_factor="0">
-      <port name="a" physical_mode_port="a[0:8]" physical_mode_pin_rotate_offset="9"/>
-      <port name="b" physical_mode_port="b[0:8]" physical_mode_pin_rotate_offset="9"/>
-      <port name="out" physical_mode_port="out[0:17]" physical_mode_pin_rotate_offset="18"/>
+      <port name="a" physical_mode_port="a[0:8]" physical_mode_port_rotate_offset="9"/>
+      <port name="b" physical_mode_port="b[0:8]" physical_mode_port_rotate_offset="9"/>
+      <port name="out" physical_mode_port="out[0:17]" physical_mode_port_rotate_offset="18"/>
     </pb_type>
     <!-- Bind the 18x18 multiplier to the physical 36x36 multiplier
          There are two 18x18 multipliers, each of which occupies part
          of the input/output of the 36x36 multiplier
       -->
     <pb_type name="mult_36[two_divisible_mult_18x18].divisible_mult_18x18[mult_18x18].mult_18x18_slice.mult_18x18" physical_pb_type_name="mult_36[mult_36x36].mult_36x36_slice.mult_36x36" mode_bits="10" physical_pb_type_index_factor="0">
-      <port name="a" physical_mode_port="a[0:17]" physical_mode_pin_rotate_offset="18"/>
-      <port name="b" physical_mode_port="b[0:17]" physical_mode_pin_rotate_offset="18"/>
-      <port name="out" physical_mode_port="out[0:35]" physical_mode_pin_rotate_offset="36"/>
+      <port name="a" physical_mode_port="a[0:17]" physical_mode_port_rotate_offset="18"/>
+      <port name="b" physical_mode_port="b[0:17]" physical_mode_port_rotate_offset="18"/>
+      <port name="out" physical_mode_port="out[0:35]" physical_mode_port_rotate_offset="36"/>
     </pb_type>
     <!-- END physical pb_type binding in complex block dsp -->
 


### PR DESCRIPTION
Mode port assertions should be bind with "physical_mode_port_rotate_offset" instead of "physical_mode_pin_rotate_offset".

> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Currently, OpenFPGA has the following limitations: 
> Repack fails on architecture "k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml"
> Issue #815
> #### What does this pull request change?
> This PR improves in the following aspects:
> Fix the typo that crashes openfpga shell.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [X] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
