### PR TITLE
Format architecture XML files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: linux_build
+name: Test 
 
 # Run CI on push, PR, and weekly.
 

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -19,6 +19,8 @@ jobs:
         config:
           - name: "C/C++"
             code_type: "-cpp"
+          - name: "XML"
+            code_type: "-xml"
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.9.1

--- a/.github/workflows/install_dependencies_build.sh
+++ b/.github/workflows/install_dependencies_build.sh
@@ -59,4 +59,5 @@ sudo apt-get install -y \
     clang-7 \
     clang-8 \
     clang-10 \
-    clang-format-10
+    clang-format-10 \
+    libxml2-utils

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ format-xml:
 # Format all the XML files under this project, excluding submodules
 	for f in `find openfpga_flow/vpr_arch openfpga_flow/openfpga_arch -iname *.xml`; \
 	do \
-	${XML_FORMAT_EXEC} --format $${f} --output $${f} || exit 1; \
+	XMLLINT_INDENT="  " && ${XML_FORMAT_EXEC} --format $${f} --output $${f} || exit 1; \
 	done
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ format-xml:
 # Format all the XML files under this project, excluding submodules
 	for f in `find openfpga_flow/vpr_arch openfpga_flow/openfpga_arch -iname *.xml`; \
 	do \
-	${XML_FORMAT_EXEC} --format $${f} || exit 1; \
+	${XML_FORMAT_EXEC} --format $${f} --output $${f} || exit 1; \
 	done
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ endif
 # Define executables
 PYTHON_EXEC ?= python3
 CLANG_FORMAT_EXEC ?= clang-format-10
+XML_FORMAT_EXEC ?= xmllint
 
 # Put it first so that "make" without argument is like "make help".
 export COMMENT_EXTRACT
@@ -73,6 +74,13 @@ format-cpp:
 	for f in `find libs openfpga -iname *.cpp -o -iname *.hpp -o -iname *.c -o -iname *.h`; \
 	do \
 	${CLANG_FORMAT_EXEC} --style=file -i $${f} || exit 1; \
+	done
+
+format-xml:
+# Format all the XML files under this project, excluding submodules
+	for f in `find openfpga_flow/vpr_arch openfpga_flow/openfpga_arch -iname *.xml`; \
+	do \
+	${XML_FORMAT_EXEC} --format $${f} || exit 1; \
 	done
 
 clean:

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTile4ClkPin_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTile4ClkPin_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -87,7 +88,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -95,7 +97,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -117,14 +120,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -139,13 +142,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -170,7 +173,7 @@
     <segment name="L4" circuit_model_name="chan_segment"/>
   </routing_segment>
   <tile_annotations>
-      <!-- MUST explicitly define the number of clock bits
+    <!-- MUST explicitly define the number of clock bits
            being consistent with physical tile port definition
         -->
     <global_port name="clk0" is_clock="true" default_val="0">
@@ -189,11 +192,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTile4Clk_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTile4Clk_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -87,7 +88,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -95,7 +97,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -117,14 +120,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -139,13 +142,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTile8Clk_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTile8Clk_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -87,7 +88,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -95,7 +97,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -117,14 +120,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -139,13 +142,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,13 +141,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -176,11 +179,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,13 +141,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -177,14 +180,13 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[physical].ff" circuit_model_name="DFFSRQ"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[inpad_registered].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[inpad_registered].ff" physical_pb_type_name="io[physical].ff"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[physical].ff" circuit_model_name="DFFSRQ"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[inpad_registered].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[inpad_registered].ff" physical_pb_type_name="io[physical].ff"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_both_set_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_both_set_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,15 +150,15 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAMSR" prefix="SRAMSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -182,11 +185,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAMR" prefix="SRAMR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_resetb_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_resetb_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAMRN" prefix="SRAMRN" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RSTN" size="1" is_global="true" default_val="1" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RSTN" size="1" is_global="true" default_val="1" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_set_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_set_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAMS" prefix="SRAMS" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_setb_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_bank_use_setb_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAMSN" prefix="SRAMSN" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pSet" lib_name="SETN" size="1" is_global="true" default_val="1" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pSet" lib_name="SETN" size="1" is_global="true" default_val="1" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_abspath_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_abspath_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,13 +141,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -171,11 +174,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_cfgdscffio_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_cfgdscffio_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,19 +141,19 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="CFGDSDFFR" prefix="CFGDSDFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="SE" size="1" is_global="true" default_val="0"/>
-       <port type="input" prefix="config_enable" lib_name="CFGE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
-       <port type="input" prefix="config_done" lib_name="CFG_DONE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="SI" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="CFGQN" size="1"/>
-       <port type="output" prefix="CFGQ" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="SE" size="1" is_global="true" default_val="0"/>
+      <port type="input" prefix="config_enable" lib_name="CFGE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
+      <port type="input" prefix="config_done" lib_name="CFG_DONE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="SI" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="CFGQN" size="1"/>
+      <port type="output" prefix="CFGQ" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO_CFGD" prefix="GPIO_CFGD" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -178,11 +181,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO_CFGD" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO_CFGD" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_cfgscff_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_cfgscff_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,18 +141,18 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="CFGSDFFR" prefix="CFGSDFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="SE" size="1" is_global="true" default_val="0"/>
-       <port type="input" prefix="config_enable" lib_name="CFGE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="SI" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="CFGQN" size="1"/>
-       <port type="output" prefix="CFGQ" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="SE" size="1" is_global="true" default_val="0"/>
+      <port type="input" prefix="config_enable" lib_name="CFGE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="SI" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="CFGQN" size="1"/>
+      <port type="output" prefix="CFGQ" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -176,11 +179,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,13 +141,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -171,11 +174,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_both_set_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_both_set_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,15 +141,15 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFSR" prefix="DFFSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -173,11 +176,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,14 +141,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -172,11 +175,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_resetb_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_resetb_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,14 +141,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFRN" prefix="DFFRN" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RSTN" size="1" is_global="true" default_val="1" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RSTN" size="1" is_global="true" default_val="1" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -172,11 +175,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_set_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_set_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,14 +141,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFS" prefix="DFFS" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -172,11 +175,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_setb_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_use_setb_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,14 +141,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFSN" prefix="DFFSN" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pSet" lib_name="SETN" size="1" is_global="true" default_val="1" is_set="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pSet" lib_name="SETN" size="1" is_global="true" default_val="1" is_set="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -172,11 +175,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_dsp8reg_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_dsp8reg_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,13 +141,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -179,11 +182,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -193,10 +195,9 @@
     <pb_type name="clb.fle[n1_lut4].ble4.lut4" circuit_model_name="lut4"/>
     <pb_type name="clb.fle[n1_lut4].ble4.ff" circuit_model_name="DFFSRQ"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_8" physical_mode_name="mult_8x8" idle_mode_name="mult_8x8"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_8[mult_8x8].mult_8x8_slice.mult_8x8" circuit_model_name="mult_8x8"/>
     <pb_type name="mult_8[mult_8x8].mult_8x8_slice.ff_A" circuit_model_name="DFFSRQ"/>
     <pb_type name="mult_8[mult_8x8].mult_8x8_slice.ff_B" circuit_model_name="DFFSRQ"/>

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_fixed_sim_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_fixed_sim_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_ccff_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_ccff_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="CK" size="1" is_edge_triggered="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="CK" size="1" is_edge_triggered="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_const_input_gnd_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_const_input_gnd_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="0"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCH" prefix="LATCH" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_no_const_input_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_no_const_input_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -80,7 +81,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -88,7 +90,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree"/>
@@ -110,14 +113,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -132,13 +135,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCH" prefix="LATCH" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -165,11 +168,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCH" prefix="LATCH" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_scff_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_scff_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,17 +150,17 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SDFFSR" prefix="SDFFSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="CK" size="1" is_edge_triggered="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
-       <port type="input" prefix="SE" lib_name="SE" size="1" is_global="true" default_val="0"/>
-       <port type="input" prefix="SI" lib_name="SI" size="1" is_global="true" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="CK" size="1" is_edge_triggered="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <port type="input" prefix="SE" lib_name="SE" size="1" is_global="true" default_val="0"/>
+      <port type="input" prefix="SI" lib_name="SI" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -184,11 +187,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_both_set_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_both_set_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,15 +150,15 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHSR" prefix="LATCHSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -182,11 +185,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_resetb_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_resetb_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHRN" prefix="LATCHRN" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RSTN" size="1" is_global="true" default_val="1" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RSTN" size="1" is_global="true" default_val="1" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_set_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_set_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHS" prefix="LATCHS" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_setb_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_use_setb_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHSN" prefix="LATCHSN" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pSet" lib_name="SETN" size="1" is_global="true" default_val="1" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pSet" lib_name="SETN" size="1" is_global="true" default_val="1" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_bank_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_bank_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_bank_use_both_set_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_bank_use_both_set_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,15 +150,15 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAMSR" prefix="SRAMSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -182,11 +185,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,13 +141,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -171,11 +174,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_cc_use_both_set_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_cc_use_both_set_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -116,14 +119,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -138,15 +141,15 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFSR" prefix="DFFSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -173,11 +176,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCH" prefix="LATCH" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_use_both_set_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_use_both_set_reset_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,15 +150,15 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHSR" prefix="LATCHSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -182,11 +185,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_qlbank_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_qlbank_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_qlbanksr_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_qlbanksr_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -166,26 +169,26 @@
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="BL_DFFRQ" prefix="BL_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v" is_default="true">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="bl" prefix="BL" lib_name="BL" size="1"/>
-       <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="bl" prefix="BL" lib_name="BL" size="1"/>
+      <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="WL_DFFRQ" prefix="WL_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
-       <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
-       <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
+      <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
   </circuit_library>
   <configuration_protocol>
@@ -206,11 +209,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_powergate_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_powergate_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -92,7 +93,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -100,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -131,14 +134,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -153,14 +156,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -187,11 +190,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbank_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbank_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -180,11 +183,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbank_wlr_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbank_wlr_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM_RE" prefix="SRAM_RE" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="wlr" prefix="wlr" lib_name="RE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="wlr" prefix="wlr" lib_name="RE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbankflatten_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbankflatten_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -183,11 +186,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbankflatten_wlr_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbankflatten_wlr_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM_RE" prefix="SRAM_RE" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="wlr" prefix="wlr" lib_name="RE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="wlr" prefix="wlr" lib_name="RE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -184,11 +187,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbanksr_multi_chain_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbanksr_multi_chain_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -166,26 +169,26 @@
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="BL_DFFRQ" prefix="BL_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v" is_default="true">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="bl" prefix="BL" lib_name="BL" size="1"/>
-       <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="bl" prefix="BL" lib_name="BL" size="1"/>
+      <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="WL_DFFRQ" prefix="WL_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
-       <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
-       <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
+      <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
   </circuit_library>
   <configuration_protocol>
@@ -206,11 +209,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbanksr_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbanksr_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,13 +150,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM" prefix="SRAM" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -166,26 +169,26 @@
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="BL_DFFRQ" prefix="BL_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v" is_default="true">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="bl" prefix="BL" lib_name="BL" size="1"/>
-       <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="bl" prefix="BL" lib_name="BL" size="1"/>
+      <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="WL_DFFRQ" prefix="WL_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
-       <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
-       <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
+      <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
   </circuit_library>
   <configuration_protocol>
@@ -206,11 +209,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbanksr_wlr_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_qlbanksr_wlr_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" lib_name="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" lib_name="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="SRAM_RE" prefix="SRAM_RE" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/sram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/sram.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="wlr" prefix="wlr" lib_name="RE" size="1"/>
-       <port type="output" prefix="out" lib_name="Q" size="1"/>
-       <port type="output" prefix="outb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="wlr" prefix="wlr" lib_name="RE" size="1"/>
+      <port type="output" prefix="out" lib_name="Q" size="1"/>
+      <port type="output" prefix="outb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -167,27 +170,27 @@
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="BL_DFFRQ" prefix="BL_DFFRQ" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="bl" prefix="BL" lib_name="BL" size="1"/>
-       <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="bl" prefix="BL" lib_name="BL" size="1"/>
+      <port type="clock" prefix="bl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
     <!-- The following flip-flop is used to build the shift register chains for configuring memory banks -->
     <circuit_model type="ccff" name="WLR_DFFRQ" prefix="WLR_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" lib_name="SIN" size="1"/>
-       <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
-       <port type="wlr" prefix="wlr" lib_name="WLR" size="1"/>
-       <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
-       <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="srReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" lib_name="SIN" size="1"/>
+      <port type="output" prefix="Q" lib_name="SOUT" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WLW" size="1"/>
+      <port type="wlr" prefix="wlr" lib_name="WLR" size="1"/>
+      <port type="clock" prefix="wl_en" lib_name="WEN" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <port type="clock" prefix="wl_sr_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true" is_shift_register="true"/>
     </circuit_model>
   </circuit_library>
   <configuration_protocol>
@@ -208,11 +211,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_standalone_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_standalone_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_N4_no_local_routing_40nm_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_no_local_routing_40nm_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle[n1_lut4].ble4.lut4" circuit_model_name="lut4"/>

--- a/openfpga_flow/openfpga_arch/k4_N5_pattern_local_routing_40nm_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N5_pattern_local_routing_40nm_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_fracNative_N4_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_fracNative_N4_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -150,14 +153,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -184,11 +187,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_40nm_cc_abspath_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_40nm_cc_abspath_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -213,11 +216,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -213,11 +216,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_40nm_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_40nm_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -224,11 +227,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -265,6 +267,5 @@
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_128x8_dp].mem_128x8_dp" circuit_model_name="dpram_128x8"/>
     <!-- END physical pb_type binding in complex block memory -->
-
   </pb_type_annotations>
 </openfpga_architecture>

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124_40nm_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124_40nm_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -228,11 +231,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -269,6 +271,5 @@
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_128x8_dp].mem_128x8_dp" circuit_model_name="dpram_128x8"/>
     <!-- END physical pb_type binding in complex block memory -->
-
   </pb_type_annotations>
 </openfpga_architecture>

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_frac_dsp32_40nm_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_frac_dsp32_40nm_frame_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="bl" prefix="bl" lib_name="D" size="1"/>
-       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
-       <port type="output" prefix="Q" lib_name="Q" size="1"/>
-       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -234,11 +237,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -275,10 +277,9 @@
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_128x8_dp].mem_128x8_dp" circuit_model_name="dpram_128x8"/>
     <!-- END physical pb_type binding in complex block memory -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_32" physical_mode_name="mult_32x32" idle_mode_name="mult_32x32"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_32[mult_32x32].mult_32x32_slice.mult_32x32" circuit_model_name="mult_32x32" mode_bits="00"/>
     <!-- Bind the 8x8 multiplier to the physical 32x32 multiplier
          There are four 8x8 multipliers, each of which occupies part

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="MULTI_MODE_DFFNRQ" prefix="MULTI_MODE_DFFNRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dffn.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="R" lib_name="RST" size="1" default_val="0"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="C" lib_name="CK" size="1" default_val="0"/>
-       <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="R" lib_name="RST" size="1" default_val="0"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="C" lib_name="CK" size="1" default_val="0"/>
+      <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -207,11 +210,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_fracff_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_fracff_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="MULTI_MODE_DFFRQ" prefix="MULTI_MODE_DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="R" lib_name="RST" size="1" default_val="0"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="C" lib_name="CK" size="1" default_val="0"/>
-       <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="R" lib_name="RST" size="1" default_val="0"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="C" lib_name="CK" size="1" default_val="0"/>
+      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -207,11 +210,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_lut_use_and_switch_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_lut_use_and_switch_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_lutram_40nm_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_lutram_40nm_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -209,11 +212,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k4_frac_cc_sky130nm.xml
      - General purpose logic block
@@ -158,7 +159,7 @@
       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -218,11 +219,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_register_scan_chain_embedded_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_register_scan_chain_embedded_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k4_frac_cc_sky130nm.xml
      - General purpose logic block
@@ -158,7 +159,7 @@
       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -224,7 +225,6 @@
     <pb_type name="gp_inpad.inpad" circuit_model_name="GPIN"/>
     <pb_type name="gp_outpad.outpad" circuit_model_name="GPOUT"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k4_frac_cc_sky130nm.xml
      - General purpose logic block
@@ -155,9 +156,9 @@
       <port type="input" prefix="D" size="1"/>
       <port type="input" prefix="DI" lib_name="SI" size="1"/>
       <port type="input" prefix="Test_en" lib_name="SE" size="1" is_global="true" default_val="0"/>
-      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/> 
+      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0" />
+      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -181,7 +182,7 @@
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
-      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/> 
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO_ISOLN" prefix="EMBEDDED_IO_ISOLN" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -228,11 +229,10 @@
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
     <!-- IMPORTANT: must set unused I/Os to operating in INPUT mode !!! -->
-    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadderSuperLUT_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadderSuperLUT_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k4_frac_cc_sky130nm.xml
      - General purpose logic block
@@ -155,9 +156,9 @@
       <port type="input" prefix="D" size="1"/>
       <port type="input" prefix="DI" lib_name="SI" size="1"/>
       <port type="input" prefix="Test_en" lib_name="SE" size="1" is_global="true" default_val="0"/>
-      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/> 
+      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0" />
+      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4_arith" prefix="frac_lut4_arith" dump_structural_verilog="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/frac_lut4_arith.v">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -183,7 +184,7 @@
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
-      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/> 
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO_ISOLN" prefix="EMBEDDED_IO_ISOLN" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -232,22 +233,21 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-      <global_port name="clk" is_clock="true" default_val="0">
-          <tile name="clb" port="clk" x="-1" y="-1"/>
-      </global_port>
-      <global_port name="Reset" is_reset="true" default_val="1">
-          <tile name="clb" port="reset" x="-1" y="-1"/>
-      </global_port>
+    <global_port name="clk" is_clock="true" default_val="0">
+      <tile name="clb" port="clk" x="-1" y="-1"/>
+    </global_port>
+    <global_port name="Reset" is_reset="true" default_val="1">
+      <tile name="clb" port="reset" x="-1" y="-1"/>
+    </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
     <!-- IMPORTANT: must set unused I/Os to operating in INPUT mode !!! -->
-    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k4_frac_cc_sky130nm.xml
      - General purpose logic block
@@ -155,9 +156,9 @@
       <port type="input" prefix="D" size="1"/>
       <port type="input" prefix="DI" lib_name="SI" size="1"/>
       <port type="input" prefix="Test_en" lib_name="SE" size="1" is_global="true" default_val="0"/>
-      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/> 
+      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0" />
+      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -182,7 +183,7 @@
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
-      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/> 
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO_ISOLN" prefix="EMBEDDED_IO_ISOLN" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -229,22 +230,21 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-      <global_port name="clk" is_clock="true" default_val="0">
-          <tile name="clb" port="clk" x="-1" y="-1"/>
-      </global_port>
-      <global_port name="Reset" is_reset="true" default_val="1">
-          <tile name="clb" port="reset" x="-1" y="-1"/>
-      </global_port>
+    <global_port name="clk" is_clock="true" default_val="0">
+      <tile name="clb" port="clk" x="-1" y="-1"/>
+    </global_port>
+    <global_port name="Reset" is_reset="true" default_val="1">
+      <tile name="clb" port="reset" x="-1" y="-1"/>
+    </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
     <!-- IMPORTANT: must set unused I/Os to operating in INPUT mode !!! -->
-    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadder_register_scan_chain_dsp8_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadder_register_scan_chain_dsp8_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k4_frac_cc_sky130nm.xml
      - General purpose logic block
@@ -155,9 +156,9 @@
       <port type="input" prefix="D" size="1"/>
       <port type="input" prefix="DI" lib_name="SI" size="1"/>
       <port type="input" prefix="Test_en" lib_name="SE" size="1" is_global="true" default_val="0"/>
-      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/> 
+      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0" />
+      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -182,7 +183,7 @@
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
-      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/> 
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO_ISOLN" prefix="EMBEDDED_IO_ISOLN" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -237,22 +238,21 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-      <global_port name="clk" is_clock="true" default_val="0">
-          <tile name="clb" port="clk" x="-1" y="-1"/>
-      </global_port>
-      <global_port name="Reset" is_reset="true" default_val="1">
-          <tile name="clb" port="reset" x="-1" y="-1"/>
-      </global_port>
+    <global_port name="clk" is_clock="true" default_val="0">
+      <tile name="clb" port="clk" x="-1" y="-1"/>
+    </global_port>
+    <global_port name="Reset" is_reset="true" default_val="1">
+      <tile name="clb" port="reset" x="-1" y="-1"/>
+    </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
     <!-- IMPORTANT: must set unused I/Os to operating in INPUT mode !!! -->
-    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>
@@ -280,10 +280,9 @@
     <!-- Binding operating pb_types in mode 'shift_register' -->
     <pb_type name="clb.fle[shift_register].shift_reg.ff" physical_pb_type_name="clb.fle[physical].fabric.ff"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_8" physical_mode_name="mult_8x8" idle_mode_name="mult_8x8"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_8[mult_8x8].mult_8x8_slice.mult_8x8" circuit_model_name="mult_8x8"/>
   </pb_type_annotations>
 </openfpga_architecture>

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadder_register_scan_chain_frac_dsp16_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_reset_softadder_register_scan_chain_frac_dsp16_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k4_frac_cc_sky130nm.xml
      - General purpose logic block
@@ -155,9 +156,9 @@
       <port type="input" prefix="D" size="1"/>
       <port type="input" prefix="DI" lib_name="SI" size="1"/>
       <port type="input" prefix="Test_en" lib_name="SE" size="1" is_global="true" default_val="0"/>
-      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/> 
+      <port type="input" prefix="reset" lib_name="RST" size="1" default_val="0"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0" />
+      <port type="clock" prefix="clk" lib_name="CK" size="1" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -182,7 +183,7 @@
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
-      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/> 
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_prog="true" is_reset="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO_ISOLN" prefix="EMBEDDED_IO_ISOLN" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -238,22 +239,21 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-      <global_port name="clk" is_clock="true" default_val="0">
-          <tile name="clb" port="clk" x="-1" y="-1"/>
-      </global_port>
-      <global_port name="Reset" is_reset="true" default_val="1">
-          <tile name="clb" port="reset" x="-1" y="-1"/>
-      </global_port>
+    <global_port name="clk" is_clock="true" default_val="0">
+      <tile name="clb" port="clk" x="-1" y="-1"/>
+    </global_port>
+    <global_port name="Reset" is_reset="true" default_val="1">
+      <tile name="clb" port="reset" x="-1" y="-1"/>
+    </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
     <!-- IMPORTANT: must set unused I/Os to operating in INPUT mode !!! -->
-    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_ISOLN" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>
@@ -281,10 +281,9 @@
     <!-- Binding operating pb_types in mode 'shift_register' -->
     <pb_type name="clb.fle[shift_register].shift_reg.ff" physical_pb_type_name="clb.fle[physical].fabric.ff"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_16" physical_mode_name="mult_16x16"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_16[mult_16x16].mult_16x16_slice.mult_16x16" circuit_model_name="frac_mult_16x16" mode_bits="0"/>
     <pb_type name="mult_16[mult_8x8].mult_8x8_slice.mult_8x8" physical_pb_type_name="mult_16[mult_16x16].mult_16x16_slice.mult_16x16" mode_bits="1" physical_pb_type_index_factor="0">
       <port name="A" physical_mode_port="A[0:7]" physical_mode_port_rotate_offset="8"/>

--- a/openfpga_flow/openfpga_arch/k6_N10_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_N10_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut6" prefix="lut6" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -147,14 +150,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -181,11 +184,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_N10_intermediate_buffer_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_N10_intermediate_buffer_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -86,7 +87,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -94,7 +96,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -125,14 +128,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="lut6" prefix="lut6" dump_structural_verilog="true">
       <design_technology type="cmos"/>
@@ -148,14 +151,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -182,11 +185,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -213,11 +216,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -235,11 +238,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -274,12 +276,10 @@
     </pb_type>
     <pb_type name="clb.fle[n1_lut6].ble6.ff" physical_pb_type_name="clb.fle[physical].fabric.ff" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
     <!-- End physical pb_type binding in complex block clb -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_36" physical_mode_name="mult_36x36" idle_mode_name="mult_36x36"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_36[mult_36x36].mult_36x36_slice.mult_36x36" circuit_model_name="mult_36x36" mode_bits="00"/>
-
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_1024x8_dp].mem_1024x8_dp" circuit_model_name="dpram_1024x8"/>
     <!-- END physical pb_type binding in complex block memory -->

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,15 +143,15 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="MULTI_MODE_DFFSRQ" prefix="MULTI_MODE_DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="S" lib_name="SET" size="1"/>
-       <port type="input" prefix="R" lib_name="RST" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="C" lib_name="CK" size="1"/>
-       <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="S" lib_name="SET" size="1"/>
+      <port type="input" prefix="R" lib_name="RST" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="C" lib_name="CK" size="1"/>
+      <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -167,14 +170,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -248,11 +251,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -320,12 +322,10 @@
       <port name="SN" physical_mode_port="S"/>
     </pb_type>
     <!-- End physical pb_type binding in complex block clb -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_36" physical_mode_name="mult_36x36" idle_mode_name="mult_36x36"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_36[mult_36x36].mult_36x36_slice.mult_36x36" circuit_model_name="mult_36x36" mode_bits="00"/>
-
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_1024x8_dp].mem_1024x8_dp" circuit_model_name="dpram_1024x8"/>
     <!-- END physical pb_type binding in complex block memory -->

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_GlobalTile8Clk_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_GlobalTile8Clk_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -248,11 +251,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -287,10 +289,9 @@
     </pb_type>
     <pb_type name="clb.fle[n1_lut6].ble6.ff" physical_pb_type_name="clb.fle[physical].fabric.ff" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
     <!-- End physical pb_type binding in complex block clb -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_36" physical_mode_name="mult_36x36" idle_mode_name="mult_36x36"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_36[mult_36x36].mult_36x36_slice.mult_36x36" circuit_model_name="mult_36x36" mode_bits="00"/>
     <!-- Bind the 9x9 multiplier to the physical 36x36 multiplier
          There are four 9x9 multipliers, each of which occupies part
@@ -311,7 +312,6 @@
       <port name="out" physical_mode_port="out[0:35]" physical_mode_pin_rotate_offset="36"/>
     </pb_type>
     <!-- END physical pb_type binding in complex block dsp -->
-
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory" physical_mode_name="physical" idle_mode_name="physical"/>
     <pb_type name="memory[physical].frac_mem_32k" circuit_model_name="frac_mem_32k" mode_bits="0000"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -239,11 +242,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -278,10 +280,9 @@
     </pb_type>
     <pb_type name="clb.fle[n1_lut6].ble6.ff" physical_pb_type_name="clb.fle[physical].fabric.ff" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
     <!-- End physical pb_type binding in complex block clb -->
-
     <!-- physical pb_type binding in complex block dsp -->
     <pb_type name="mult_36" physical_mode_name="mult_36x36" idle_mode_name="mult_36x36"/>
-    <!-- Bind the primitive pb_type in the physical mode to a circuit model --> 
+    <!-- Bind the primitive pb_type in the physical mode to a circuit model -->
     <pb_type name="mult_36[mult_36x36].mult_36x36_slice.mult_36x36" circuit_model_name="mult_36x36" mode_bits="00"/>
     <!-- Bind the 9x9 multiplier to the physical 36x36 multiplier
          There are four 9x9 multipliers, each of which occupies part
@@ -302,7 +303,6 @@
       <port name="out" physical_mode_port="out[0:35]" physical_mode_pin_rotate_offset="36"/>
     </pb_type>
     <!-- END physical pb_type binding in complex block dsp -->
-
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory" physical_mode_name="physical" idle_mode_name="physical"/>
     <pb_type name="memory[physical].frac_mem_32k" circuit_model_name="frac_mem_32k" mode_bits="0000"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -225,11 +228,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -264,8 +266,6 @@
     </pb_type>
     <pb_type name="clb.fle[n1_lut6].ble6.ff" physical_pb_type_name="clb.fle[physical].fabric.ff" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
     <!-- End physical pb_type binding in complex block clb -->
-
-
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_512x32_dp].mem_512x32_dp" circuit_model_name="dpram_512x32"/>
     <!-- END physical pb_type binding in complex block memory -->

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_aib_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_aib_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -237,11 +240,10 @@
     <pb_type name="aib[physical].aib_core" circuit_model_name="AIB"/>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -276,8 +278,6 @@
     </pb_type>
     <pb_type name="clb.fle[n1_lut6].ble6.ff" physical_pb_type_name="clb.fle[physical].fabric.ff" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
     <!-- End physical pb_type binding in complex block clb -->
-
-
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_512x32_dp].mem_512x32_dp" circuit_model_name="dpram_512x32"/>
     <!-- END physical pb_type binding in complex block memory -->

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem1K_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem1K_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -231,11 +234,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">
@@ -270,8 +272,6 @@
     </pb_type>
     <pb_type name="clb.fle[n1_lut6].ble6.ff" physical_pb_type_name="clb.fle[physical].fabric.ff" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
     <!-- End physical pb_type binding in complex block clb -->
-
-
     <!-- physical pb_type binding in complex block memory -->
     <pb_type name="memory[mem_128x8_dp].mem_128x8_dp" circuit_model_name="dpram_128x8"/>
     <!-- END physical pb_type binding in complex block memory -->

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_column_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_column_chain_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -213,11 +216,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_chain_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -166,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -214,11 +217,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -143,16 +146,16 @@
         When the TESTEN is enabled, the data will be propagated form DI instead of D
       -->
     <circuit_model type="ff" name="SDFFSRQ" prefix="SDFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="DI" lib_name="SI" size="1"/>
-       <port type="input" prefix="TESTEN" lib_name="SE" size="1" is_global="true" default_val="0"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="DI" lib_name="SI" size="1"/>
+      <port type="input" prefix="TESTEN" lib_name="SE" size="1" is_global="true" default_val="0"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -171,14 +174,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -220,11 +223,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -143,16 +146,16 @@
         When the TESTEN is enabled, the data will be propagated form DI instead of D
       -->
     <circuit_model type="ff" name="SDFFSRQ" prefix="SDFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="D_chain" lib_name="SI" size="1"/>
-       <port type="input" prefix="TESTEN" lib_name="SE" size="1" is_global="true" default_val="0"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="D_chain" lib_name="SI" size="1"/>
+      <port type="input" prefix="TESTEN" lib_name="SE" size="1" is_global="true" default_val="0"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -171,14 +174,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -223,7 +226,6 @@
     <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
     <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_spypad_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_spypad_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -143,16 +146,16 @@
         When the TESTEN is enabled, the data will be propagated form DI instead of D
       -->
     <circuit_model type="ff" name="SDFFSRQ" prefix="SDFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="D_chain" lib_name="SI" size="1"/>
-       <port type="input" prefix="TESTEN" lib_name="SE" size="1" is_global="true" default_val="0"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="D_chain" lib_name="SI" size="1"/>
+      <port type="input" prefix="TESTEN" lib_name="SE" size="1" is_global="true" default_val="0"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" is_default="true" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -186,14 +189,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -238,7 +241,6 @@
     <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
     <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb.fle" physical_mode_name="physical"/>
@@ -271,11 +273,9 @@
     <!-- Binding operating pb_types in mode 'shift_register' -->
     <pb_type name="clb.fle[shift_register].ble_shift.ff" physical_pb_type_name="clb.fle[physical].ff_phy"/>
     <!-- End physical pb_type binding in complex block CLB -->
-
     <!-- physical pb_type binding in complex block CLB with spypads-->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb_spypad.fle" physical_mode_name="physical"/>
-
     <!-- Binding regular FLEs -->
     <pb_type name="clb_spypad.fle[physical].frac_logic.frac_lut6" circuit_model_name="frac_lut6" mode_bits="00"/>
     <pb_type name="clb_spypad.fle[physical].ff_phy" circuit_model_name="SDFFSRQ"/>
@@ -305,11 +305,9 @@
     <pb_type name="clb_spypad.fle[n1_lut6].ble6.ff" physical_pb_type_name="clb_spypad.fle[physical].ff_phy" physical_pb_type_index_factor="2" physical_pb_type_index_offset="1"/>
     <!-- Binding operating pb_types in mode 'shift_register' -->
     <pb_type name="clb_spypad.fle[shift_register].ble_shift.ff" physical_pb_type_name="clb_spypad.fle[physical].ff_phy"/>
-
     <!-- Binding FLE with spy pads -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb_spypad.fle_spypad" physical_mode_name="physical"/>
-
     <pb_type name="clb_spypad.fle_spypad[physical].frac_logic.frac_lut6" circuit_model_name="frac_lut6_spypad" mode_bits="00"/>
     <pb_type name="clb_spypad.fle_spypad[physical].ff_phy" circuit_model_name="SDFFSRQ"/>
     <pb_type name="clb_spypad.fle_spypad[physical].frac_logic.adder_phy" circuit_model_name="ADDF"/>
@@ -339,6 +337,5 @@
     <!-- Binding operating pb_types in mode 'shift_register' -->
     <pb_type name="clb_spypad.fle_spypad[shift_register].ble_shift.ff" physical_pb_type_name="clb_spypad.fle_spypad[physical].ff_phy"/>
     <!-- End physical pb_type binding in complex block CLB with spypads-->
-
   </pb_type_annotations>
 </openfpga_architecture>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_behavioral_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_behavioral_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_local_encoder_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_local_encoder_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1" local_encoder="true"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_spyio_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_spyio_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,20 +168,20 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true" />
+      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true"/>
       <!-- A spypad for the direction port of the I/O pad, which can be visible in the fpga_top -->
       <port type="input" prefix="din" size="1" is_global="true" is_io="true" default_value="0"/>
       <port type="output" prefix="dout" size="1" is_global="true" is_io="true"/>
@@ -203,11 +206,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_stdcell_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_stdcell_mux_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -102,7 +103,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -110,7 +112,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" is_default="true" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -132,14 +135,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -157,14 +160,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -191,11 +194,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_stdcell_mux_40nm_openfpga_synthesizable.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_stdcell_mux_40nm_openfpga_synthesizable.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -102,7 +103,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -110,7 +112,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" is_default="true" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -132,14 +135,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -157,14 +160,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -191,11 +194,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_tree_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_tree_mux_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" is_default="true" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -131,14 +134,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -156,14 +159,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -190,11 +193,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N8_40nm.xml
      - General purpose logic block
@@ -143,14 +144,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -168,14 +169,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -206,7 +207,6 @@
     <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
     <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_debuf_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_debuf_mux_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N8_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_inbuf_only_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_inbuf_only_mux_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N8_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_local_encoder_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_local_encoder_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1" local_encoder="true"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_outbuf_only_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_outbuf_only_mux_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N8_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
       <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
@@ -140,14 +143,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -165,14 +168,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -199,11 +202,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_stdcell_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_stdcell_mux_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -102,7 +103,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -110,7 +112,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" is_default="true" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -132,14 +135,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -157,13 +160,13 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFRQ" prefix="DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -190,11 +193,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_tree_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_tree_mux_40nm_openfpga.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- Architecture annotation for OpenFPGA framework
      This annotation supports the k6_N10_40nm.xml 
      - General purpose logic block
@@ -101,7 +102,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
     </circuit_model>
     <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
       <design_technology type="cmos"/>
@@ -109,7 +111,8 @@
       <output_buffer exist="false"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
-      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
     <circuit_model type="mux" name="mux_tree" prefix="mux_tree" is_default="true" dump_structural_verilog="true">
       <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
@@ -131,14 +134,14 @@
     </circuit_model>
     <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
     <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
-       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
     </circuit_model>
     <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
@@ -156,14 +159,14 @@
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
     <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
-       <design_technology type="cmos"/>
-       <input_buffer exist="true" circuit_model_name="INVTX1"/>
-       <output_buffer exist="true" circuit_model_name="INVTX1"/>
-       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
-       <port type="input" prefix="D" size="1"/>
-       <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
-       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
       <design_technology type="cmos"/>
@@ -190,11 +193,10 @@
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
-    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
     <!-- End physical pb_type binding in complex block IO -->
-
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->
     <pb_type name="clb">

--- a/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,64 +23,68 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io.outpad</loc>     
-             <loc side="right">io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!-- Perimeter of 'EMPTY' blocks -->   
-         <perimeter type="EMPTY" priority="100"/>   
-         <!--Fill with 'io'-->   
-         <fill type="io" priority="10"/>   
-         <!-- Build an inner region of clbs -->   
-         <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/>    
-      </auto_layout>  
-      <fixed_layout name="2x2" width="6" height="6">   
-         <!-- Perimeter of 'EMPTY' blocks -->   
-         <perimeter type="EMPTY" priority="100"/>   
-         <!--Fill with 'io'-->   
-         <fill type="io" priority="10"/>   
-         <!-- Build an inner region of clbs -->   
-         <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/>    
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io.outpad</loc>
+          <loc side="right">io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!-- Perimeter of 'EMPTY' blocks -->
+      <perimeter type="EMPTY" priority="100"/>
+      <!--Fill with 'io'-->
+      <fill type="io" priority="10"/>
+      <!-- Build an inner region of clbs -->
+      <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="6" height="6">
+      <!-- Perimeter of 'EMPTY' blocks -->
+      <perimeter type="EMPTY" priority="100"/>
+      <!--Fill with 'io'-->
+      <fill type="io" priority="10"/>
+      <!-- Build an inner region of clbs -->
+      <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -92,21 +98,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -118,81 +124,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -200,69 +206,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -270,23 +276,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,92 +23,96 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="48x48" width="50" height="50">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="72x72" width="74" height="74">
-        <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-        <perimeter type="io" priority="100"/>
-        <corners type="EMPTY" priority="101"/>
-        <!--Fill with 'clb'-->
-        <fill type="clb" priority="10"/>
-      </fixed_layout>
-      <fixed_layout name="96x96" width="98" height="98">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="72x72" width="74" height="74">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="96x96" width="98" height="98">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -120,21 +126,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -146,81 +152,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -228,69 +234,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -298,23 +304,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile4Clk_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile4Clk_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -13,8 +14,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -22,66 +24,70 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="4"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="4"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -95,21 +101,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -121,81 +127,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -203,69 +209,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="4"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="4"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -273,23 +279,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile8Clk_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTile8Clk_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -13,8 +14,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -22,66 +24,70 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="8"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="8"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -95,21 +101,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -121,81 +127,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -203,69 +209,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="8"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="8"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -273,23 +279,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,66 +23,70 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -94,21 +100,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -120,81 +126,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -202,69 +208,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -272,23 +278,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,69 +23,73 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad io.clk</loc>     
-             <loc side="top">io.outpad io.inpad io.clk</loc>     
-             <loc side="right">io.outpad io.inpad io.clk</loc>     
-             <loc side="bottom">io.outpad io.inpad io.clk</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad io.clk</loc>
+          <loc side="top">io.outpad io.inpad io.clk</loc>
+          <loc side="right">io.outpad io.inpad io.clk</loc>
+          <loc side="bottom">io.outpad io.inpad io.clk</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -97,21 +103,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -123,112 +129,112 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">     
-               <input name="D" num_pins="1" port_class="D"/>     
-               <output name="Q" num_pins="1" port_class="Q"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="66e-12" port="ff.D" clock="clk"/>     
-               <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="clk" input="io.clk" output="ff.clk"/>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <!-- Create a selector between registered/combinational I/O -->     
-               <direct name="inpad" input="iopad.inpad" output="ff.D"/>     
-               <mux name="mux1" input="iopad.inpad ff.Q" output="io.inpad">      
-                  <delay_constant max="4.5e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-                  <delay_constant max="4.243e-11" in_port="ff.Q" out_port="io.inpad"/>      
-               </mux>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="io.clk" output="ff.clk"/>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <!-- Create a selector between registered/combinational I/O -->
+          <direct name="inpad" input="iopad.inpad" output="ff.D"/>
+          <mux name="mux1" input="iopad.inpad ff.Q" output="io.inpad">
+            <delay_constant max="4.5e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+            <delay_constant max="4.243e-11" in_port="ff.Q" out_port="io.inpad"/>
+          </mux>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="inpad_registered">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">     
-               <input name="D" num_pins="1" port_class="D"/>     
-               <output name="Q" num_pins="1" port_class="Q"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="66e-12" port="ff.D" clock="clk"/>     
-               <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="clk" input="io.clk" output="ff.clk"/>     
-               <direct name="inpad" input="inpad.inpad" output="ff.D">      
-                  <pack_pattern name="registered_io" in_port="inpad.inpad" out_port="ff.D"/>      
-               </direct>     
-               <direct name="ff2inpad" input="ff.Q" output="io.inpad"/>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="inpad_registered">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="io.clk" output="ff.clk"/>
+          <direct name="inpad" input="inpad.inpad" output="ff.D">
+            <pack_pattern name="registered_io" in_port="inpad.inpad" out_port="ff.D"/>
+          </direct>
+          <direct name="ff2inpad" input="ff.Q" output="io.inpad"/>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -236,69 +242,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -306,23 +312,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzBr_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzBr_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,69 +23,73 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top"/>     
-             <loc side="right">clb.I[5:9] clb.O[2:3]</loc>     
-             <loc side="bottom">clb.clk clb.I[0:4] clb.O[0:1]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top"/>
+          <loc side="right">clb.I[5:9] clb.O[2:3]</loc>
+          <loc side="bottom">clb.clk clb.I[0:4] clb.O[0:1]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -97,21 +103,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -123,81 +129,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -205,69 +211,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -275,23 +281,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTl_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTl_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,69 +23,73 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">clb.clk clb.I[0:4] clb.O[0:1]</loc>     
-             <loc side="left">clb.I[5:9] clb.O[2:3]</loc>     
-             <loc side="right"/>     
-             <loc side="bottom"/>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">clb.clk clb.I[0:4] clb.O[0:1]</loc>
+          <loc side="left">clb.I[5:9] clb.O[2:3]</loc>
+          <loc side="right"/>
+          <loc side="bottom"/>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -97,21 +103,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -123,81 +129,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -205,69 +211,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -275,23 +281,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTr_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_TileOrgzTr_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,69 +23,73 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">clb.clk clb.I[0:4] clb.O[0:1]</loc>     
-             <loc side="right">clb.I[5:9] clb.O[2:3]</loc>     
-             <loc side="bottom"/>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">clb.clk clb.I[0:4] clb.O[0:1]</loc>
+          <loc side="right">clb.I[5:9] clb.O[2:3]</loc>
+          <loc side="bottom"/>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -97,21 +103,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -123,81 +129,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -205,69 +211,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -275,23 +281,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_customIoLoc_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,77 +23,85 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_top[0:1].inpad io_top[0:1].outpad</loc>     
-             <loc side="right">io_top[3:2].inpad</loc>     
-             <loc side="bottom">io_top[4:5].inpad io_top[2:4].outpad</loc>     
-             <loc side="left">io_top[6:7].inpad io_top[5:7].outpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="6">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom[0:1].outpad</loc>     
-             <loc side="right">io_bottom[2:2].outpad io_bottom[0:3].inpad</loc>     
-             <loc side="bottom">io_bottom[3:3].outpad</loc>     
-             <loc side="left">io_bottom[4:5].outpad io_bottom[4:5].inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="2">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_right[0:0].inpad</loc>     
-             <loc side="right">io_right[1:1].outpad</loc>     
-             <loc side="bottom">io_right[0:0].outpad</loc>     
-             <loc side="left">io_right[1:1].inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_top[0:1].inpad io_top[0:1].outpad</loc>
+          <loc side="right">io_top[3:2].inpad</loc>
+          <loc side="bottom">io_top[4:5].inpad io_top[2:4].outpad</loc>
+          <loc side="left">io_top[6:7].inpad io_top[5:7].outpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="6">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom[0:1].outpad</loc>
+          <loc side="right">io_bottom[2:2].outpad io_bottom[0:3].inpad</loc>
+          <loc side="bottom">io_bottom[3:3].outpad</loc>
+          <loc side="left">io_bottom[4:5].outpad io_bottom[4:5].inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="2">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_right[0:0].inpad</loc>
+          <loc side="right">io_right[1:1].outpad</loc>
+          <loc side="bottom">io_right[0:0].outpad</loc>
+          <loc side="left">io_right[1:1].inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'EMPTY' blocks, I/Os are placed on the inner ring
         Intend to have no I/Os on the left side, it is to check the correctness of I/O indexing in OpenFPGA
         -->
       <row type="io_top" starty="H-2" priority="90"/>
@@ -223,21 +233,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -249,81 +259,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -331,69 +341,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -401,23 +411,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_dsp8reg_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -15,8 +16,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -24,101 +26,107 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <model name="mult_8">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-      <tile name="mult_8" height="2" area="396000">   <sub_tile name="mult_8">    
-          <equivalent_sites>     
-             <site pb_type="mult_8" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="8"/>    
-          <input name="b" num_pins="8"/>    
-          <output name="out" num_pins="16"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!-- pinlocations are designed to spread pin on 4 sides evenly -->    
-          <pinlocations pattern="custom">     
-             <loc side="left">mult_8.a[0:3] mult_8.b[0:3] mult_8.out[0:7]</loc>     
-             <loc side="top">mult_8.clk</loc>     
-             <loc side="right">mult_8.a[4:7] mult_8.b[4:7] mult_8.out[8:15]</loc>     
-             <loc side="bottom"/>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="mult_8">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+    <tile name="mult_8" height="2" area="396000">
+      <sub_tile name="mult_8">
+        <equivalent_sites>
+          <site pb_type="mult_8" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="8"/>
+        <input name="b" num_pins="8"/>
+        <output name="out" num_pins="16"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- pinlocations are designed to spread pin on 4 sides evenly -->
+        <pinlocations pattern="custom">
+          <loc side="left">mult_8.a[0:3] mult_8.b[0:3] mult_8.out[0:7]</loc>
+          <loc side="top">mult_8.clk</loc>
+          <loc side="right">mult_8.a[4:7] mult_8.b[4:7] mult_8.out[8:15]</loc>
+          <loc side="bottom"/>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -132,21 +140,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -158,81 +166,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -240,69 +248,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -310,132 +318,131 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define 8-bit multiplier with input and output registers begin -->  
-      <pb_type name="mult_8">   
-         <input name="a" num_pins="8"/>   
-         <input name="b" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <output name="out" num_pins="16"/>   
-         <mode name="mult_8x8">    
-            <pb_type name="mult_8x8_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="8"/>     
-               <input name="B_cfg" num_pins="8"/>     
-               <output name="OUT_cfg" num_pins="16"/>     
-               <clock name="clk" num_pins="1"/>     
-               <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">      
-                  <input name="A" num_pins="8"/>      
-                  <input name="B" num_pins="8"/>      
-                  <output name="Y" num_pins="16"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>      
-               </pb_type>     
-               <pb_type name="ff_A" blif_model=".latch" num_pb="8" class="flipflop">      
-                  <input name="D" num_pins="1" port_class="D"/>      
-                  <output name="Q" num_pins="1" port_class="Q"/>      
-                  <clock name="clk" num_pins="1" port_class="clock"/>      
-                  <T_setup value="66e-12" port="ff_A.D" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_A.Q" clock="clk"/>      
-               </pb_type>     
-               <pb_type name="ff_B" blif_model=".latch" num_pb="8" class="flipflop">      
-                  <input name="D" num_pins="1" port_class="D"/>      
-                  <output name="Q" num_pins="1" port_class="Q"/>      
-                  <clock name="clk" num_pins="1" port_class="clock"/>      
-                  <T_setup value="66e-12" port="ff_B.D" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_B.Q" clock="clk"/>      
-               </pb_type>     
-               <pb_type name="ff_Y" blif_model=".latch" num_pb="16" class="flipflop">      
-                  <input name="D" num_pins="1" port_class="D"/>      
-                  <output name="Q" num_pins="1" port_class="Q"/>      
-                  <clock name="clk" num_pins="1" port_class="clock"/>      
-                  <T_setup value="66e-12" port="ff_Y.D" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_Y.Q" clock="clk"/>      
-               </pb_type>     
-               <interconnect>      
-                  <mux name="a2a0" input="mult_8x8_slice.A_cfg[0] ff_A[0].Q" output="mult_8x8.A[0]"/>      
-                  <mux name="a2a1" input="mult_8x8_slice.A_cfg[1] ff_A[1].Q" output="mult_8x8.A[1]"/>      
-                  <mux name="a2a2" input="mult_8x8_slice.A_cfg[2] ff_A[2].Q" output="mult_8x8.A[2]"/>      
-                  <mux name="a2a3" input="mult_8x8_slice.A_cfg[3] ff_A[3].Q" output="mult_8x8.A[3]"/>      
-                  <mux name="a2a4" input="mult_8x8_slice.A_cfg[4] ff_A[4].Q" output="mult_8x8.A[4]"/>      
-                  <mux name="a2a5" input="mult_8x8_slice.A_cfg[5] ff_A[5].Q" output="mult_8x8.A[5]"/>      
-                  <mux name="a2a6" input="mult_8x8_slice.A_cfg[6] ff_A[6].Q" output="mult_8x8.A[6]"/>      
-                  <mux name="a2a7" input="mult_8x8_slice.A_cfg[7] ff_A[7].Q" output="mult_8x8.A[7]"/>      
-                  <direct name="a2ff" input="mult_8x8_slice.A_cfg[7:0]" output="ff_A[7:0].D"/>      
-                  <mux name="b2b0" input="mult_8x8_slice.B_cfg[0] ff_B[0].Q" output="mult_8x8.B[0]"/>      
-                  <mux name="b2b1" input="mult_8x8_slice.B_cfg[1] ff_B[1].Q" output="mult_8x8.B[1]"/>      
-                  <mux name="b2b2" input="mult_8x8_slice.B_cfg[2] ff_B[2].Q" output="mult_8x8.B[2]"/>      
-                  <mux name="b2b3" input="mult_8x8_slice.B_cfg[3] ff_B[3].Q" output="mult_8x8.B[3]"/>      
-                  <mux name="b2b4" input="mult_8x8_slice.B_cfg[4] ff_B[4].Q" output="mult_8x8.B[4]"/>      
-                  <mux name="b2b5" input="mult_8x8_slice.B_cfg[5] ff_B[5].Q" output="mult_8x8.B[5]"/>      
-                  <mux name="b2b6" input="mult_8x8_slice.B_cfg[6] ff_B[6].Q" output="mult_8x8.B[6]"/>      
-                  <mux name="b2b7" input="mult_8x8_slice.B_cfg[7] ff_B[7].Q" output="mult_8x8.B[7]"/>      
-                  <direct name="b2ff" input="mult_8x8_slice.B_cfg[7:0]" output="ff_B[7:0].D"/>      
-                  <mux name="out2out0" input="mult_8x8.Y[0] ff_Y[0].Q" output="mult_8x8_slice.OUT_cfg[0]"/>      
-                  <mux name="out2out1" input="mult_8x8.Y[1] ff_Y[1].Q" output="mult_8x8_slice.OUT_cfg[1]"/>      
-                  <mux name="out2out2" input="mult_8x8.Y[2] ff_Y[2].Q" output="mult_8x8_slice.OUT_cfg[2]"/>      
-                  <mux name="out2out3" input="mult_8x8.Y[3] ff_Y[3].Q" output="mult_8x8_slice.OUT_cfg[3]"/>      
-                  <mux name="out2out4" input="mult_8x8.Y[4] ff_Y[4].Q" output="mult_8x8_slice.OUT_cfg[4]"/>      
-                  <mux name="out2out5" input="mult_8x8.Y[5] ff_Y[5].Q" output="mult_8x8_slice.OUT_cfg[5]"/>      
-                  <mux name="out2out6" input="mult_8x8.Y[6] ff_Y[6].Q" output="mult_8x8_slice.OUT_cfg[6]"/>      
-                  <mux name="out2out7" input="mult_8x8.Y[7] ff_Y[7].Q" output="mult_8x8_slice.OUT_cfg[7]"/>      
-                  <mux name="out2out8" input="mult_8x8.Y[8] ff_Y[8].Q" output="mult_8x8_slice.OUT_cfg[8]"/>      
-                  <mux name="out2out9" input="mult_8x8.Y[9] ff_Y[9].Q" output="mult_8x8_slice.OUT_cfg[9]"/>      
-                  <mux name="out2out10" input="mult_8x8.Y[10] ff_Y[10].Q" output="mult_8x8_slice.OUT_cfg[10]"/>      
-                  <mux name="out2out11" input="mult_8x8.Y[11] ff_Y[11].Q" output="mult_8x8_slice.OUT_cfg[11]"/>      
-                  <mux name="out2out12" input="mult_8x8.Y[12] ff_Y[12].Q" output="mult_8x8_slice.OUT_cfg[12]"/>      
-                  <mux name="out2out13" input="mult_8x8.Y[13] ff_Y[13].Q" output="mult_8x8_slice.OUT_cfg[13]"/>      
-                  <mux name="out2out14" input="mult_8x8.Y[14] ff_Y[14].Q" output="mult_8x8_slice.OUT_cfg[14]"/>      
-                  <mux name="out2out15" input="mult_8x8.Y[15] ff_Y[15].Q" output="mult_8x8_slice.OUT_cfg[15]"/>      
-                  <direct name="out2ff" input="mult_8x8.Y[15:0]" output="ff_Y[15:0].D"/>      
-                  <complete name="clk_ff_A" input="mult_8x8_slice.clk" output="ff_A.clk"/>      
-                  <complete name="clk_ff_B" input="mult_8x8_slice.clk" output="ff_B.clk"/>      
-                  <complete name="clk_ff_Y" input="mult_8x8_slice.clk" output="ff_Y.clk"/>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define 8-bit multiplier with input and output registers begin -->
+    <pb_type name="mult_8">
+      <input name="a" num_pins="8"/>
+      <input name="b" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <output name="out" num_pins="16"/>
+      <mode name="mult_8x8">
+        <pb_type name="mult_8x8_slice" num_pb="1">
+          <input name="A_cfg" num_pins="8"/>
+          <input name="B_cfg" num_pins="8"/>
+          <output name="OUT_cfg" num_pins="16"/>
+          <clock name="clk" num_pins="1"/>
+          <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">
+            <input name="A" num_pins="8"/>
+            <input name="B" num_pins="8"/>
+            <output name="Y" num_pins="16"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
+          </pb_type>
+          <pb_type name="ff_A" blif_model=".latch" num_pb="8" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff_A.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_A.Q" clock="clk"/>
+          </pb_type>
+          <pb_type name="ff_B" blif_model=".latch" num_pb="8" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff_B.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_B.Q" clock="clk"/>
+          </pb_type>
+          <pb_type name="ff_Y" blif_model=".latch" num_pb="16" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff_Y.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_Y.Q" clock="clk"/>
+          </pb_type>
+          <interconnect>
+            <mux name="a2a0" input="mult_8x8_slice.A_cfg[0] ff_A[0].Q" output="mult_8x8.A[0]"/>
+            <mux name="a2a1" input="mult_8x8_slice.A_cfg[1] ff_A[1].Q" output="mult_8x8.A[1]"/>
+            <mux name="a2a2" input="mult_8x8_slice.A_cfg[2] ff_A[2].Q" output="mult_8x8.A[2]"/>
+            <mux name="a2a3" input="mult_8x8_slice.A_cfg[3] ff_A[3].Q" output="mult_8x8.A[3]"/>
+            <mux name="a2a4" input="mult_8x8_slice.A_cfg[4] ff_A[4].Q" output="mult_8x8.A[4]"/>
+            <mux name="a2a5" input="mult_8x8_slice.A_cfg[5] ff_A[5].Q" output="mult_8x8.A[5]"/>
+            <mux name="a2a6" input="mult_8x8_slice.A_cfg[6] ff_A[6].Q" output="mult_8x8.A[6]"/>
+            <mux name="a2a7" input="mult_8x8_slice.A_cfg[7] ff_A[7].Q" output="mult_8x8.A[7]"/>
+            <direct name="a2ff" input="mult_8x8_slice.A_cfg[7:0]" output="ff_A[7:0].D"/>
+            <mux name="b2b0" input="mult_8x8_slice.B_cfg[0] ff_B[0].Q" output="mult_8x8.B[0]"/>
+            <mux name="b2b1" input="mult_8x8_slice.B_cfg[1] ff_B[1].Q" output="mult_8x8.B[1]"/>
+            <mux name="b2b2" input="mult_8x8_slice.B_cfg[2] ff_B[2].Q" output="mult_8x8.B[2]"/>
+            <mux name="b2b3" input="mult_8x8_slice.B_cfg[3] ff_B[3].Q" output="mult_8x8.B[3]"/>
+            <mux name="b2b4" input="mult_8x8_slice.B_cfg[4] ff_B[4].Q" output="mult_8x8.B[4]"/>
+            <mux name="b2b5" input="mult_8x8_slice.B_cfg[5] ff_B[5].Q" output="mult_8x8.B[5]"/>
+            <mux name="b2b6" input="mult_8x8_slice.B_cfg[6] ff_B[6].Q" output="mult_8x8.B[6]"/>
+            <mux name="b2b7" input="mult_8x8_slice.B_cfg[7] ff_B[7].Q" output="mult_8x8.B[7]"/>
+            <direct name="b2ff" input="mult_8x8_slice.B_cfg[7:0]" output="ff_B[7:0].D"/>
+            <mux name="out2out0" input="mult_8x8.Y[0] ff_Y[0].Q" output="mult_8x8_slice.OUT_cfg[0]"/>
+            <mux name="out2out1" input="mult_8x8.Y[1] ff_Y[1].Q" output="mult_8x8_slice.OUT_cfg[1]"/>
+            <mux name="out2out2" input="mult_8x8.Y[2] ff_Y[2].Q" output="mult_8x8_slice.OUT_cfg[2]"/>
+            <mux name="out2out3" input="mult_8x8.Y[3] ff_Y[3].Q" output="mult_8x8_slice.OUT_cfg[3]"/>
+            <mux name="out2out4" input="mult_8x8.Y[4] ff_Y[4].Q" output="mult_8x8_slice.OUT_cfg[4]"/>
+            <mux name="out2out5" input="mult_8x8.Y[5] ff_Y[5].Q" output="mult_8x8_slice.OUT_cfg[5]"/>
+            <mux name="out2out6" input="mult_8x8.Y[6] ff_Y[6].Q" output="mult_8x8_slice.OUT_cfg[6]"/>
+            <mux name="out2out7" input="mult_8x8.Y[7] ff_Y[7].Q" output="mult_8x8_slice.OUT_cfg[7]"/>
+            <mux name="out2out8" input="mult_8x8.Y[8] ff_Y[8].Q" output="mult_8x8_slice.OUT_cfg[8]"/>
+            <mux name="out2out9" input="mult_8x8.Y[9] ff_Y[9].Q" output="mult_8x8_slice.OUT_cfg[9]"/>
+            <mux name="out2out10" input="mult_8x8.Y[10] ff_Y[10].Q" output="mult_8x8_slice.OUT_cfg[10]"/>
+            <mux name="out2out11" input="mult_8x8.Y[11] ff_Y[11].Q" output="mult_8x8_slice.OUT_cfg[11]"/>
+            <mux name="out2out12" input="mult_8x8.Y[12] ff_Y[12].Q" output="mult_8x8_slice.OUT_cfg[12]"/>
+            <mux name="out2out13" input="mult_8x8.Y[13] ff_Y[13].Q" output="mult_8x8_slice.OUT_cfg[13]"/>
+            <mux name="out2out14" input="mult_8x8.Y[14] ff_Y[14].Q" output="mult_8x8_slice.OUT_cfg[14]"/>
+            <mux name="out2out15" input="mult_8x8.Y[15] ff_Y[15].Q" output="mult_8x8_slice.OUT_cfg[15]"/>
+            <direct name="out2ff" input="mult_8x8.Y[15:0]" output="ff_Y[15:0].D"/>
+            <complete name="clk_ff_A" input="mult_8x8_slice.clk" output="ff_A.clk"/>
+            <complete name="clk_ff_B" input="mult_8x8_slice.clk" output="ff_B.clk"/>
+            <complete name="clk_ff_Y" input="mult_8x8_slice.clk" output="ff_Y.clk"/>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
 		   to a 134 ps delay.
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_8.a" output="mult_8x8_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_8.a" out_port="mult_8x8_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_8.b" output="mult_8x8_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_8.b" out_port="mult_8x8_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_8x8_slice.OUT_cfg" output="mult_8.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice.OUT_cfg" out_port="mult_8.out"/>      
-               </direct>     
-               <complete name="clk" input="mult_8.clk" output="mult_8x8_slice.clk"/>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-
-   </complexblocklist> 
+              -->
+          <direct name="a2a" input="mult_8.a" output="mult_8x8_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_8.a" out_port="mult_8x8_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_8.b" output="mult_8x8_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_8.b" out_port="mult_8x8_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_8x8_slice.OUT_cfg" output="mult_8.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice.OUT_cfg" out_port="mult_8.out"/>
+          </direct>
+          <complete name="clk" input="mult_8.clk" output="mult_8x8_slice.clk"/>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_full_output_crossbar_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_full_output_crossbar_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -13,8 +14,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -22,64 +24,68 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="10" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="full"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="full"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -93,21 +99,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -119,81 +125,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -201,69 +207,69 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="10" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="full"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="full"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -271,25 +277,25 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <complete name="output_crossbar" input="fle[3:0].out" output="clb.O">     
-               <delay_constant max="45e-12" in_port="fle[3:0].out" out_port="clb.O"/>     
-            </complete>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <complete name="output_crossbar" input="fle[3:0].out" output="clb.O">
+          <delay_constant max="45e-12" in_port="fle[3:0].out" out_port="clb.O"/>
+        </complete>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_no_local_routing_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_no_local_routing_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -13,8 +14,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -22,67 +24,71 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="4" equivalent="full"/>    
-          <input name="I1" num_pins="4" equivalent="full"/>    
-          <input name="I2" num_pins="4" equivalent="full"/>    
-          <input name="I3" num_pins="4" equivalent="full"/>    
-          <output name="O" num_pins="4" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="4" equivalent="full"/>
+        <input name="I1" num_pins="4" equivalent="full"/>
+        <input name="I2" num_pins="4" equivalent="full"/>
+        <input name="I3" num_pins="4" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -96,21 +102,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -122,81 +128,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -204,91 +210,91 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <!-- FIXME These inputs should be logic equivalent
+	   -->
+    <pb_type name="clb">
+      <!-- FIXME These inputs should be logic equivalent
            However, current annotation engine does not support this
            The feature should be enabled after patching
-        -->   
-         <input name="I0" num_pins="4" equivalent="full"/>   
-         <input name="I1" num_pins="4" equivalent="full"/>   
-         <input name="I2" num_pins="4" equivalent="full"/>   
-         <input name="I3" num_pins="4" equivalent="full"/>   
-         <output name="O" num_pins="4" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+        -->
+      <input name="I0" num_pins="4" equivalent="full"/>
+      <input name="I1" num_pins="4" equivalent="full"/>
+      <input name="I2" num_pins="4" equivalent="full"/>
+      <input name="I3" num_pins="4" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <direct name="crossbar0" input="clb.I0" output="fle[0:0].in"/>    
-            <direct name="crossbar1" input="clb.I1" output="fle[1:1].in"/>    
-            <direct name="crossbar2" input="clb.I2" output="fle[2:2].in"/>    
-            <direct name="crossbar3" input="clb.I3" output="fle[3:3].in"/>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <direct name="crossbar0" input="clb.I0" output="fle[0:0].in"/>
+        <direct name="crossbar1" input="clb.I1" output="fle[1:1].in"/>
+        <direct name="crossbar2" input="clb.I2" output="fle[2:2].in"/>
+        <direct name="crossbar3" input="clb.I3" output="fle[3:3].in"/>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="output_crossbar" input="fle[3:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="output_crossbar" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_N5_tileable_pattern_local_routing_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N5_tileable_pattern_local_routing_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,64 +23,68 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <output name="O" num_pins="5" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <output name="O" num_pins="5" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -92,21 +98,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -118,81 +124,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -200,73 +206,73 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <output name="O" num_pins="5" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <output name="O" num_pins="5" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 4-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="5">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="1"/>    
-            <output name="lut_out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="lut_out" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+        -->
+      <pb_type name="fle" num_pb="5">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <output name="lut_out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="lut_out" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="lut4.out" output="ble4.lut_out"/>       
-                     <direct name="direct4" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="ble4.lut_out" output="fle.lut_out[0:0]"/>      
-                  <direct name="direct4" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="lut4.out" output="ble4.lut_out"/>
+              <direct name="direct4" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="ble4.lut_out" output="fle.lut_out[0:0]"/>
+            <direct name="direct4" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -274,81 +280,81 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <!-- Local routing for FLE[0] inputs -->    
-            <complete name="crossbar_fle0" input="clb.I fle[4:0].out" output="fle[0:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[0:0].in"/>     
-            </complete>    
-            <!-- Local routing for FLE[1] inputs -->    
-            <complete name="crossbar_fle1_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[1:1].in[0]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[1:1].in[0]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[1:1].in[0]"/>     
-            </complete>    
-            <complete name="crossbar_fle1" input="clb.I fle[4:0].out" output="fle[1:1].in[1:3]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[1:1].in[1:3]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[1:1].in[1:3]"/>     
-            </complete>    
-            <!-- Local routing for FLE[2] inputs -->    
-            <complete name="crossbar_fle2_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[2:2].in[0]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[2:2].in[0]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[2:2].in[0]"/>     
-            </complete>    
-            <complete name="crossbar_fle2_in1" input="clb.I fle[4:0].out fle[1:1].lut_out" output="fle[2:2].in[1]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[2:2].in[1]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[1:1].lut_out" out_port="fle[2:2].in[1]"/>     
-            </complete>    
-            <complete name="crossbar_fle2" input="clb.I fle[4:0].out" output="fle[2:2].in[2:3]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[2:2].in[2:3]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[2:2].in[2:3]"/>     
-            </complete>    
-            <!-- Local routing for FLE[3] inputs -->    
-            <complete name="crossbar_fle3_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[3:3].in[0]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[0]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[3:3].in[0]"/>     
-            </complete>    
-            <complete name="crossbar_fle3_in1" input="clb.I fle[4:0].out fle[1:1].lut_out" output="fle[3:3].in[1]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[1]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[1:1].lut_out" out_port="fle[3:3].in[1]"/>     
-            </complete>    
-            <complete name="crossbar_fle3_in2" input="clb.I fle[4:0].out fle[2:2].lut_out" output="fle[3:3].in[2]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[2]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[2:2].lut_out" out_port="fle[3:3].in[2]"/>     
-            </complete>    
-            <complete name="crossbar_fle3" input="clb.I fle[4:0].out" output="fle[3:3].in[3:3]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[3:3]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[3:3].in[3:3]"/>     
-            </complete>    
-            <!-- Local routing for FLE[4] inputs -->    
-            <complete name="crossbar_fle4_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[4:4].in[0]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[0]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[4:4].in[0]"/>     
-            </complete>    
-            <complete name="crossbar_fle4_in1" input="clb.I fle[4:0].out fle[1:1].lut_out" output="fle[4:4].in[1]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[1]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[1:1].lut_out" out_port="fle[4:4].in[1]"/>     
-            </complete>    
-            <complete name="crossbar_fle4_in2" input="clb.I fle[4:0].out fle[2:2].lut_out" output="fle[4:4].in[2]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[2]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[2:2].lut_out" out_port="fle[4:4].in[2]"/>     
-            </complete>    
-            <complete name="crossbar_fle4_in3" input="clb.I fle[4:0].out fle[3:3].lut_out" output="fle[4:4].in[3]">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[3]"/>     
-               <delay_constant max="75e-12" in_port="fle[4:0].out fle[3:3].lut_out" out_port="fle[4:4].in[3]"/>     
-            </complete>    
-            <!-- Local clock connections -->    
-            <complete name="clks" input="clb.clk" output="fle[4:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <!-- Local routing for FLE[0] inputs -->
+        <complete name="crossbar_fle0" input="clb.I fle[4:0].out" output="fle[0:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[0:0].in"/>
+        </complete>
+        <!-- Local routing for FLE[1] inputs -->
+        <complete name="crossbar_fle1_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[1:1].in[0]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[1:1].in[0]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[1:1].in[0]"/>
+        </complete>
+        <complete name="crossbar_fle1" input="clb.I fle[4:0].out" output="fle[1:1].in[1:3]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[1:1].in[1:3]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[1:1].in[1:3]"/>
+        </complete>
+        <!-- Local routing for FLE[2] inputs -->
+        <complete name="crossbar_fle2_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[2:2].in[0]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[2:2].in[0]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[2:2].in[0]"/>
+        </complete>
+        <complete name="crossbar_fle2_in1" input="clb.I fle[4:0].out fle[1:1].lut_out" output="fle[2:2].in[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[2:2].in[1]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[1:1].lut_out" out_port="fle[2:2].in[1]"/>
+        </complete>
+        <complete name="crossbar_fle2" input="clb.I fle[4:0].out" output="fle[2:2].in[2:3]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[2:2].in[2:3]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[2:2].in[2:3]"/>
+        </complete>
+        <!-- Local routing for FLE[3] inputs -->
+        <complete name="crossbar_fle3_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[3:3].in[0]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[0]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[3:3].in[0]"/>
+        </complete>
+        <complete name="crossbar_fle3_in1" input="clb.I fle[4:0].out fle[1:1].lut_out" output="fle[3:3].in[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[1]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[1:1].lut_out" out_port="fle[3:3].in[1]"/>
+        </complete>
+        <complete name="crossbar_fle3_in2" input="clb.I fle[4:0].out fle[2:2].lut_out" output="fle[3:3].in[2]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[2]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[2:2].lut_out" out_port="fle[3:3].in[2]"/>
+        </complete>
+        <complete name="crossbar_fle3" input="clb.I fle[4:0].out" output="fle[3:3].in[3:3]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:3].in[3:3]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out" out_port="fle[3:3].in[3:3]"/>
+        </complete>
+        <!-- Local routing for FLE[4] inputs -->
+        <complete name="crossbar_fle4_in0" input="clb.I fle[4:0].out fle[0:0].lut_out" output="fle[4:4].in[0]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[0]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[0:0].lut_out" out_port="fle[4:4].in[0]"/>
+        </complete>
+        <complete name="crossbar_fle4_in1" input="clb.I fle[4:0].out fle[1:1].lut_out" output="fle[4:4].in[1]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[1]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[1:1].lut_out" out_port="fle[4:4].in[1]"/>
+        </complete>
+        <complete name="crossbar_fle4_in2" input="clb.I fle[4:0].out fle[2:2].lut_out" output="fle[4:4].in[2]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[2]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[2:2].lut_out" out_port="fle[4:4].in[2]"/>
+        </complete>
+        <complete name="crossbar_fle4_in3" input="clb.I fle[4:0].out fle[3:3].lut_out" output="fle[4:4].in[3]">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[4:4].in[3]"/>
+          <delay_constant max="75e-12" in_port="fle[4:0].out fle[3:3].lut_out" out_port="fle[4:4].in[3]"/>
+        </complete>
+        <!-- Local clock connections -->
+        <complete name="clks" input="clb.clk" output="fle[4:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[4:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[4:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_fracNative_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_fracNative_N4_tileable_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,85 +23,89 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -113,21 +119,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -139,87 +145,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -227,168 +232,168 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define a native (no mode switch) 4-input fracturable LUT 
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define a native (no mode switch) 4-input fracturable LUT 
                    Different from standard fracturable LUT4 whose input can be tri-stated
                    to enable fracturable output,
                    The native fracturable LUT4 has a LUT3 output without any switches
                    to enable it. Therefore, none of its inputs will be tri-stated
                    The LUT3 output is directly wired to an internal point of LUT4
                    which can be considered a spy output
-                -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="1"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                        <direct name="direct3" input="frac_lut4.lut4_out[0]" output="frac_logic.out[1]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- 3-LUT + LUT4 with shared inputs mode definition begin -->    
-            <mode name="shared_lut3_lut4">     
-               <pb_type name="ble3" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT3 -->      
-                  <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="3" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="1"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+                <direct name="direct3" input="frac_lut4.lut4_out[0]" output="frac_logic.out[1]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- 3-LUT + LUT4 with shared inputs mode definition begin -->
+        <mode name="shared_lut3_lut4">
+          <pb_type name="ble3" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT3 -->
+            <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="3" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define the flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                 </pb_type>      
-                 <interconnect>       
-                    <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>       
-                    <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">        
-                       <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                       <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>        
-                    </direct>       
-                    <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>       
-                    <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">        
-                       <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                       <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>        
-                       <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>        
-                    </mux>       
-                 </interconnect>      
-               </pb_type>     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT4 -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+              </delay_matrix>
+            </pb_type>
+            <!-- Define the flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+              <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+              </direct>
+              <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+              <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT4 -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define the flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                 </pb_type>      
-                 <interconnect>       
-                    <direct name="direct1" input="ble4.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                    <direct name="direct2" input="lut4[0:0].out" output="ff[0:0].D">        
-                       <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                       <pack_pattern name="ble4" in_port="lut4[0:0].out" out_port="ff[0:0].D"/>        
-                    </direct>       
-                    <direct name="direct3" input="ble4.clk" output="ff[0:0].clk"/>       
-                    <mux name="mux1" input="ff[0:0].Q lut4.out[0:0]" output="ble4.out[0:0]">        
-                       <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                       <delay_constant max="25e-12" in_port="lut4.out[0:0]" out_port="ble4.out[0:0]"/>        
-                       <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble4.out[0:0]"/>        
-                    </mux>       
-                 </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="ble3.in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="ble4.in"/>      
-                  <direct name="direct3" input="ble3.out" output="fle.out[0:0]"/>      
-                  <direct name="direct4" input="ble4.out" output="fle.out[1:1]"/>      
-                  <direct name="direct5" input="fle.clk" output="ble3.clk"/>      
-                  <direct name="direct6" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define the flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="direct2" input="lut4[0:0].out" output="ff[0:0].D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4[0:0].out" out_port="ff[0:0].D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff[0:0].clk"/>
+              <mux name="mux1" input="ff[0:0].Q lut4.out[0:0]" output="ble4.out[0:0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out[0:0]" out_port="ble4.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble4.out[0:0]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="ble3.in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="ble4.in"/>
+            <direct name="direct3" input="ble3.out" output="fle.out[0:0]"/>
+            <direct name="direct4" input="ble4.out" output="fle.out[1:1]"/>
+            <direct name="direct5" input="fle.clk" output="ble3.clk"/>
+            <direct name="direct6" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -396,24 +401,24 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N1_tileable_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N1_tileable_fracff_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -8,8 +9,9 @@
   - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -17,128 +19,132 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dff">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffr">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="R" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-     <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffrn">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="RN" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dff">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffrn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="RN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="4" equivalent="full"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="2" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="48x48" width="50" height="50">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="4" equivalent="full"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="2" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -152,21 +158,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -178,87 +184,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -266,224 +271,224 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="4" equivalent="full"/>   
-         <input name="reset" num_pins="1"/>   
-         <output name="O" num_pins="2" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="4" equivalent="full"/>
+      <input name="reset" num_pins="1"/>
+      <output name="O" num_pins="2" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="1">    
-            <input name="in" num_pins="4"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="C" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="C"/>       
-                     <T_setup value="66e-12" port="ff.R" clock="C"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>       
-                     <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="1">
+        <input name="in" num_pins="4"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">
+              <input name="D" num_pins="1" port_class="D"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="C" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="C"/>
+              <T_setup value="66e-12" port="ff.R" clock="C"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>
+              <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct4" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <input name="reset" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" num_pb="1">        
-                        <input name="D" num_pins="1"/>        
-                        <input name="R" num_pins="1"/>        
-                        <output name="Q" num_pins="1"/>        
-                        <clock name="C" num_pins="1"/>        
-                        <mode name="latch">         
-                           <pb_type name="latch" blif_model=".latch" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="latch.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="latch.D"/>          
-                              <direct name="direct2" input="ff.C" output="latch.clk"/>          
-                              <direct name="direct3" input="latch.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dff">         
-                           <pb_type name="dff" blif_model=".subckt dff" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dff.D" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dff.D"/>          
-                              <direct name="direct2" input="ff.C" output="dff.C"/>          
-                              <direct name="direct3" input="dff.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffr">         
-                           <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="R" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffr.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffr.R" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffr.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffr.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffr.R"/>          
-                              <direct name="direct4" input="dffr.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffrn">         
-                           <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="RN" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffrn.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffrn.RN" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffrn.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffrn.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffrn.RN"/>          
-                              <direct name="direct4" input="dffrn.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                     </pb_type>        
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>        
-                        <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                     <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" num_pb="1">
+                <input name="D" num_pins="1"/>
+                <input name="R" num_pins="1"/>
+                <output name="Q" num_pins="1"/>
+                <clock name="C" num_pins="1"/>
+                <mode name="latch">
+                  <pb_type name="latch" blif_model=".latch" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="latch.D"/>
+                    <direct name="direct2" input="ff.C" output="latch.clk"/>
+                    <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dff">
+                  <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dff.D" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dff.D"/>
+                    <direct name="direct2" input="ff.C" output="dff.C"/>
+                    <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffr">
+                  <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="R" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffr.D"/>
+                    <direct name="direct2" input="ff.C" output="dffr.C"/>
+                    <direct name="direct3" input="ff.R" output="dffr.R"/>
+                    <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffrn">
+                  <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="RN" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                    <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                    <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                    <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>
+                <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+              <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+            <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -491,109 +496,109 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define the flip-flop -->      
-                  <pb_type name="ff" num_pb="1">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="C" num_pins="1"/>       
-                     <mode name="latch">        
-                        <pb_type name="latch" blif_model=".latch" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="clk" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="latch.D" clock="clk"/>         
-                           <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="latch.D"/>         
-                           <direct name="direct2" input="ff.C" output="latch.clk"/>         
-                           <direct name="direct3" input="latch.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dff">        
-                        <pb_type name="dff" blif_model=".subckt dff" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dff.D" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dff.D"/>         
-                           <direct name="direct2" input="ff.C" output="dff.C"/>         
-                           <direct name="direct3" input="dff.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffr">        
-                        <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffr.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffr.R" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffr.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffr.R"/>         
-                           <direct name="direct4" input="dffr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffrn">        
-                        <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffrn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffrn.RN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffrn.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffrn.RN"/>         
-                           <direct name="direct4" input="dffrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>       
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.C"/>       
-                     <direct name="direct4" input="ble4.reset" output="ff.R"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="ble4.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define the flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.C"/>
+              <direct name="direct4" input="ble4.reset" output="ff.R"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+            <direct name="direct4" input="fle.reset" output="ble4.reset"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -601,26 +606,26 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[0:0].out" output="fle[0:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[0:0].out" out_port="fle[0:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[0:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[0:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[0:0].out" output="fle[0:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[0:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[0:0].out" out_port="fle[0:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[0:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[0:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[0:0].out[0:0]" output="clb.O[0:0]"/>    
-            <direct name="clbouts2" input="fle[0:0].out[1:1]" output="clb.O[1:1]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[0:0].out[0:0]" output="clb.O[0:0]"/>
+        <direct name="clbouts2" input="fle[0:0].out[1:1]" output="clb.O[1:1]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,85 +23,89 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -113,21 +119,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -139,87 +145,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -227,150 +232,150 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -378,46 +383,46 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -425,24 +430,24 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,85 +23,89 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -113,21 +119,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -139,87 +145,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -227,150 +232,150 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -378,46 +383,46 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -425,24 +430,24 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,107 +23,111 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[3:0] clb.I[5:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[3:0] clb.I[5:0]</loc>
+          <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -135,21 +141,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -161,90 +167,89 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -252,265 +257,265 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>       
-                     <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>       
-                     <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>
+              <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>
+              <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- BEGIN arithmetic mode of dual lut3 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="3" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- BEGIN arithmetic mode of dual lut3 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="3" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  -->
+              <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <complete name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>       
-                     <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
-              </direct>       
-                     <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
-              </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>        
-                     </mux>       
-                     <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <complete name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>
+              <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
+              </direct>
+              <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>
+              </mux>
+              <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>
+                <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -518,46 +523,46 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -565,36 +570,36 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">     
-               <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">
+          <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,150 +23,156 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[3:0] clb.I[5:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="7"/>    
-          <input name="raddr" num_pins="7"/>    
-          <input name="d_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[3:0] clb.I[5:0]</loc>
+          <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="7"/>
+        <input name="raddr" num_pins="7"/>
+        <input name="d_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -178,21 +186,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -204,90 +212,89 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -295,265 +302,265 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>       
-                     <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>       
-                     <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>
+              <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>
+              <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- BEGIN arithmetic mode of dual lut3 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="3" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- BEGIN arithmetic mode of dual lut3 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="3" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  -->
+              <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <complete name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>       
-                     <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
-              </direct>       
-                     <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
-              </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>        
-                     </mux>       
-                     <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <complete name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>
+              <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
+              </direct>
+              <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>
+              </mux>
+              <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>
+                <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -561,46 +568,46 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -608,94 +615,94 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">     
-               <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="7"/>   
-         <input name="raddr" num_pins="7"/>   
-         <input name="d_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 128x8=1Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">
+          <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="7"/>
+      <input name="raddr" num_pins="7"/>
+      <input name="d_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 128x8=1Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 1K dual-port RAM
-        -->   
-         <mode name="mem_128x8_dp">    
-            <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="7" port_class="address"/>     
-               <input name="raddr" num_pins="7" port_class="address"/>     
-               <input name="d_in" num_pins="8" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="8" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_128x8_dp">
+        <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="7" port_class="address"/>
+          <input name="raddr" num_pins="7" port_class="address"/>
+          <input name="d_in" num_pins="8" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -15,8 +16,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -24,150 +26,156 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[3:0] clb.I[5:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="7"/>    
-          <input name="raddr" num_pins="7"/>    
-          <input name="d_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[3:0] clb.I[5:0]</loc>
+          <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="7"/>
+        <input name="raddr" num_pins="7"/>
+        <input name="d_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -181,21 +189,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -207,102 +215,101 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="1.000000" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="1.000000" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="1.000000" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="1.000000" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -310,265 +317,265 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>       
-                     <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>       
-                     <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>
+              <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>
+              <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- BEGIN arithmetic mode of dual lut3 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="3" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- BEGIN arithmetic mode of dual lut3 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="3" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  -->
+              <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <complete name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>       
-                     <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
-              </direct>       
-                     <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
-              </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>        
-                     </mux>       
-                     <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <complete name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>
+              <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
+              </direct>
+              <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>
+              </mux>
+              <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>
+                <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -576,46 +583,46 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -623,94 +630,94 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">     
-               <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="7"/>   
-         <input name="raddr" num_pins="7"/>   
-         <input name="d_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 128x8=1Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">
+          <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="7"/>
+      <input name="raddr" num_pins="7"/>
+      <input name="d_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 128x8=1Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 1K dual-port RAM
-        -->   
-         <mode name="mem_128x8_dp">    
-            <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="7" port_class="address"/>     
-               <input name="raddr" num_pins="7" port_class="address"/>     
-               <input name="d_in" num_pins="8" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="8" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_128x8_dp">
+        <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="7" port_class="address"/>
+          <input name="raddr" num_pins="7" port_class="address"/>
+          <input name="d_in" num_pins="8" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_frac_dsp32_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_frac_dsp32_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -17,8 +18,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -26,172 +28,180 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <model name="multiply">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="out"/>    
-            <port name="b" combinational_sink_ports="out"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="multiply">
+      <input_ports>
+        <port name="a" combinational_sink_ports="out"/>
+        <port name="b" combinational_sink_ports="out"/>
+      </input_ports>
+      <output_ports>
+        <port name="out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[3:0] clb.I[5:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="7"/>    
-          <input name="raddr" num_pins="7"/>    
-          <input name="d_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-      <tile name="mult_32" height="4" area="396000">   <sub_tile name="mult_32">    
-          <equivalent_sites>     
-             <site pb_type="mult_32" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="32"/>    
-          <input name="b" num_pins="32"/>    
-          <output name="out" num_pins="64"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <pinlocations pattern="spread"/>    
-          <!--pinlocations pattern="custom">
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[3:0] clb.I[5:0]</loc>
+          <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="7"/>
+        <input name="raddr" num_pins="7"/>
+        <input name="d_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+    <tile name="mult_32" height="4" area="396000">
+      <sub_tile name="mult_32">
+        <equivalent_sites>
+          <site pb_type="mult_32" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="32"/>
+        <input name="b" num_pins="32"/>
+        <output name="out" num_pins="64"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <pinlocations pattern="spread"/>
+        <!--pinlocations pattern="custom">
         <loc side="left"></loc>
         <loc side="top"></loc>
         <loc side="right">mult_32.a[0:15] mult_32.b[0:15] mult_32.out[0:31]</loc>
         <loc side="bottom">mult_32.a[16:31] mult_32.b[16:31] mult_32.out[32:63]</loc>
-      </pinlocations-->    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_32' with 'EMPTY' blocks wherever a 'mult_32' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_32" startx="4" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="4" repeatx="8" starty="1" priority="19"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_32' with 'EMPTY' blocks wherever a 'mult_32' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_32" startx="4" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="4" repeatx="8" starty="1" priority="19"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+      </pinlocations-->
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_32' with 'EMPTY' blocks wherever a 'mult_32' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_32" startx="4" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="4" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_32' with 'EMPTY' blocks wherever a 'mult_32' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_32" startx="4" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="4" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -205,21 +215,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -231,90 +241,89 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -322,265 +331,265 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>       
-                     <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>       
-                     <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>
+              <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>
+              <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- BEGIN arithmetic mode of dual lut3 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="3" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- BEGIN arithmetic mode of dual lut3 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="3" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  -->
+              <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <complete name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>       
-                     <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
-              </direct>       
-                     <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
-              </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>        
-                     </mux>       
-                     <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <complete name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>
+              <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
+              </direct>
+              <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>
+              </mux>
+              <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>
+                <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -588,46 +597,46 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -635,97 +644,97 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">     
-               <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="7"/>   
-         <input name="raddr" num_pins="7"/>   
-         <input name="d_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 128x8=1Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">
+          <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="7"/>
+      <input name="raddr" num_pins="7"/>
+      <input name="d_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 128x8=1Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 1K dual-port RAM
-        -->   
-         <mode name="mem_128x8_dp">    
-            <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="7" port_class="address"/>     
-               <input name="raddr" num_pins="7" port_class="address"/>     
-               <input name="d_in" num_pins="8" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="8" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-      <!-- Define fracturable multiplier begin -->  
-      <!-- This multiplier can operate as a 32x32 multiplier that can fracture to two 16x16 multipliers each of which can further fracture to two 8x8 multipliers 
+        -->
+      <mode name="mem_128x8_dp">
+        <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="7" port_class="address"/>
+          <input name="raddr" num_pins="7" port_class="address"/>
+          <input name="d_in" num_pins="8" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+    <!-- Define fracturable multiplier begin -->
+    <!-- This multiplier can operate as a 32x32 multiplier that can fracture to two 16x16 multipliers each of which can further fracture to two 8x8 multipliers 
 	   For delay modelling, the 32x32 DSP multiplier in Stratix IV has a maximum delay of 1.523 ns + 1.93 ns
 	    = 3.45 ns. The average difference between the maximum and minimum values of a dsp mac out in 36 bit multiply
 		mode is 0.51. Hence, the minimum delay is modeled as 0.776 ns + 0.984 ns = 1.760 ns.
@@ -748,154 +757,153 @@
 		  block (single tile). It also includes 3.6x the outputs of a logic block, and 1.8x the inputs. Hence a slight overestimate of the routing
 		  area associated with our DSP block is four times that of a logic tile, where the routing area of a logic tile was calculated above (at W = 300)
 		  as 30481 MWTAs. Hence the (core, non-routing) area our DSP block is approximately 518,000 - 4 * 30,481 = 396,000 MWTUs.
-      -->  
-      <pb_type name="mult_32">   
-         <input name="a" num_pins="32"/>   
-         <input name="b" num_pins="32"/>   
-         <output name="out" num_pins="64"/>   
-         <mode name="two_divisible_mult_16x16">    
-            <pb_type name="divisible_mult_16x16" num_pb="2">     
-               <input name="a" num_pins="16"/>     
-               <input name="b" num_pins="16"/>     
-               <output name="out" num_pins="32"/>     
-               <!-- Model 8x8 delay and 16x16 delay as the same.  8x8 could be faster, but in Stratix IV
+      -->
+    <pb_type name="mult_32">
+      <input name="a" num_pins="32"/>
+      <input name="b" num_pins="32"/>
+      <output name="out" num_pins="64"/>
+      <mode name="two_divisible_mult_16x16">
+        <pb_type name="divisible_mult_16x16" num_pb="2">
+          <input name="a" num_pins="16"/>
+          <input name="b" num_pins="16"/>
+          <output name="out" num_pins="32"/>
+          <!-- Model 8x8 delay and 16x16 delay as the same.  8x8 could be faster, but in Stratix IV
 	          isn't, presumably because the multiplier layout is really optimized for 16x16.
-		        -->     
-               <mode name="two_mult_8x8">      
-                  <pb_type name="mult_8x8_slice" num_pb="2">       
-                     <input name="A_cfg" num_pins="8"/>       
-                     <input name="B_cfg" num_pins="8"/>       
-                     <output name="OUT_cfg" num_pins="16"/>       
-                     <pb_type name="mult_8x8" blif_model=".subckt multiply" num_pb="1">        
-                        <input name="a" num_pins="8"/>        
-                        <input name="b" num_pins="8"/>        
-                        <output name="out" num_pins="16"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.a" out_port="mult_8x8.out"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.b" out_port="mult_8x8.out"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.a">
-                </direct>        
-                        <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.b">
-                </direct>        
-                        <direct name="out2out" input="mult_8x8.out" output="mult_8x8_slice.OUT_cfg">
-                </direct>        
-                     </interconnect>       
-                     <power method="pin-toggle">        
-                        <port name="A_cfg" energy_per_toggle="1.45e-12"/>        
-                        <port name="B_cfg" energy_per_toggle="1.45e-12"/>        
-                        <static_power power_per_instance="0.0"/>        
-                     </power>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="a2a" input="divisible_mult_16x16.a" output="mult_8x8_slice[1:0].A_cfg">
-              </direct>       
-                     <direct name="b2b" input="divisible_mult_16x16.b" output="mult_8x8_slice[1:0].B_cfg">
-              </direct>       
-                     <direct name="out2out" input="mult_8x8_slice[1:0].OUT_cfg" output="divisible_mult_16x16.out">
-              </direct>       
-                  </interconnect>      
-               </mode>     
-               <mode name="mult_16x16">      
-                  <pb_type name="mult_16x16_slice" num_pb="1">       
-                     <input name="A_cfg" num_pins="16"/>       
-                     <input name="B_cfg" num_pins="16"/>       
-                     <output name="OUT_cfg" num_pins="32"/>       
-                     <pb_type name="mult_16x16" blif_model=".subckt multiply" num_pb="1">        
-                        <input name="a" num_pins="16"/>        
-                        <input name="b" num_pins="16"/>        
-                        <output name="out" num_pins="32"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.a" out_port="mult_16x16.out"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.b" out_port="mult_16x16.out"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="a2a" input="mult_16x16_slice.A_cfg" output="mult_16x16.a">
-                </direct>        
-                        <direct name="b2b" input="mult_16x16_slice.B_cfg" output="mult_16x16.b">
-                </direct>        
-                        <direct name="out2out" input="mult_16x16.out" output="mult_16x16_slice.OUT_cfg">
-                </direct>        
-                     </interconnect>       
-                     <power method="pin-toggle">        
-                        <port name="A_cfg" energy_per_toggle="1.09e-12"/>        
-                        <port name="B_cfg" energy_per_toggle="1.09e-12"/>        
-                        <static_power power_per_instance="0.0"/>        
-                     </power>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="a2a" input="divisible_mult_16x16.a" output="mult_16x16_slice.A_cfg">
-              </direct>       
-                     <direct name="b2b" input="divisible_mult_16x16.b" output="mult_16x16_slice.B_cfg">
-              </direct>       
-                     <direct name="out2out" input="mult_16x16_slice.OUT_cfg" output="divisible_mult_16x16.out">
-              </direct>       
-                  </interconnect>      
-               </mode>     
-               <power method="sum-of-children"/>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		        -->
+          <mode name="two_mult_8x8">
+            <pb_type name="mult_8x8_slice" num_pb="2">
+              <input name="A_cfg" num_pins="8"/>
+              <input name="B_cfg" num_pins="8"/>
+              <output name="OUT_cfg" num_pins="16"/>
+              <pb_type name="mult_8x8" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="8"/>
+                <input name="b" num_pins="8"/>
+                <output name="out" num_pins="16"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.a" out_port="mult_8x8.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.b" out_port="mult_8x8.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.a">
+                </direct>
+                <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.b">
+                </direct>
+                <direct name="out2out" input="mult_8x8.out" output="mult_8x8_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.45e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.45e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_16x16.a" output="mult_8x8_slice[1:0].A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_16x16.b" output="mult_8x8_slice[1:0].B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_8x8_slice[1:0].OUT_cfg" output="divisible_mult_16x16.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <mode name="mult_16x16">
+            <pb_type name="mult_16x16_slice" num_pb="1">
+              <input name="A_cfg" num_pins="16"/>
+              <input name="B_cfg" num_pins="16"/>
+              <output name="OUT_cfg" num_pins="32"/>
+              <pb_type name="mult_16x16" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="16"/>
+                <input name="b" num_pins="16"/>
+                <output name="out" num_pins="32"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.a" out_port="mult_16x16.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.b" out_port="mult_16x16.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_16x16_slice.A_cfg" output="mult_16x16.a">
+                </direct>
+                <direct name="b2b" input="mult_16x16_slice.B_cfg" output="mult_16x16.b">
+                </direct>
+                <direct name="out2out" input="mult_16x16.out" output="mult_16x16_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.09e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.09e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_16x16.a" output="mult_16x16_slice.A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_16x16.b" output="mult_16x16_slice.B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_16x16_slice.OUT_cfg" output="divisible_mult_16x16.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <power method="sum-of-children"/>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading 134 ps
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_32.a" output="divisible_mult_16x16[1:0].a">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_32.a" out_port="divisible_mult_16x16[1:0].a"/>      
-               </direct>     
-               <direct name="b2b" input="mult_32.b" output="divisible_mult_16x16[1:0].b">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_32.b" out_port="divisible_mult_16x16[1:0].b"/>      
-               </direct>     
-               <direct name="out2out" input="divisible_mult_16x16[1:0].out" output="mult_32.out">      
-                  <delay_constant max="1.09e-9" min="74e-12" in_port="divisible_mult_16x16[1:0].out" out_port="mult_32.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mult_32x32">    
-            <pb_type name="mult_32x32_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="32"/>     
-               <input name="B_cfg" num_pins="32"/>     
-               <output name="OUT_cfg" num_pins="64"/>     
-               <pb_type name="mult_32x32" blif_model=".subckt multiply" num_pb="1">      
-                  <input name="a" num_pins="32"/>      
-                  <input name="b" num_pins="32"/>      
-                  <output name="out" num_pins="64"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_32x32.a" out_port="mult_32x32.out"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_32x32.b" out_port="mult_32x32.out"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_32x32_slice.A_cfg" output="mult_32x32.a">
-            </direct>      
-                  <direct name="b2b" input="mult_32x32_slice.B_cfg" output="mult_32x32.b">
-            </direct>      
-                  <direct name="out2out" input="mult_32x32.out" output="mult_32x32_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+              -->
+          <direct name="a2a" input="mult_32.a" output="divisible_mult_16x16[1:0].a">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_32.a" out_port="divisible_mult_16x16[1:0].a"/>
+          </direct>
+          <direct name="b2b" input="mult_32.b" output="divisible_mult_16x16[1:0].b">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_32.b" out_port="divisible_mult_16x16[1:0].b"/>
+          </direct>
+          <direct name="out2out" input="divisible_mult_16x16[1:0].out" output="mult_32.out">
+            <delay_constant max="1.09e-9" min="74e-12" in_port="divisible_mult_16x16[1:0].out" out_port="mult_32.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_32x32">
+        <pb_type name="mult_32x32_slice" num_pb="1">
+          <input name="A_cfg" num_pins="32"/>
+          <input name="B_cfg" num_pins="32"/>
+          <output name="OUT_cfg" num_pins="64"/>
+          <pb_type name="mult_32x32" blif_model=".subckt multiply" num_pb="1">
+            <input name="a" num_pins="32"/>
+            <input name="b" num_pins="32"/>
+            <output name="out" num_pins="64"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_32x32.a" out_port="mult_32x32.out"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_32x32.b" out_port="mult_32x32.out"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_32x32_slice.A_cfg" output="mult_32x32.a">
+            </direct>
+            <direct name="b2b" input="mult_32x32_slice.B_cfg" output="mult_32x32.b">
+            </direct>
+            <direct name="out2out" input="mult_32x32.out" output="mult_32x32_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
 		   to a 134 ps delay.
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_32.a" output="mult_32x32_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_32.a" out_port="mult_32x32_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_32.b" output="mult_32x32_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_32.b" out_port="mult_32x32_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_32x32_slice.OUT_cfg" output="mult_32.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_32x32_slice.OUT_cfg" out_port="mult_32.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-
-   </complexblocklist> 
+              -->
+          <direct name="a2a" input="mult_32.a" output="mult_32x32_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_32.a" out_port="mult_32x32_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_32.b" output="mult_32x32_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_32.b" out_port="mult_32x32_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_32x32_slice.OUT_cfg" output="mult_32.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_32x32_slice.OUT_cfg" out_port="mult_32.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff2edge_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff2edge_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -8,8 +9,9 @@
   - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -17,160 +19,164 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dff">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffn">   
-         <input_ports>    
-            <port name="D" clock="CN"/>    
-            <port name="CN" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="CN"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffr">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="R" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffnr">   
-         <input_ports>    
-            <port name="D" clock="CN"/>    
-            <port name="R" clock="CN"/>    
-            <port name="CN" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="CN"/>    
-         </output_ports>   
-      </model>  
-     <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffrn">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="RN" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffnrn">   
-         <input_ports>    
-            <port name="D" clock="CN"/>    
-            <port name="RN" clock="CN"/>    
-            <port name="CN" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="CN"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dff">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffn">
+      <input_ports>
+        <port name="D" clock="CN"/>
+        <port name="CN" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="CN"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffnr">
+      <input_ports>
+        <port name="D" clock="CN"/>
+        <port name="R" clock="CN"/>
+        <port name="CN" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="CN"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffrn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="RN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffnrn">
+      <input_ports>
+        <port name="D" clock="CN"/>
+        <port name="RN" clock="CN"/>
+        <port name="CN" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="CN"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="48x48" width="50" height="50">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -184,21 +190,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -210,87 +216,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -298,272 +303,272 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <input name="reset" num_pins="1"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="reset" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="C" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="C"/>       
-                     <T_setup value="66e-12" port="ff.R" clock="C"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>       
-                     <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">
+              <input name="D" num_pins="1" port_class="D"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="C" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="C"/>
+              <T_setup value="66e-12" port="ff.R" clock="C"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>
+              <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct4" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <input name="reset" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" num_pb="1">        
-                        <input name="D" num_pins="1"/>        
-                        <input name="R" num_pins="1"/>        
-                        <output name="Q" num_pins="1"/>        
-                        <clock name="C" num_pins="1"/>        
-                        <mode name="latch">         
-                           <pb_type name="latch" blif_model=".latch" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="latch.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="latch.D"/>          
-                              <direct name="direct2" input="ff.C" output="latch.clk"/>          
-                              <direct name="direct3" input="latch.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dff">         
-                           <pb_type name="dff" blif_model=".subckt dff" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dff.D" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dff.D"/>          
-                              <direct name="direct2" input="ff.C" output="dff.C"/>          
-                              <direct name="direct3" input="dff.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffn">         
-                           <pb_type name="dffn" blif_model=".subckt dffn" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="CN" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffn.D" clock="CN"/>          
-                              <T_clock_to_Q max="124e-12" port="dffn.Q" clock="CN"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffn.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffn.CN"/>          
-                              <direct name="direct3" input="dffn.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffr">         
-                           <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="R" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffr.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffr.R" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffr.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffr.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffr.R"/>          
-                              <direct name="direct4" input="dffr.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffnr">         
-                           <pb_type name="dffnr" blif_model=".subckt dffnr" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="R" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="CN" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffnr.D" clock="CN"/>          
-                              <T_setup value="66e-12" port="dffnr.R" clock="CN"/>          
-                              <T_clock_to_Q max="124e-12" port="dffnr.Q" clock="CN"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffnr.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffnr.CN"/>          
-                              <direct name="direct3" input="ff.R" output="dffnr.R"/>          
-                              <direct name="direct4" input="dffnr.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffrn">         
-                           <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="RN" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffrn.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffrn.RN" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffrn.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffrn.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffrn.RN"/>          
-                              <direct name="direct4" input="dffrn.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffnrn">         
-                           <pb_type name="dffnrn" blif_model=".subckt dffnrn" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="RN" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="CN" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffnrn.D" clock="CN"/>          
-                              <T_setup value="66e-12" port="dffnrn.RN" clock="CN"/>          
-                              <T_clock_to_Q max="124e-12" port="dffnrn.Q" clock="CN"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffnrn.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffnrn.CN"/>          
-                              <direct name="direct3" input="ff.R" output="dffnrn.RN"/>          
-                              <direct name="direct4" input="dffnrn.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                     </pb_type>        
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>        
-                        <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                     <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" num_pb="1">
+                <input name="D" num_pins="1"/>
+                <input name="R" num_pins="1"/>
+                <output name="Q" num_pins="1"/>
+                <clock name="C" num_pins="1"/>
+                <mode name="latch">
+                  <pb_type name="latch" blif_model=".latch" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="latch.D"/>
+                    <direct name="direct2" input="ff.C" output="latch.clk"/>
+                    <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dff">
+                  <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dff.D" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dff.D"/>
+                    <direct name="direct2" input="ff.C" output="dff.C"/>
+                    <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffn">
+                  <pb_type name="dffn" blif_model=".subckt dffn" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="CN" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffn.D" clock="CN"/>
+                    <T_clock_to_Q max="124e-12" port="dffn.Q" clock="CN"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffn.D"/>
+                    <direct name="direct2" input="ff.C" output="dffn.CN"/>
+                    <direct name="direct3" input="dffn.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffr">
+                  <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="R" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffr.D"/>
+                    <direct name="direct2" input="ff.C" output="dffr.C"/>
+                    <direct name="direct3" input="ff.R" output="dffr.R"/>
+                    <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffnr">
+                  <pb_type name="dffnr" blif_model=".subckt dffnr" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="R" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="CN" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffnr.D" clock="CN"/>
+                    <T_setup value="66e-12" port="dffnr.R" clock="CN"/>
+                    <T_clock_to_Q max="124e-12" port="dffnr.Q" clock="CN"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffnr.D"/>
+                    <direct name="direct2" input="ff.C" output="dffnr.CN"/>
+                    <direct name="direct3" input="ff.R" output="dffnr.R"/>
+                    <direct name="direct4" input="dffnr.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffrn">
+                  <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="RN" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                    <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                    <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                    <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffnrn">
+                  <pb_type name="dffnrn" blif_model=".subckt dffnrn" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="RN" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="CN" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffnrn.D" clock="CN"/>
+                    <T_setup value="66e-12" port="dffnrn.RN" clock="CN"/>
+                    <T_clock_to_Q max="124e-12" port="dffnrn.Q" clock="CN"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffnrn.D"/>
+                    <direct name="direct2" input="ff.C" output="dffnrn.CN"/>
+                    <direct name="direct3" input="ff.R" output="dffnrn.RN"/>
+                    <direct name="direct4" input="dffnrn.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>
+                <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+              <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+            <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -571,157 +576,157 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define the flip-flop -->      
-                  <pb_type name="ff" num_pb="1">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="C" num_pins="1"/>       
-                     <mode name="latch">        
-                        <pb_type name="latch" blif_model=".latch" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="clk" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="latch.D" clock="clk"/>         
-                           <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="latch.D"/>         
-                           <direct name="direct2" input="ff.C" output="latch.clk"/>         
-                           <direct name="direct3" input="latch.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dff">        
-                        <pb_type name="dff" blif_model=".subckt dff" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dff.D" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dff.D"/>         
-                           <direct name="direct2" input="ff.C" output="dff.C"/>         
-                           <direct name="direct3" input="dff.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffn">        
-                        <pb_type name="dffn" blif_model=".subckt dffn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="CN" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffn.D" clock="CN"/>         
-                           <T_clock_to_Q max="124e-12" port="dffn.Q" clock="CN"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffn.CN"/>         
-                           <direct name="direct3" input="dffn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffr">        
-                        <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffr.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffr.R" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffr.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffr.R"/>         
-                           <direct name="direct4" input="dffr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffnr">        
-                        <pb_type name="dffnr" blif_model=".subckt dffnr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="CN" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffnr.D" clock="CN"/>         
-                           <T_setup value="66e-12" port="dffnr.R" clock="CN"/>         
-                           <T_clock_to_Q max="124e-12" port="dffnr.Q" clock="CN"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffnr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffnr.CN"/>         
-                           <direct name="direct3" input="ff.R" output="dffnr.R"/>         
-                           <direct name="direct4" input="dffnr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffrn">        
-                        <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffrn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffrn.RN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffrn.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffrn.RN"/>         
-                           <direct name="direct4" input="dffrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffnrn">        
-                        <pb_type name="dffnrn" blif_model=".subckt dffnrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="CN" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffnrn.D" clock="CN"/>         
-                           <T_setup value="66e-12" port="dffnrn.RN" clock="CN"/>         
-                           <T_clock_to_Q max="124e-12" port="dffnrn.Q" clock="CN"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffnrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffnrn.CN"/>         
-                           <direct name="direct3" input="ff.R" output="dffnrn.RN"/>         
-                           <direct name="direct4" input="dffnrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>       
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.C"/>       
-                     <direct name="direct4" input="ble4.reset" output="ff.R"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="ble4.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define the flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffn">
+                <pb_type name="dffn" blif_model=".subckt dffn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="CN" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffn.D" clock="CN"/>
+                  <T_clock_to_Q max="124e-12" port="dffn.Q" clock="CN"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffn.CN"/>
+                  <direct name="direct3" input="dffn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffnr">
+                <pb_type name="dffnr" blif_model=".subckt dffnr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="CN" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffnr.D" clock="CN"/>
+                  <T_setup value="66e-12" port="dffnr.R" clock="CN"/>
+                  <T_clock_to_Q max="124e-12" port="dffnr.Q" clock="CN"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffnr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffnr.CN"/>
+                  <direct name="direct3" input="ff.R" output="dffnr.R"/>
+                  <direct name="direct4" input="dffnr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffnrn">
+                <pb_type name="dffnrn" blif_model=".subckt dffnrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="CN" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffnrn.D" clock="CN"/>
+                  <T_setup value="66e-12" port="dffnrn.RN" clock="CN"/>
+                  <T_clock_to_Q max="124e-12" port="dffnrn.Q" clock="CN"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffnrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffnrn.CN"/>
+                  <direct name="direct3" input="ff.R" output="dffnrn.RN"/>
+                  <direct name="direct4" input="dffnrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.C"/>
+              <direct name="direct4" input="ble4.reset" output="ff.R"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+            <direct name="direct4" input="fle.reset" output="ble4.reset"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -729,26 +734,26 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[3:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[3:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -8,8 +9,9 @@
   - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -17,128 +19,132 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dff">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffr">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="R" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-     <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffrn">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="RN" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dff">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffrn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="RN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="48x48" width="50" height="50">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -152,21 +158,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -178,87 +184,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -266,224 +271,224 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <input name="reset" num_pins="1"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="reset" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="C" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="C"/>       
-                     <T_setup value="66e-12" port="ff.R" clock="C"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>       
-                     <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">
+              <input name="D" num_pins="1" port_class="D"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="C" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="C"/>
+              <T_setup value="66e-12" port="ff.R" clock="C"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>
+              <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct4" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <input name="reset" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" num_pb="1">        
-                        <input name="D" num_pins="1"/>        
-                        <input name="R" num_pins="1"/>        
-                        <output name="Q" num_pins="1"/>        
-                        <clock name="C" num_pins="1"/>        
-                        <mode name="latch">         
-                           <pb_type name="latch" blif_model=".latch" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="latch.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="latch.D"/>          
-                              <direct name="direct2" input="ff.C" output="latch.clk"/>          
-                              <direct name="direct3" input="latch.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dff">         
-                           <pb_type name="dff" blif_model=".subckt dff" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dff.D" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dff.D"/>          
-                              <direct name="direct2" input="ff.C" output="dff.C"/>          
-                              <direct name="direct3" input="dff.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffr">         
-                           <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="R" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffr.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffr.R" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffr.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffr.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffr.R"/>          
-                              <direct name="direct4" input="dffr.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffrn">         
-                           <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="RN" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffrn.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffrn.RN" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffrn.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffrn.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffrn.RN"/>          
-                              <direct name="direct4" input="dffrn.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                     </pb_type>        
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>        
-                        <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                     <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" num_pb="1">
+                <input name="D" num_pins="1"/>
+                <input name="R" num_pins="1"/>
+                <output name="Q" num_pins="1"/>
+                <clock name="C" num_pins="1"/>
+                <mode name="latch">
+                  <pb_type name="latch" blif_model=".latch" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="latch.D"/>
+                    <direct name="direct2" input="ff.C" output="latch.clk"/>
+                    <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dff">
+                  <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dff.D" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dff.D"/>
+                    <direct name="direct2" input="ff.C" output="dff.C"/>
+                    <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffr">
+                  <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="R" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffr.D"/>
+                    <direct name="direct2" input="ff.C" output="dffr.C"/>
+                    <direct name="direct3" input="ff.R" output="dffr.R"/>
+                    <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffrn">
+                  <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="RN" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                    <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                    <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                    <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>
+                <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+              <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+            <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -491,109 +496,109 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define the flip-flop -->      
-                  <pb_type name="ff" num_pb="1">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="C" num_pins="1"/>       
-                     <mode name="latch">        
-                        <pb_type name="latch" blif_model=".latch" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="clk" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="latch.D" clock="clk"/>         
-                           <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="latch.D"/>         
-                           <direct name="direct2" input="ff.C" output="latch.clk"/>         
-                           <direct name="direct3" input="latch.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dff">        
-                        <pb_type name="dff" blif_model=".subckt dff" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dff.D" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dff.D"/>         
-                           <direct name="direct2" input="ff.C" output="dff.C"/>         
-                           <direct name="direct3" input="dff.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffr">        
-                        <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffr.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffr.R" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffr.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffr.R"/>         
-                           <direct name="direct4" input="dffr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffrn">        
-                        <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffrn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffrn.RN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffrn.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffrn.RN"/>         
-                           <direct name="direct4" input="dffrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>       
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.C"/>       
-                     <direct name="direct4" input="ble4.reset" output="ff.R"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="ble4.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define the flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.C"/>
+              <direct name="direct4" input="ble4.reset" output="ff.R"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+            <direct name="direct4" input="fle.reset" output="ble4.reset"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -601,26 +606,26 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[3:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[3:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_rstOnLut_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_rstOnLut_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -8,8 +9,9 @@
   - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -17,128 +19,132 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dff">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffr">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="R" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-     <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="dffrn">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="RN" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dff">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="dffrn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="RN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="48x48" width="50" height="50">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -152,21 +158,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -178,87 +184,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -266,224 +271,224 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <input name="reset" num_pins="1"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="reset" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="C" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="C"/>       
-                     <T_setup value="66e-12" port="ff.R" clock="C"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>       
-                     <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".subckt dffr" num_pb="2">
+              <input name="D" num_pins="1" port_class="D"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="C" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="C"/>
+              <T_setup value="66e-12" port="ff.R" clock="C"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].C"/>
+              <complete name="direct4" input="fabric.reset" output="ff[1:0].R"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct4" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <input name="reset" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" num_pb="1">        
-                        <input name="D" num_pins="1"/>        
-                        <input name="R" num_pins="1"/>        
-                        <output name="Q" num_pins="1"/>        
-                        <clock name="C" num_pins="1"/>        
-                        <mode name="latch">         
-                           <pb_type name="latch" blif_model=".latch" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="latch.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="latch.D"/>          
-                              <direct name="direct2" input="ff.C" output="latch.clk"/>          
-                              <direct name="direct3" input="latch.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dff">         
-                           <pb_type name="dff" blif_model=".subckt dff" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dff.D" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dff.D"/>          
-                              <direct name="direct2" input="ff.C" output="dff.C"/>          
-                              <direct name="direct3" input="dff.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffr">         
-                           <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="R" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffr.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffr.R" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffr.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffr.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffr.R"/>          
-                              <direct name="direct4" input="dffr.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                        <mode name="dffrn">         
-                           <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <input name="RN" num_pins="1"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="C" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="dffrn.D" clock="C"/>          
-                              <T_setup value="66e-12" port="dffrn.RN" clock="C"/>          
-                              <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>          
-                           </pb_type>          
-                           <interconnect>          
-                              <direct name="direct1" input="ff.D" output="dffrn.D"/>          
-                              <direct name="direct2" input="ff.C" output="dffrn.C"/>          
-                              <direct name="direct3" input="ff.R" output="dffrn.RN"/>          
-                              <direct name="direct4" input="dffrn.Q" output="ff.Q"/>          
-                           </interconnect>         
-                        </mode>        
-                     </pb_type>        
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>        
-                        <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                     <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" num_pb="1">
+                <input name="D" num_pins="1"/>
+                <input name="R" num_pins="1"/>
+                <output name="Q" num_pins="1"/>
+                <clock name="C" num_pins="1"/>
+                <mode name="latch">
+                  <pb_type name="latch" blif_model=".latch" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="latch.D"/>
+                    <direct name="direct2" input="ff.C" output="latch.clk"/>
+                    <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dff">
+                  <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dff.D" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dff.D"/>
+                    <direct name="direct2" input="ff.C" output="dff.C"/>
+                    <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffr">
+                  <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="R" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffr.D"/>
+                    <direct name="direct2" input="ff.C" output="dffr.C"/>
+                    <direct name="direct3" input="ff.R" output="dffr.R"/>
+                    <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+                <mode name="dffrn">
+                  <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <input name="RN" num_pins="1"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="C" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                    <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                    <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                    <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                    <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                    <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                  </interconnect>
+                </mode>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].C"/>
+                <direct name="direct4" input="ble3.reset" output="ff[0:0].R"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+              <complete name="complete2" input="lut3inter.reset" output="ble3[1:0].reset"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+            <direct name="direct4" input="fle.reset" output="lut3inter.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -491,109 +496,109 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define the flip-flop -->      
-                  <pb_type name="ff" num_pb="1">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="R" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="C" num_pins="1"/>       
-                     <mode name="latch">        
-                        <pb_type name="latch" blif_model=".latch" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="clk" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="latch.D" clock="clk"/>         
-                           <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="latch.D"/>         
-                           <direct name="direct2" input="ff.C" output="latch.clk"/>         
-                           <direct name="direct3" input="latch.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dff">        
-                        <pb_type name="dff" blif_model=".subckt dff" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dff.D" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dff.D"/>         
-                           <direct name="direct2" input="ff.C" output="dff.C"/>         
-                           <direct name="direct3" input="dff.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffr">        
-                        <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffr.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffr.R" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffr.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffr.R"/>         
-                           <direct name="direct4" input="dffr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffrn">        
-                        <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffrn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffrn.RN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffrn.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffrn.RN"/>         
-                           <direct name="direct4" input="dffrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>       
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.C"/>       
-                     <direct name="direct4" input="ble4.reset" output="ff.R"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="ble4.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define the flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.C"/>
+              <direct name="direct4" input="ble4.reset" output="ff.R"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+            <direct name="direct4" input="fle.reset" output="ble4.reset"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -601,26 +606,26 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out clb.reset" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I clb.reset" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[3:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out clb.reset" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I clb.reset" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[3:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_lutram_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_lutram_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -13,8 +14,9 @@
   Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -22,102 +24,106 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="spram_4x1">   
-         <input_ports>    
-            <port name="wr_en" clock="clk"/>    
-            <port name="addr" clock="clk"/>    
-            <port name="d_in" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="spram_4x1">
+      <input_ports>
+        <port name="wr_en" clock="clk"/>
+        <port name="addr" clock="clk"/>
+        <port name="d_in" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="12" equivalent="full"/>    
-          <output name="O" num_pins="8" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top"/>     
-             <loc side="right">clb.O[3:0] clb.I[5:0]</loc>     
-             <loc side="bottom">clb.O[7:4] clb.I[11:6]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top"/>
+          <loc side="right">clb.O[3:0] clb.I[5:0]</loc>
+          <loc side="bottom">clb.O[7:4] clb.I[11:6]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -131,21 +137,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -157,87 +163,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -245,222 +250,222 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="12" equivalent="full"/>   
-         <output name="O" num_pins="8" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="4">    
-            <input name="in" num_pins="4"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <!-- Define spram_4x1 -->      
-                  <pb_type name="spram_4x1" blif_model=".subckt spram_4x1" num_pb="1">       
-                     <input name="wr_en" num_pins="1"/>       
-                     <input name="addr" num_pins="2"/>       
-                     <input name="d_in" num_pins="1"/>       
-                     <output name="d_out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-          		       <T_setup value="509e-12" port="spram_4x1.wr_en" clock="clk"/>       
-          		       <T_setup value="509e-12" port="spram_4x1.addr" clock="clk"/>       
-         		       <T_setup value="509e-12" port="spram_4x1.d_in" clock="clk"/>       
-          		       <T_clock_to_Q max="1.234e-9" port="spram_4x1.d_out" clock="clk"/>       
-          	         <power method="pin-toggle">        
-            	        <port name="clk" energy_per_toggle="17.9e-12"/>        
-            	        <static_power power_per_instance="0.0"/>        
-          	         </power>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct_mem_en" input="fabric.in[0]" output="spram_4x1.wr_en"/>       
-                     <direct name="direct_mem_in" input="fabric.in[3]" output="spram_4x1.d_in"/>       
-                     <direct name="direct_mem_addr" input="fabric.in[2:1]" output="spram_4x1.addr"/>       
-                     <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <complete name="direct_mem_clk" input="fabric.clk" output="spram_4x1.clk"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] spram_4x1.d_out" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="spram_4x1.d_out" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] spram_4x1.d_out" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="spram_4x1.d_out" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="spram_4x1.d_out ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define spram_4x1 -->
+            <pb_type name="spram_4x1" blif_model=".subckt spram_4x1" num_pb="1">
+              <input name="wr_en" num_pins="1"/>
+              <input name="addr" num_pins="2"/>
+              <input name="d_in" num_pins="1"/>
+              <output name="d_out" num_pins="1"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="509e-12" port="spram_4x1.wr_en" clock="clk"/>
+              <T_setup value="509e-12" port="spram_4x1.addr" clock="clk"/>
+              <T_setup value="509e-12" port="spram_4x1.d_in" clock="clk"/>
+              <T_clock_to_Q max="1.234e-9" port="spram_4x1.d_out" clock="clk"/>
+              <power method="pin-toggle">
+                <port name="clk" energy_per_toggle="17.9e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct_mem_en" input="fabric.in[0]" output="spram_4x1.wr_en"/>
+              <direct name="direct_mem_in" input="fabric.in[3]" output="spram_4x1.d_in"/>
+              <direct name="direct_mem_addr" input="fabric.in[2:1]" output="spram_4x1.addr"/>
+              <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="direct_mem_clk" input="fabric.clk" output="spram_4x1.clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] spram_4x1.d_out" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="spram_4x1.d_out" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] spram_4x1.d_out" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="spram_4x1.d_out" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="spram_4x1.d_out ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- BEGIN lutram mode -->    
-            <mode name="lutram">     
-               <pb_type name="lutram" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="spram_4x1" blif_model=".subckt spram_4x1" num_pb="1">       
-                     <input name="wr_en" num_pins="1"/>       
-                     <input name="addr" num_pins="2"/>       
-                     <input name="d_in" num_pins="1"/>       
-                     <output name="d_out" num_pins="1"/>       
-			         <clock name="clk" num_pins="1" port_class="clock"/>       
-          		       <T_setup value="509e-12" port="spram_4x1.wr_en" clock="clk"/>       
-          		       <T_setup value="509e-12" port="spram_4x1.addr" clock="clk"/>       
-         		       <T_setup value="509e-12" port="spram_4x1.d_in" clock="clk"/>       
-          		       <T_clock_to_Q max="1.234e-9" port="spram_4x1.d_out" clock="clk"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock_mem" input="lutram.clk" output="spram_4x1.clk"/>       
-                     <direct name="mem_wr_en" input="lutram.in[0]" output="spram_4x1.wr_en"/>       
-                     <direct name="mem_addr" input="lutram.in[2:1]" output="spram_4x1.addr"/>       
-                     <direct name="mem_d_in" input="lutram.in[3]" output="spram_4x1.d_in"/>       
-                     <complete name="ff_d" input="spram_4x1.d_out" output="ff.D"/>       
-                     <complete name="clock_ff" input="lutram.clk" output="ff.clk"/>       
-                     <mux name="mem_out_0" input="ff[0].Q spram_4x1.d_out" output="lutram.out[0]">        
-                        <delay_constant max="25e-12" in_port="spram_4x1.d_out" out_port="lutram.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="lutram.out"/>        
-                     </mux>       
-                     <mux name="mem_out_1" input="ff[1].Q spram_4x1.d_out" output="lutram.out[1]">        
-                        <delay_constant max="25e-12" in_port="spram_4x1.d_out" out_port="lutram.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="lutram.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="lutram.in"/>      
-                  <direct name="direct3" input="fle.clk" output="lutram.clk"/>      
-                  <direct name="direct4" input="lutram.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- BEGIN lutram mode -->
+        <mode name="lutram">
+          <pb_type name="lutram" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="spram_4x1" blif_model=".subckt spram_4x1" num_pb="1">
+              <input name="wr_en" num_pins="1"/>
+              <input name="addr" num_pins="2"/>
+              <input name="d_in" num_pins="1"/>
+              <output name="d_out" num_pins="1"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="509e-12" port="spram_4x1.wr_en" clock="clk"/>
+              <T_setup value="509e-12" port="spram_4x1.addr" clock="clk"/>
+              <T_setup value="509e-12" port="spram_4x1.d_in" clock="clk"/>
+              <T_clock_to_Q max="1.234e-9" port="spram_4x1.d_out" clock="clk"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock_mem" input="lutram.clk" output="spram_4x1.clk"/>
+              <direct name="mem_wr_en" input="lutram.in[0]" output="spram_4x1.wr_en"/>
+              <direct name="mem_addr" input="lutram.in[2:1]" output="spram_4x1.addr"/>
+              <direct name="mem_d_in" input="lutram.in[3]" output="spram_4x1.d_in"/>
+              <complete name="ff_d" input="spram_4x1.d_out" output="ff.D"/>
+              <complete name="clock_ff" input="lutram.clk" output="ff.clk"/>
+              <mux name="mem_out_0" input="ff[0].Q spram_4x1.d_out" output="lutram.out[0]">
+                <delay_constant max="25e-12" in_port="spram_4x1.d_out" out_port="lutram.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="lutram.out"/>
+              </mux>
+              <mux name="mem_out_1" input="ff[1].Q spram_4x1.d_out" output="lutram.out[1]">
+                <delay_constant max="25e-12" in_port="spram_4x1.d_out" out_port="lutram.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="lutram.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="lutram.in"/>
+            <direct name="direct3" input="fle.clk" output="lutram.clk"/>
+            <direct name="direct4" input="lutram.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -468,46 +473,46 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -515,24 +520,24 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[3:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>    
-            <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -12,8 +13,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,170 +23,179 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <!-- Top-side has 1 I/O per tile -->  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Right-side has 1 I/O per tile -->  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Bottom-side has 6 I/O per tile -->  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="6">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Left-side has 1 I/O per tile -->  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- CLB has most pins on the top and right sides -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="3" equivalent="full"/>    
-          <input name="I0i" num_pins="1" equivalent="none"/>    
-          <input name="I1" num_pins="3" equivalent="full"/>    
-          <input name="I1i" num_pins="1" equivalent="none"/>    
-          <input name="I2" num_pins="3" equivalent="full"/>    
-          <input name="I2i" num_pins="1" equivalent="none"/>    
-          <input name="I3" num_pins="3" equivalent="full"/>    
-          <input name="I3i" num_pins="1" equivalent="none"/>    
-          <input name="I4" num_pins="3" equivalent="full"/>    
-          <input name="I4i" num_pins="1" equivalent="none"/>    
-          <input name="I5" num_pins="3" equivalent="full"/>    
-          <input name="I5i" num_pins="1" equivalent="none"/>    
-          <input name="I6" num_pins="3" equivalent="full"/>    
-          <input name="I6i" num_pins="1" equivalent="none"/>    
-          <input name="I7" num_pins="3" equivalent="full"/>    
-          <input name="I7i" num_pins="1" equivalent="none"/>    
-          <input name="regin" num_pins="1"/>    
-          <input name="scin" num_pins="1"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="regout" num_pins="1"/>    
-          <output name="scout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="regin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="regout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="scin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="scout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.regin clb.scin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i </loc>     
-             <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-             <loc side="bottom">clb.regout clb.scout </loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="12x12" width="14" height="14">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Bottom-side has 6 I/O per tile -->
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="6">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="3" equivalent="full"/>
+        <input name="I0i" num_pins="1" equivalent="none"/>
+        <input name="I1" num_pins="3" equivalent="full"/>
+        <input name="I1i" num_pins="1" equivalent="none"/>
+        <input name="I2" num_pins="3" equivalent="full"/>
+        <input name="I2i" num_pins="1" equivalent="none"/>
+        <input name="I3" num_pins="3" equivalent="full"/>
+        <input name="I3i" num_pins="1" equivalent="none"/>
+        <input name="I4" num_pins="3" equivalent="full"/>
+        <input name="I4i" num_pins="1" equivalent="none"/>
+        <input name="I5" num_pins="3" equivalent="full"/>
+        <input name="I5i" num_pins="1" equivalent="none"/>
+        <input name="I6" num_pins="3" equivalent="full"/>
+        <input name="I6i" num_pins="1" equivalent="none"/>
+        <input name="I7" num_pins="3" equivalent="full"/>
+        <input name="I7i" num_pins="1" equivalent="none"/>
+        <input name="regin" num_pins="1"/>
+        <input name="scin" num_pins="1"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="regout" num_pins="1"/>
+        <output name="scout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="regin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="regout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="scin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="scout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.regin clb.scin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i </loc>
+          <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+          <loc side="bottom">clb.regout clb.scout </loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -198,21 +209,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -224,283 +235,282 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.scout" to_pin="clb.scin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define input pads begin -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.scout" to_pin="clb.scin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- -Due to the absence of local routing, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
          the 4 inputs of fracturable LUT4 are no longer equivalent, 
          because the 4th input can not be switched when the dual-LUT3 modes are used.
          So pin equivalence should be applied to the first 3 inputs only
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="3" equivalent="full"/>   
-         <input name="I0i" num_pins="1" equivalent="none"/>   
-         <input name="I1" num_pins="3" equivalent="full"/>   
-         <input name="I1i" num_pins="1" equivalent="none"/>   
-         <input name="I2" num_pins="3" equivalent="full"/>   
-         <input name="I2i" num_pins="1" equivalent="none"/>   
-         <input name="I3" num_pins="3" equivalent="full"/>   
-         <input name="I3i" num_pins="1" equivalent="none"/>   
-         <input name="I4" num_pins="3" equivalent="full"/>   
-         <input name="I4i" num_pins="1" equivalent="none"/>   
-         <input name="I5" num_pins="3" equivalent="full"/>   
-         <input name="I5i" num_pins="1" equivalent="none"/>   
-         <input name="I6" num_pins="3" equivalent="full"/>   
-         <input name="I6i" num_pins="1" equivalent="none"/>   
-         <input name="I7" num_pins="3" equivalent="full"/>   
-         <input name="I7i" num_pins="1" equivalent="none"/>   
-         <input name="regin" num_pins="1"/>   
-         <input name="scin" num_pins="1"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="regout" num_pins="1"/>   
-         <output name="scout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="3" equivalent="full"/>
+      <input name="I0i" num_pins="1" equivalent="none"/>
+      <input name="I1" num_pins="3" equivalent="full"/>
+      <input name="I1i" num_pins="1" equivalent="none"/>
+      <input name="I2" num_pins="3" equivalent="full"/>
+      <input name="I2i" num_pins="1" equivalent="none"/>
+      <input name="I3" num_pins="3" equivalent="full"/>
+      <input name="I3i" num_pins="1" equivalent="none"/>
+      <input name="I4" num_pins="3" equivalent="full"/>
+      <input name="I4i" num_pins="1" equivalent="none"/>
+      <input name="I5" num_pins="3" equivalent="full"/>
+      <input name="I5i" num_pins="1" equivalent="none"/>
+      <input name="I6" num_pins="3" equivalent="full"/>
+      <input name="I6i" num_pins="1" equivalent="none"/>
+      <input name="I7" num_pins="3" equivalent="full"/>
+      <input name="I7i" num_pins="1" equivalent="none"/>
+      <input name="regin" num_pins="1"/>
+      <input name="scin" num_pins="1"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="regout" num_pins="1"/>
+      <output name="scout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="regin" num_pins="1"/>    
-            <input name="scin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="regout" num_pins="1"/>    
-            <output name="scout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="scin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <output name="scout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.scin" output="ff[0].DI"/>       
-                     <direct name="direct3" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct4" input="ff[1].Q" output="fabric.scout"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.regout"/>       
-                     <direct name="direct6" input="frac_logic.out[1:1]" output="ff[1:1].D"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.regin" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.regin" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct3" input="fle.regin" output="fabric.regin"/>      
-                  <direct name="direct4" input="fle.scin" output="fabric.scin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct7" input="fabric.regout" output="fle.regout"/>      
-                  <direct name="direct8" input="fabric.scout" output="fle.scout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="regin" num_pins="1"/>
+        <input name="scin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="regout" num_pins="1"/>
+        <output name="scout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="regin" num_pins="1"/>
+            <input name="scin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="regout" num_pins="1"/>
+            <output name="scout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.scin" output="ff[0].DI"/>
+              <direct name="direct3" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct4" input="ff[1].Q" output="fabric.scout"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.regout"/>
+              <direct name="direct6" input="frac_logic.out[1:1]" output="ff[1:1].D"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.regin" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.regin" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux3" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct3" input="fle.regin" output="fabric.regin"/>
+            <direct name="direct4" input="fle.scin" output="fabric.scin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct7" input="fabric.regout" output="fle.regout"/>
+            <direct name="direct8" input="fabric.scout" output="fle.scout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -508,157 +518,157 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="regin" num_pins="1"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>      
-                  <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>      
-                  <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="regin" num_pins="1"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>
+            <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>
+            <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <direct name="direct_fle0" input="clb.I0" output="fle[0:0].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i" output="fle[0:0].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1" output="fle[1:1].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i" output="fle[1:1].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2" output="fle[2:2].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i" output="fle[2:2].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3" output="fle[3:3].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i" output="fle[3:3].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4" output="fle[4:4].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i" output="fle[4:4].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5" output="fle[5:5].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i" output="fle[5:5].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6" output="fle[6:6].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i" output="fle[6:6].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7" output="fle[7:7].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i" output="fle[7:7].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0" output="fle[0:0].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i" output="fle[0:0].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1" output="fle[1:1].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i" output="fle[1:1].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2" output="fle[2:2].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i" output="fle[2:2].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3" output="fle[3:3].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i" output="fle[3:3].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4" output="fle[4:4].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i" output="fle[4:4].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5" output="fle[5:5].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i" output="fle[5:5].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6" output="fle[6:6].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i" output="fle[6:6].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7" output="fle[7:7].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i" output="fle[7:7].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-               <!--pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].regout" output="clb.regout">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].regout" out_port="clb.regout"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].regout" output="fle[7:1].regin">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].regout" out_port="fle[7:1].regin"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.scin" output="fle[0:0].scin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.scin" out_port="fle[0:0].scin"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].scout" output="clb.scout">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].scout" output="fle[7:1].scin">
-        </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>
+          <!--pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].regout" output="clb.regout">
+          <!--pack_pattern name="chain" in_port="fle[7:7].regout" out_port="clb.regout"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].regout" output="fle[7:1].regin">
+          <!--pack_pattern name="chain" in_port="fle[6:0].regout" out_port="fle[7:1].regin"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.scin" output="fle[0:0].scin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.scin" out_port="fle[0:0].scin"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].scout" output="clb.scout">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].scout" output="fle[7:1].scin">
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_embedded_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_register_scan_chain_nonLR_embedded_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -12,8 +13,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,173 +23,179 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="gp_inpad" area="0">   <sub_tile name="gp_inpad" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="gp_inpad"/>     
-          </equivalent_sites>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">gp_inpad.inpad</loc>     
-             <loc side="top">gp_inpad.inpad</loc>     
-             <loc side="right">gp_inpad.inpad</loc>     
-             <loc side="bottom">gp_inpad.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="gp_outpad" area="0">   <sub_tile name="gp_outpad" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="gp_outpad"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">gp_outpad.outpad</loc>     
-             <loc side="top">gp_outpad.outpad</loc>     
-             <loc side="right">gp_outpad.outpad</loc>     
-             <loc side="bottom">gp_outpad.outpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="3" equivalent="full"/>    
-          <input name="I0i" num_pins="1" equivalent="none"/>    
-          <input name="I1" num_pins="3" equivalent="full"/>    
-          <input name="I1i" num_pins="1" equivalent="none"/>    
-          <input name="I2" num_pins="3" equivalent="full"/>    
-          <input name="I2i" num_pins="1" equivalent="none"/>    
-          <input name="I3" num_pins="3" equivalent="full"/>    
-          <input name="I3i" num_pins="1" equivalent="none"/>    
-          <input name="I4" num_pins="3" equivalent="full"/>    
-          <input name="I4i" num_pins="1" equivalent="none"/>    
-          <input name="I5" num_pins="3" equivalent="full"/>    
-          <input name="I5i" num_pins="1" equivalent="none"/>    
-          <input name="I6" num_pins="3" equivalent="full"/>    
-          <input name="I6i" num_pins="1" equivalent="none"/>    
-          <input name="I7" num_pins="3" equivalent="full"/>    
-          <input name="I7i" num_pins="1" equivalent="none"/>    
-          <input name="regin" num_pins="1"/>    
-          <input name="scin" num_pins="1"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="regout" num_pins="1"/>    
-          <output name="scout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="regin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="regout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="scin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="scout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.regin clb.scin</loc>     
-             <loc side="right">clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i </loc>     
-             <loc side="bottom">clb.regout clb.scout clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!-- On each side, general-purpose inpad and outpad are interleaved -->   
-         <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->   
-         <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>   
-         <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>   
-         <!-- On right side, I/Os are organized as 
+     -->
+    <tile name="gp_inpad" area="0">
+      <sub_tile name="gp_inpad" capacity="8">
+        <equivalent_sites>
+          <site pb_type="gp_inpad"/>
+        </equivalent_sites>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">gp_inpad.inpad</loc>
+          <loc side="top">gp_inpad.inpad</loc>
+          <loc side="right">gp_inpad.inpad</loc>
+          <loc side="bottom">gp_inpad.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="gp_outpad" area="0">
+      <sub_tile name="gp_outpad" capacity="8">
+        <equivalent_sites>
+          <site pb_type="gp_outpad"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">gp_outpad.outpad</loc>
+          <loc side="top">gp_outpad.outpad</loc>
+          <loc side="right">gp_outpad.outpad</loc>
+          <loc side="bottom">gp_outpad.outpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="3" equivalent="full"/>
+        <input name="I0i" num_pins="1" equivalent="none"/>
+        <input name="I1" num_pins="3" equivalent="full"/>
+        <input name="I1i" num_pins="1" equivalent="none"/>
+        <input name="I2" num_pins="3" equivalent="full"/>
+        <input name="I2i" num_pins="1" equivalent="none"/>
+        <input name="I3" num_pins="3" equivalent="full"/>
+        <input name="I3i" num_pins="1" equivalent="none"/>
+        <input name="I4" num_pins="3" equivalent="full"/>
+        <input name="I4i" num_pins="1" equivalent="none"/>
+        <input name="I5" num_pins="3" equivalent="full"/>
+        <input name="I5i" num_pins="1" equivalent="none"/>
+        <input name="I6" num_pins="3" equivalent="full"/>
+        <input name="I6i" num_pins="1" equivalent="none"/>
+        <input name="I7" num_pins="3" equivalent="full"/>
+        <input name="I7i" num_pins="1" equivalent="none"/>
+        <input name="regin" num_pins="1"/>
+        <input name="scin" num_pins="1"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="regout" num_pins="1"/>
+        <output name="scout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="regin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="regout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="scin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="scout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.regin clb.scin</loc>
+          <loc side="right">clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i </loc>
+          <loc side="bottom">clb.regout clb.scout clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!-- On each side, general-purpose inpad and outpad are interleaved -->
+      <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->
+      <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>
+      <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>
+      <!-- On right side, I/Os are organized as 
            inpad 
            outpad
            ...
            inpad
            outpad
            This is to avoid unroutable conditions when FPGA size is too small (only gp_inpad is available)
-           -->   
-         <region type="gp_outpad" priority="100" startx="W-1" endx="W-1" starty="1" endy="H-1" incry="2"/>   
-         <region type="gp_inpad" priority="100" startx="W-1" endx="W-1" starty="2" endy="H-1" incry="2"/>   
-         <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->   
-         <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="0" endy="0"/>   
-         <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="0" endy="0"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!-- On left side, I/Os are organized as 
+           -->
+      <region type="gp_outpad" priority="100" startx="W-1" endx="W-1" starty="1" endy="H-1" incry="2"/>
+      <region type="gp_inpad" priority="100" startx="W-1" endx="W-1" starty="2" endy="H-1" incry="2"/>
+      <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->
+      <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="0" endy="0"/>
+      <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="0" endy="0"/>
+      <corners type="EMPTY" priority="101"/>
+      <!-- On left side, I/Os are organized as 
            inpad 
            outpad
            ...
            inpad
            outpad
            This is to avoid unroutable conditions when FPGA size is too small (only gp_inpad is available)
-           -->   
-         <region type="gp_outpad" priority="100" startx="0" endx="0" starty="1" endy="H-1" incry="2"/>   
-         <region type="gp_inpad" priority="100" startx="0" endx="0" starty="2" endy="H-1" incry="2"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!-- On each side, general-purpose inpad and outpad are interleaved -->   
-         <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->   
-         <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>   
-         <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>   
-         <!-- On right side, I/Os are organized as 
+           -->
+      <region type="gp_outpad" priority="100" startx="0" endx="0" starty="1" endy="H-1" incry="2"/>
+      <region type="gp_inpad" priority="100" startx="0" endx="0" starty="2" endy="H-1" incry="2"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!-- On each side, general-purpose inpad and outpad are interleaved -->
+      <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->
+      <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>
+      <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="H-1" endy="H-1"/>
+      <!-- On right side, I/Os are organized as 
            inpad 
            outpad
            ...
            inpad
            outpad
            This is to avoid unroutable conditions when FPGA size is too small (only gp_inpad is available)
-           -->   
-         <region type="gp_outpad" priority="100" startx="W-1" endx="W-1" starty="1" endy="H-1" incry="2"/>   
-         <region type="gp_inpad" priority="100" startx="W-1" endx="W-1" starty="2" endy="H-1" incry="2"/>   
-         <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->   
-         <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="0" endy="0"/>   
-         <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="0" endy="0"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!-- On left side, I/Os are organized as 
+           -->
+      <region type="gp_outpad" priority="100" startx="W-1" endx="W-1" starty="1" endy="H-1" incry="2"/>
+      <region type="gp_inpad" priority="100" startx="W-1" endx="W-1" starty="2" endy="H-1" incry="2"/>
+      <!-- On top side, I/Os are organized as inpad, outpad, inpad, outpad, ... -->
+      <region type="gp_inpad" priority="100" startx="1" endx="W-1" incrx="2" starty="0" endy="0"/>
+      <region type="gp_outpad" priority="100" startx="2" endx="W-1" incrx="2" starty="0" endy="0"/>
+      <corners type="EMPTY" priority="101"/>
+      <!-- On left side, I/Os are organized as 
            inpad 
            outpad
            ...
            inpad
            outpad
            This is to avoid unroutable conditions when FPGA size is too small (only gp_inpad is available)
-           -->   
-         <region type="gp_outpad" priority="100" startx="0" endx="0" starty="1" endy="H-1" incry="2"/>   
-         <region type="gp_inpad" priority="100" startx="0" endx="0" starty="2" endy="H-1" incry="2"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+           -->
+      <region type="gp_outpad" priority="100" startx="0" endx="0" starty="1" endy="H-1" incry="2"/>
+      <region type="gp_inpad" priority="100" startx="0" endx="0" starty="2" endy="H-1" incry="2"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -201,21 +209,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -227,261 +235,261 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.scout" to_pin="clb.scin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Different from GPIOs, embedded I/O interfaces can afford splitting
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.scout" to_pin="clb.scin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Different from GPIOs, embedded I/O interfaces can afford splitting
          input and output pin. Therefore, the input pad and output pad are defined
          as different blocks
-	   -->  
-      <!-- Define input pads begin -->  
-      <pb_type name="gp_inpad">   
-         <output name="inpad" num_pins="1"/>   
-         <pb_type name="inpad" blif_model=".input" num_pb="1">    
-            <output name="inpad" num_pins="1"/>    
-         </pb_type>   
-         <interconnect>    
-            <direct name="inpad" input="inpad.inpad" output="gp_inpad.inpad">     
-               <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="gp_inpad.inpad"/>     
-            </direct>    
-         </interconnect>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define input pads end -->  
-      <!-- Define output pads begin -->  
-      <pb_type name="gp_outpad">   
-         <input name="outpad" num_pins="1"/>   
-         <pb_type name="outpad" blif_model=".output" num_pb="1">    
-            <input name="outpad" num_pins="1"/>    
-         </pb_type>   
-         <interconnect>    
-            <direct name="outpad" input="gp_outpad.outpad" output="outpad.outpad">     
-               <delay_constant max="1.394e-11" in_port="gp_outpad.outpad" out_port="outpad.outpad"/>     
-            </direct>    
-         </interconnect>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define output pads end -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- -Due to the absence of local routing, 
+	   -->
+    <!-- Define input pads begin -->
+    <pb_type name="gp_inpad">
+      <output name="inpad" num_pins="1"/>
+      <pb_type name="inpad" blif_model=".input" num_pb="1">
+        <output name="inpad" num_pins="1"/>
+      </pb_type>
+      <interconnect>
+        <direct name="inpad" input="inpad.inpad" output="gp_inpad.inpad">
+          <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="gp_inpad.inpad"/>
+        </direct>
+      </interconnect>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define input pads end -->
+    <!-- Define output pads begin -->
+    <pb_type name="gp_outpad">
+      <input name="outpad" num_pins="1"/>
+      <pb_type name="outpad" blif_model=".output" num_pb="1">
+        <input name="outpad" num_pins="1"/>
+      </pb_type>
+      <interconnect>
+        <direct name="outpad" input="gp_outpad.outpad" output="outpad.outpad">
+          <delay_constant max="1.394e-11" in_port="gp_outpad.outpad" out_port="outpad.outpad"/>
+        </direct>
+      </interconnect>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define output pads end -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
          the 4 inputs of fracturable LUT4 are no longer equivalent, 
          because the 4th input can not be switched when the dual-LUT3 modes are used.
          So pin equivalence should be applied to the first 3 inputs only
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="3" equivalent="full"/>   
-         <input name="I0i" num_pins="1" equivalent="none"/>   
-         <input name="I1" num_pins="3" equivalent="full"/>   
-         <input name="I1i" num_pins="1" equivalent="none"/>   
-         <input name="I2" num_pins="3" equivalent="full"/>   
-         <input name="I2i" num_pins="1" equivalent="none"/>   
-         <input name="I3" num_pins="3" equivalent="full"/>   
-         <input name="I3i" num_pins="1" equivalent="none"/>   
-         <input name="I4" num_pins="3" equivalent="full"/>   
-         <input name="I4i" num_pins="1" equivalent="none"/>   
-         <input name="I5" num_pins="3" equivalent="full"/>   
-         <input name="I5i" num_pins="1" equivalent="none"/>   
-         <input name="I6" num_pins="3" equivalent="full"/>   
-         <input name="I6i" num_pins="1" equivalent="none"/>   
-         <input name="I7" num_pins="3" equivalent="full"/>   
-         <input name="I7i" num_pins="1" equivalent="none"/>   
-         <input name="regin" num_pins="1"/>   
-         <input name="scin" num_pins="1"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="regout" num_pins="1"/>   
-         <output name="scout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="3" equivalent="full"/>
+      <input name="I0i" num_pins="1" equivalent="none"/>
+      <input name="I1" num_pins="3" equivalent="full"/>
+      <input name="I1i" num_pins="1" equivalent="none"/>
+      <input name="I2" num_pins="3" equivalent="full"/>
+      <input name="I2i" num_pins="1" equivalent="none"/>
+      <input name="I3" num_pins="3" equivalent="full"/>
+      <input name="I3i" num_pins="1" equivalent="none"/>
+      <input name="I4" num_pins="3" equivalent="full"/>
+      <input name="I4i" num_pins="1" equivalent="none"/>
+      <input name="I5" num_pins="3" equivalent="full"/>
+      <input name="I5i" num_pins="1" equivalent="none"/>
+      <input name="I6" num_pins="3" equivalent="full"/>
+      <input name="I6i" num_pins="1" equivalent="none"/>
+      <input name="I7" num_pins="3" equivalent="full"/>
+      <input name="I7i" num_pins="1" equivalent="none"/>
+      <input name="regin" num_pins="1"/>
+      <input name="scin" num_pins="1"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="regout" num_pins="1"/>
+      <output name="scout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="regin" num_pins="1"/>    
-            <input name="scin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="regout" num_pins="1"/>    
-            <output name="scout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="scin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <output name="scout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.scin" output="ff[0].DI"/>       
-                     <direct name="direct3" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct4" input="ff[1].Q" output="fabric.scout"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.regout"/>       
-                     <direct name="direct6" input="frac_logic.out[1:1]" output="ff[1:1].D"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.regin" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.regin" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct3" input="fle.regin" output="fabric.regin"/>      
-                  <direct name="direct4" input="fle.scin" output="fabric.scin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct7" input="fabric.regout" output="fle.regout"/>      
-                  <direct name="direct8" input="fabric.scout" output="fle.scout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="regin" num_pins="1"/>
+        <input name="scin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="regout" num_pins="1"/>
+        <output name="scout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="regin" num_pins="1"/>
+            <input name="scin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="regout" num_pins="1"/>
+            <output name="scout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.scin" output="ff[0].DI"/>
+              <direct name="direct3" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct4" input="ff[1].Q" output="fabric.scout"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.regout"/>
+              <direct name="direct6" input="frac_logic.out[1:1]" output="ff[1:1].D"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.regin" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.regin" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux3" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct3" input="fle.regin" output="fabric.regin"/>
+            <direct name="direct4" input="fle.scin" output="fabric.scin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct7" input="fabric.regout" output="fle.regout"/>
+            <direct name="direct8" input="fabric.scout" output="fle.scout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -489,157 +497,157 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="regin" num_pins="1"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>      
-                  <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>      
-                  <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="regin" num_pins="1"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>
+            <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>
+            <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <direct name="direct_fle0" input="clb.I0" output="fle[0:0].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i" output="fle[0:0].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1" output="fle[1:1].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i" output="fle[1:1].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2" output="fle[2:2].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i" output="fle[2:2].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3" output="fle[3:3].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i" output="fle[3:3].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4" output="fle[4:4].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i" output="fle[4:4].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5" output="fle[5:5].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i" output="fle[5:5].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6" output="fle[6:6].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i" output="fle[6:6].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7" output="fle[7:7].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i" output="fle[7:7].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0" output="fle[0:0].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i" output="fle[0:0].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1" output="fle[1:1].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i" output="fle[1:1].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2" output="fle[2:2].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i" output="fle[2:2].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3" output="fle[3:3].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i" output="fle[3:3].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4" output="fle[4:4].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i" output="fle[4:4].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5" output="fle[5:5].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i" output="fle[5:5].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6" output="fle[6:6].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i" output="fle[6:6].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7" output="fle[7:7].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i" output="fle[7:7].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-               <!--pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].regout" output="clb.regout">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].regout" out_port="clb.regout"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].regout" output="fle[7:1].regin">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].regout" out_port="fle[7:1].regin"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.scin" output="fle[0:0].scin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.scin" out_port="fle[0:0].scin"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].scout" output="clb.scout">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].scout" output="fle[7:1].scin">
-        </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>
+          <!--pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].regout" output="clb.regout">
+          <!--pack_pattern name="chain" in_port="fle[7:7].regout" out_port="clb.regout"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].regout" output="fle[7:1].regin">
+          <!--pack_pattern name="chain" in_port="fle[6:0].regout" out_port="fle[7:1].regin"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.scin" output="fle[0:0].scin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.scin" out_port="fle[0:0].scin"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].scout" output="clb.scout">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].scout" output="fle[7:1].scin">
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -12,8 +13,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,174 +23,183 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="reset" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="reset" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <!-- Top-side has 1 I/O per tile -->  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Right-side has 1 I/O per tile -->  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Bottom-side has 9 I/O per tile -->  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Left-side has 1 I/O per tile -->  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- CLB has most pins on the top and right sides -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="3" equivalent="full"/>    
-          <input name="I0i" num_pins="1" equivalent="none"/>    
-          <input name="I1" num_pins="3" equivalent="full"/>    
-          <input name="I1i" num_pins="1" equivalent="none"/>    
-          <input name="I2" num_pins="3" equivalent="full"/>    
-          <input name="I2i" num_pins="1" equivalent="none"/>    
-          <input name="I3" num_pins="3" equivalent="full"/>    
-          <input name="I3i" num_pins="1" equivalent="none"/>    
-          <input name="I4" num_pins="3" equivalent="full"/>    
-          <input name="I4i" num_pins="1" equivalent="none"/>    
-          <input name="I5" num_pins="3" equivalent="full"/>    
-          <input name="I5i" num_pins="1" equivalent="none"/>    
-          <input name="I6" num_pins="3" equivalent="full"/>    
-          <input name="I6i" num_pins="1" equivalent="none"/>    
-          <input name="I7" num_pins="3" equivalent="full"/>    
-          <input name="I7i" num_pins="1" equivalent="none"/>    
-          <input name="reg_in" num_pins="1"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="reg_out" num_pins="1"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk clb.reset</loc>     
-             <loc side="top">clb.reg_in clb.sc_in clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>     
-             <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-             <loc side="bottom">clb.reg_out clb.sc_out</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="12x12" width="14" height="14">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Bottom-side has 9 I/O per tile -->
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="3" equivalent="full"/>
+        <input name="I0i" num_pins="1" equivalent="none"/>
+        <input name="I1" num_pins="3" equivalent="full"/>
+        <input name="I1i" num_pins="1" equivalent="none"/>
+        <input name="I2" num_pins="3" equivalent="full"/>
+        <input name="I2i" num_pins="1" equivalent="none"/>
+        <input name="I3" num_pins="3" equivalent="full"/>
+        <input name="I3i" num_pins="1" equivalent="none"/>
+        <input name="I4" num_pins="3" equivalent="full"/>
+        <input name="I4i" num_pins="1" equivalent="none"/>
+        <input name="I5" num_pins="3" equivalent="full"/>
+        <input name="I5i" num_pins="1" equivalent="none"/>
+        <input name="I6" num_pins="3" equivalent="full"/>
+        <input name="I6i" num_pins="1" equivalent="none"/>
+        <input name="I7" num_pins="3" equivalent="full"/>
+        <input name="I7i" num_pins="1" equivalent="none"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset</loc>
+          <loc side="top">clb.reg_in clb.sc_in clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>
+          <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+          <loc side="bottom">clb.reg_out clb.sc_out</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -202,21 +213,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -228,293 +239,292 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define input pads begin -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- -Due to the absence of local routing, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
          the 4 inputs of fracturable LUT4 are no longer equivalent, 
          because the 4th input can not be switched when the dual-LUT3 modes are used.
          So pin equivalence should be applied to the first 3 inputs only
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="3" equivalent="full"/>   
-         <input name="I0i" num_pins="1" equivalent="none"/>   
-         <input name="I1" num_pins="3" equivalent="full"/>   
-         <input name="I1i" num_pins="1" equivalent="none"/>   
-         <input name="I2" num_pins="3" equivalent="full"/>   
-         <input name="I2i" num_pins="1" equivalent="none"/>   
-         <input name="I3" num_pins="3" equivalent="full"/>   
-         <input name="I3i" num_pins="1" equivalent="none"/>   
-         <input name="I4" num_pins="3" equivalent="full"/>   
-         <input name="I4i" num_pins="1" equivalent="none"/>   
-         <input name="I5" num_pins="3" equivalent="full"/>   
-         <input name="I5i" num_pins="1" equivalent="none"/>   
-         <input name="I6" num_pins="3" equivalent="full"/>   
-         <input name="I6i" num_pins="1" equivalent="none"/>   
-         <input name="I7" num_pins="3" equivalent="full"/>   
-         <input name="I7i" num_pins="1" equivalent="none"/>   
-         <input name="reg_in" num_pins="1"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="reset" num_pins="1" is_non_clock_global="true"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="reg_out" num_pins="1"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="3" equivalent="full"/>
+      <input name="I0i" num_pins="1" equivalent="none"/>
+      <input name="I1" num_pins="3" equivalent="full"/>
+      <input name="I1i" num_pins="1" equivalent="none"/>
+      <input name="I2" num_pins="3" equivalent="full"/>
+      <input name="I2i" num_pins="1" equivalent="none"/>
+      <input name="I3" num_pins="3" equivalent="full"/>
+      <input name="I3i" num_pins="1" equivalent="none"/>
+      <input name="I4" num_pins="3" equivalent="full"/>
+      <input name="I4i" num_pins="1" equivalent="none"/>
+      <input name="I5" num_pins="3" equivalent="full"/>
+      <input name="I5i" num_pins="1" equivalent="none"/>
+      <input name="I6" num_pins="3" equivalent="full"/>
+      <input name="I6i" num_pins="1" equivalent="none"/>
+      <input name="I7" num_pins="3" equivalent="full"/>
+      <input name="I7i" num_pins="1" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="reg_in" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="reg_out" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reg_in" num_pins="1"/>      
-                  <input name="sc_in" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <output name="sc_out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>        
-                        <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.reset" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.sc_in" output="ff[0].DI"/>       
-                     <direct name="direct3" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct4" input="ff[1].Q" output="fabric.sc_out"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.reg_out"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct3" input="fle.reg_in" output="fabric.reg_in"/>      
-                  <direct name="direct4" input="fle.sc_in" output="fabric.sc_in"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct7" input="fabric.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct8" input="fabric.sc_out" output="fle.sc_out"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct10" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reg_in" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <input name="reset" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.sc_in" output="ff[0].DI"/>
+              <direct name="direct3" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct4" input="ff[1].Q" output="fabric.sc_out"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.reg_out"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct3" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct4" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct7" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct8" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -522,167 +532,167 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="reg_in" num_pins="1"/>      
-                  <output name="ff_out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>       
-                     <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>       
-                     <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>      
-                  <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>      
-                  <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="reg_in" num_pins="1"/>
+            <output name="ff_out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>
+              <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>
+              <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <!-- FIXME: The implicit port definition results in I0[0] connected to
+          -->
+        <!-- FIXME: The implicit port definition results in I0[0] connected to
                     in[2]. Such twisted connection is not expected.
                     I[0] should be connected to in[0]
-          -->    
-            <direct name="direct_fle0" input="clb.I0[0:2]" output="fle[0:0].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i" output="fle[0:0].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1[0:2]" output="fle[1:1].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i" output="fle[1:1].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2[0:2]" output="fle[2:2].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i" output="fle[2:2].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3[0:2]" output="fle[3:3].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i" output="fle[3:3].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4[0:2]" output="fle[4:4].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i" output="fle[4:4].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5[0:2]" output="fle[5:5].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i" output="fle[5:5].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6[0:2]" output="fle[6:6].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i" output="fle[6:6].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7[0:2]" output="fle[7:7].in[0:2]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i" output="fle[7:7].in[3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[7:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0[0:2]" output="fle[0:0].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i" output="fle[0:0].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1[0:2]" output="fle[1:1].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i" output="fle[1:1].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2[0:2]" output="fle[2:2].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i" output="fle[2:2].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3[0:2]" output="fle[3:3].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i" output="fle[3:3].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4[0:2]" output="fle[4:4].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i" output="fle[4:4].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5[0:2]" output="fle[5:5].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i" output="fle[5:5].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6[0:2]" output="fle[6:6].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i" output="fle[6:6].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7[0:2]" output="fle[7:7].in[0:2]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i" output="fle[7:7].in[3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>     
-               <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
-        </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadderSuperLUT_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadderSuperLUT_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -12,8 +13,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,189 +23,199 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <model name="adder_lut4">   
-         <input_ports>    
-            <port name="in" combinational_sink_ports="lut4_out cout"/>    
-            <port name="cin" combinational_sink_ports="lut4_out cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <model name="frac_lut4_arith">   
-         <input_ports>    
-            <port name="in" combinational_sink_ports="lut3_out lut4_out cout"/>    
-            <port name="cin" combinational_sink_ports="lut3_out lut4_out cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="reset" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="adder_lut4">
+      <input_ports>
+        <port name="in" combinational_sink_ports="lut4_out cout"/>
+        <port name="cin" combinational_sink_ports="lut4_out cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4_arith">
+      <input_ports>
+        <port name="in" combinational_sink_ports="lut3_out lut4_out cout"/>
+        <port name="cin" combinational_sink_ports="lut3_out lut4_out cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="reset" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <!-- Top-side has 1 I/O per tile -->  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Right-side has 1 I/O per tile -->  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Bottom-side has 9 I/O per tile -->  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Left-side has 1 I/O per tile -->  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- CLB has most pins on the top and right sides -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="2" equivalent="none"/>    
-          <input name="I0i" num_pins="2" equivalent="none"/>    
-          <input name="I1" num_pins="2" equivalent="none"/>    
-          <input name="I1i" num_pins="2" equivalent="none"/>    
-          <input name="I2" num_pins="2" equivalent="none"/>    
-          <input name="I2i" num_pins="2" equivalent="none"/>    
-          <input name="I3" num_pins="2" equivalent="none"/>    
-          <input name="I3i" num_pins="2" equivalent="none"/>    
-          <input name="I4" num_pins="2" equivalent="none"/>    
-          <input name="I4i" num_pins="2" equivalent="none"/>    
-          <input name="I5" num_pins="2" equivalent="none"/>    
-          <input name="I5i" num_pins="2" equivalent="none"/>    
-          <input name="I6" num_pins="2" equivalent="none"/>    
-          <input name="I6i" num_pins="2" equivalent="none"/>    
-          <input name="I7" num_pins="2" equivalent="none"/>    
-          <input name="I7i" num_pins="2" equivalent="none"/>    
-          <input name="reg_in" num_pins="1"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="reg_out" num_pins="1"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk clb.reset</loc>     
-             <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>     
-             <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-             <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="12x12" width="14" height="14">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Bottom-side has 9 I/O per tile -->
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="2" equivalent="none"/>
+        <input name="I0i" num_pins="2" equivalent="none"/>
+        <input name="I1" num_pins="2" equivalent="none"/>
+        <input name="I1i" num_pins="2" equivalent="none"/>
+        <input name="I2" num_pins="2" equivalent="none"/>
+        <input name="I2i" num_pins="2" equivalent="none"/>
+        <input name="I3" num_pins="2" equivalent="none"/>
+        <input name="I3i" num_pins="2" equivalent="none"/>
+        <input name="I4" num_pins="2" equivalent="none"/>
+        <input name="I4i" num_pins="2" equivalent="none"/>
+        <input name="I5" num_pins="2" equivalent="none"/>
+        <input name="I5i" num_pins="2" equivalent="none"/>
+        <input name="I6" num_pins="2" equivalent="none"/>
+        <input name="I6i" num_pins="2" equivalent="none"/>
+        <input name="I7" num_pins="2" equivalent="none"/>
+        <input name="I7i" num_pins="2" equivalent="none"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset</loc>
+          <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>
+          <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+          <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -217,21 +229,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -243,365 +255,364 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define input pads begin -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- Due to that LUT bitstream may be overwritten by .eblif files
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- Due to that LUT bitstream may be overwritten by .eblif files
          Pin equivalence of CLB inputs are all disabled.
          This is because the hard coded bitstream in .eblif cannot be
          adapted to the net swapping from VPR's routing optimization
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="2" equivalent="none"/>   
-         <input name="I0i" num_pins="2" equivalent="none"/>   
-         <input name="I1" num_pins="2" equivalent="none"/>   
-         <input name="I1i" num_pins="2" equivalent="none"/>   
-         <input name="I2" num_pins="2" equivalent="none"/>   
-         <input name="I2i" num_pins="2" equivalent="none"/>   
-         <input name="I3" num_pins="2" equivalent="none"/>   
-         <input name="I3i" num_pins="2" equivalent="none"/>   
-         <input name="I4" num_pins="2" equivalent="none"/>   
-         <input name="I4i" num_pins="2" equivalent="none"/>   
-         <input name="I5" num_pins="2" equivalent="none"/>   
-         <input name="I5i" num_pins="2" equivalent="none"/>   
-         <input name="I6" num_pins="2" equivalent="none"/>   
-         <input name="I6i" num_pins="2" equivalent="none"/>   
-         <input name="I7" num_pins="2" equivalent="none"/>   
-         <input name="I7i" num_pins="2" equivalent="none"/>   
-         <input name="reg_in" num_pins="1"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="reset" num_pins="1" is_non_clock_global="true"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="reg_out" num_pins="1"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="2" equivalent="none"/>
+      <input name="I0i" num_pins="2" equivalent="none"/>
+      <input name="I1" num_pins="2" equivalent="none"/>
+      <input name="I1i" num_pins="2" equivalent="none"/>
+      <input name="I2" num_pins="2" equivalent="none"/>
+      <input name="I2i" num_pins="2" equivalent="none"/>
+      <input name="I3" num_pins="2" equivalent="none"/>
+      <input name="I3i" num_pins="2" equivalent="none"/>
+      <input name="I4" num_pins="2" equivalent="none"/>
+      <input name="I4i" num_pins="2" equivalent="none"/>
+      <input name="I5" num_pins="2" equivalent="none"/>
+      <input name="I5i" num_pins="2" equivalent="none"/>
+      <input name="I6" num_pins="2" equivalent="none"/>
+      <input name="I6i" num_pins="2" equivalent="none"/>
+      <input name="I7" num_pins="2" equivalent="none"/>
+      <input name="I7i" num_pins="2" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="reg_in" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="reg_out" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reg_in" num_pins="1"/>      
-                  <input name="sc_in" num_pins="1"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <output name="sc_out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="2"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4_arith" blif_model=".subckt frac_lut4_arith" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <input name="cin" num_pins="1"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                        <output name="cout" num_pins="1"/>        
-                        <delay_constant max="0.3e-9" in_port="frac_lut4_arith.cin" out_port="frac_lut4_arith.lut3_out"/>        
-                        <delay_constant max="0.3e-9" in_port="frac_lut4_arith.cin" out_port="frac_lut4_arith.lut4_out"/>        
-                        <delay_constant max="0.3e-9" in_port="frac_lut4_arith.cin" out_port="frac_lut4_arith.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="frac_lut4_arith.in" out_port="frac_lut4_arith.lut3_out"/>        
-                        <delay_constant max="0.3e-9" in_port="frac_lut4_arith.in" out_port="frac_lut4_arith.lut4_out"/>        
-                        <delay_constant max="0.3e-9" in_port="frac_lut4_arith.in" out_port="frac_lut4_arith.cout"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in[0:3]" output="frac_lut4_arith.in[0:3]"/>        
-                        <direct name="direct2" input="frac_logic.cin" output="frac_lut4_arith.cin"/>        
-                        <direct name="direct3" input="frac_lut4_arith.cout" output="frac_logic.cout"/>        
-                        <direct name="direct4" input="frac_lut4_arith.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4_arith.lut4_out frac_lut4_arith.lut3_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.reset" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>       
-                     <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>       
-                     <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>       
-                     <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>       
-                     <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>      
-                  <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>      
-                  <direct name="direct4" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>      
-                  <direct name="direct8" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct10" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Arithmetic mode definition begin -->    
-            <mode name="arithmetic">     
-               <pb_type name="soft_adder" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="sumout" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <!-- Define special LUT marco to be used as adder -->      
-                  <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">       
-                     <input name="cin" num_pins="1"/>       
-                     <input name="in" num_pins="4"/>       
-                     <output name="lut4_out" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.cin" out_port="adder_lut4.lut4_out"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.cin" out_port="adder_lut4.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>       
-                     <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>       
-                     <direct name="direct3" input="soft_adder.cin" output="adder_lut4.cin">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="soft_adder.cin" out_port="adder_lut4.cin"/>        
-                     </direct>       
-                     <direct name="direct4" input="adder_lut4.cout" output="soft_adder.cout">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="adder_lut4.cout" out_port="soft_adder.cout"/>        
-                     </direct>       
-                     <direct name="direct5" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
-              </direct>       
-                     <direct name="direct6" input="soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
-              </direct>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="soft_adder.in"/>      
-                  <direct name="direct2" input="fle.cin" output="soft_adder.cin">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>       
-                  </direct>      
-                  <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>      
-                  <direct name="direct4" input="soft_adder.cout" output="fle.cout">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Arithmetic mode definition end -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reg_in" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="cin" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="2"/>
+              <output name="cout" num_pins="1"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4_arith" blif_model=".subckt frac_lut4_arith" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <input name="cin" num_pins="1"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+                <output name="cout" num_pins="1"/>
+                <delay_constant max="0.3e-9" in_port="frac_lut4_arith.cin" out_port="frac_lut4_arith.lut3_out"/>
+                <delay_constant max="0.3e-9" in_port="frac_lut4_arith.cin" out_port="frac_lut4_arith.lut4_out"/>
+                <delay_constant max="0.3e-9" in_port="frac_lut4_arith.cin" out_port="frac_lut4_arith.cout"/>
+                <delay_constant max="0.3e-9" in_port="frac_lut4_arith.in" out_port="frac_lut4_arith.lut3_out"/>
+                <delay_constant max="0.3e-9" in_port="frac_lut4_arith.in" out_port="frac_lut4_arith.lut4_out"/>
+                <delay_constant max="0.3e-9" in_port="frac_lut4_arith.in" out_port="frac_lut4_arith.cout"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in[0:3]" output="frac_lut4_arith.in[0:3]"/>
+                <direct name="direct2" input="frac_logic.cin" output="frac_lut4_arith.cin"/>
+                <direct name="direct3" input="frac_lut4_arith.cout" output="frac_logic.cout"/>
+                <direct name="direct4" input="frac_lut4_arith.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4_arith.lut4_out frac_lut4_arith.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <input name="reset" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>
+              <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>
+              <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>
+              <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>
+              <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Arithmetic mode definition begin -->
+        <mode name="arithmetic">
+          <pb_type name="soft_adder" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="sumout" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <!-- Define special LUT marco to be used as adder -->
+            <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">
+              <input name="cin" num_pins="1"/>
+              <input name="in" num_pins="4"/>
+              <output name="lut4_out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.cin" out_port="adder_lut4.lut4_out"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.cin" out_port="adder_lut4.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>
+              <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>
+              <direct name="direct3" input="soft_adder.cin" output="adder_lut4.cin">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="soft_adder.cin" out_port="adder_lut4.cin"/>
+              </direct>
+              <direct name="direct4" input="adder_lut4.cout" output="soft_adder.cout">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="adder_lut4.cout" out_port="soft_adder.cout"/>
+              </direct>
+              <direct name="direct5" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
+              </direct>
+              <direct name="direct6" input="soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
+              </direct>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="soft_adder.in"/>
+            <direct name="direct2" input="fle.cin" output="soft_adder.cin">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>
+            </direct>
+            <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>
+            <direct name="direct4" input="soft_adder.cout" output="fle.cout">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Arithmetic mode definition end -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -609,179 +620,179 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="reg_in" num_pins="1"/>      
-                  <output name="ff_out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>       
-                     <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>       
-                     <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>      
-                  <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>      
-                  <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="reg_in" num_pins="1"/>
+            <output name="ff_out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>
+              <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>
+              <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <!-- FIXME: The implicit port definition results in I0[0] connected to
+          -->
+        <!-- FIXME: The implicit port definition results in I0[0] connected to
                     in[2]. Such twisted connection is not expected.
                     I[0] should be connected to in[0]
-          -->    
-            <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[7:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>     
-               <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
-        </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">     
-               <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
+          <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_dsp8_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_dsp8_nonLR_caravel_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -14,8 +15,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -23,240 +25,252 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="mult_8">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <model name="adder_lut4">   
-         <input_ports>    
-            <port name="in" combinational_sink_ports="lut2_out lut4_out"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower_physical">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="reset" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <model name="mult_8">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="adder_lut4">
+      <input_ports>
+        <port name="in" combinational_sink_ports="lut2_out lut4_out"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower_physical">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="reset" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <!-- Top-side has 1 I/O per tile -->  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Right-side has 1 I/O per tile -->  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Bottom-side has 9 I/O per tile -->  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Left-side has 1 I/O per tile -->  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- CLB has most pins on the top and right sides -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="2" equivalent="full"/>    
-          <input name="I0i" num_pins="2" equivalent="none"/>    
-          <input name="I1" num_pins="2" equivalent="full"/>    
-          <input name="I1i" num_pins="2" equivalent="none"/>    
-          <input name="I2" num_pins="2" equivalent="full"/>    
-          <input name="I2i" num_pins="2" equivalent="none"/>    
-          <input name="I3" num_pins="2" equivalent="full"/>    
-          <input name="I3i" num_pins="2" equivalent="none"/>    
-          <input name="I4" num_pins="2" equivalent="full"/>    
-          <input name="I4i" num_pins="2" equivalent="none"/>    
-          <input name="I5" num_pins="2" equivalent="full"/>    
-          <input name="I5i" num_pins="2" equivalent="none"/>    
-          <input name="I6" num_pins="2" equivalent="full"/>    
-          <input name="I6i" num_pins="2" equivalent="none"/>    
-          <input name="I7" num_pins="2" equivalent="full"/>    
-          <input name="I7i" num_pins="2" equivalent="none"/>    
-          <input name="reg_in" num_pins="1"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="reg_out" num_pins="1"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk clb.reset</loc>     
-             <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>     
-             <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-             <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="mult_8" height="2" area="396000">   <sub_tile name="mult_8">    
-          <equivalent_sites>     
-             <site pb_type="mult_8" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="8"/>    
-          <input name="b" num_pins="8"/>    
-          <output name="out" num_pins="16"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top"/>     
-             <loc side="right" yoffset="0">mult_8.a[0:2] mult_8.b[0:2] mult_8.out[0:5]</loc>     
-             <loc side="right" yoffset="1">mult_8.a[3:5] mult_8.b[3:5] mult_8.out[6:10]</loc>     
-             <loc side="bottom">mult_8.a[6:7] mult_8.b[6:7] mult_8.out[11:15]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </fixed_layout>  
-      <fixed_layout name="12x12" width="14" height="14">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Bottom-side has 9 I/O per tile -->
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="2" equivalent="full"/>
+        <input name="I0i" num_pins="2" equivalent="none"/>
+        <input name="I1" num_pins="2" equivalent="full"/>
+        <input name="I1i" num_pins="2" equivalent="none"/>
+        <input name="I2" num_pins="2" equivalent="full"/>
+        <input name="I2i" num_pins="2" equivalent="none"/>
+        <input name="I3" num_pins="2" equivalent="full"/>
+        <input name="I3i" num_pins="2" equivalent="none"/>
+        <input name="I4" num_pins="2" equivalent="full"/>
+        <input name="I4i" num_pins="2" equivalent="none"/>
+        <input name="I5" num_pins="2" equivalent="full"/>
+        <input name="I5i" num_pins="2" equivalent="none"/>
+        <input name="I6" num_pins="2" equivalent="full"/>
+        <input name="I6i" num_pins="2" equivalent="none"/>
+        <input name="I7" num_pins="2" equivalent="full"/>
+        <input name="I7i" num_pins="2" equivalent="none"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset</loc>
+          <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>
+          <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+          <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_8" height="2" area="396000">
+      <sub_tile name="mult_8">
+        <equivalent_sites>
+          <site pb_type="mult_8" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="8"/>
+        <input name="b" num_pins="8"/>
+        <output name="out" num_pins="16"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top"/>
+          <loc side="right" yoffset="0">mult_8.a[0:2] mult_8.b[0:2] mult_8.out[0:5]</loc>
+          <loc side="right" yoffset="1">mult_8.a[3:5] mult_8.b[3:5] mult_8.out[6:10]</loc>
+          <loc side="bottom">mult_8.a[6:7] mult_8.b[6:7] mult_8.out[11:15]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_8" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -270,21 +284,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -296,384 +310,383 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define input pads begin -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- -Due to the absence of local routing, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
          the 4 inputs of fracturable LUT4 are no longer equivalent, 
          because the 4th input can not be switched when the dual-LUT3 modes are used.
          So pin equivalence should be applied to the first 3 inputs only
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="2" equivalent="full"/>   
-         <input name="I0i" num_pins="2" equivalent="none"/>   
-         <input name="I1" num_pins="2" equivalent="full"/>   
-         <input name="I1i" num_pins="2" equivalent="none"/>   
-         <input name="I2" num_pins="2" equivalent="full"/>   
-         <input name="I2i" num_pins="2" equivalent="none"/>   
-         <input name="I3" num_pins="2" equivalent="full"/>   
-         <input name="I3i" num_pins="2" equivalent="none"/>   
-         <input name="I4" num_pins="2" equivalent="full"/>   
-         <input name="I4i" num_pins="2" equivalent="none"/>   
-         <input name="I5" num_pins="2" equivalent="full"/>   
-         <input name="I5i" num_pins="2" equivalent="none"/>   
-         <input name="I6" num_pins="2" equivalent="full"/>   
-         <input name="I6i" num_pins="2" equivalent="none"/>   
-         <input name="I7" num_pins="2" equivalent="full"/>   
-         <input name="I7i" num_pins="2" equivalent="none"/>   
-         <input name="reg_in" num_pins="1"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="reset" num_pins="1" is_non_clock_global="true"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="reg_out" num_pins="1"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="2" equivalent="full"/>
+      <input name="I0i" num_pins="2" equivalent="none"/>
+      <input name="I1" num_pins="2" equivalent="full"/>
+      <input name="I1i" num_pins="2" equivalent="none"/>
+      <input name="I2" num_pins="2" equivalent="full"/>
+      <input name="I2i" num_pins="2" equivalent="none"/>
+      <input name="I3" num_pins="2" equivalent="full"/>
+      <input name="I3i" num_pins="2" equivalent="none"/>
+      <input name="I4" num_pins="2" equivalent="full"/>
+      <input name="I4i" num_pins="2" equivalent="none"/>
+      <input name="I5" num_pins="2" equivalent="full"/>
+      <input name="I5i" num_pins="2" equivalent="none"/>
+      <input name="I6" num_pins="2" equivalent="full"/>
+      <input name="I6i" num_pins="2" equivalent="none"/>
+      <input name="I7" num_pins="2" equivalent="full"/>
+      <input name="I7i" num_pins="2" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="reg_in" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="reg_out" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reg_in" num_pins="1"/>      
-                  <input name="sc_in" num_pins="1"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <output name="sc_out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="2"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut2_out" num_pins="2"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">        
-                        <input name="a" num_pins="1"/>        
-                        <input name="b" num_pins="1"/>        
-                        <input name="cin" num_pins="1"/>        
-                        <output name="cout" num_pins="1"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>        
-                        <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>        
-                        <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>        
-                        <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>        
-                        <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>        
-                        <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>        
-                        <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                        <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.reset" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>       
-                     <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>       
-                     <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>       
-                     <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>       
-                     <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>      
-                  <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>      
-                  <direct name="direct4" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>      
-                  <direct name="direct8" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct10" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Arithmetic mode definition begin -->    
-            <mode name="arithmetic">     
-               <pb_type name="soft_adder" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="sumout" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <!-- Define special LUT marco to be used as adder -->      
-                  <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="lut2_out" num_pins="2"/>       
-                     <output name="lut4_out" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>       
-                  </pb_type>      
-                  <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>       
-                     <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>       
-                     <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>        
-                     </direct>       
-                     <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">        
-                        <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
-                     considered by packer -->        
-                        <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>        
-                     </direct>       
-                     <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
-              </direct>       
-                     <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>        
-                     </direct>       
-                     <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
-              </direct>       
-                     <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="soft_adder.in"/>      
-                  <direct name="direct2" input="fle.cin" output="soft_adder.cin">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>       
-                  </direct>      
-                  <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>      
-                  <direct name="direct4" input="soft_adder.cout" output="fle.cout">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Arithmetic mode definition end -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reg_in" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="cin" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="2"/>
+              <output name="cout" num_pins="1"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut2_out" num_pins="2"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">
+                <input name="a" num_pins="1"/>
+                <input name="b" num_pins="1"/>
+                <input name="cin" num_pins="1"/>
+                <output name="cout" num_pins="1"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>
+                <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>
+                <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>
+                <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
+                <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
+                <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
+                <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+                <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <input name="reset" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>
+              <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>
+              <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>
+              <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>
+              <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Arithmetic mode definition begin -->
+        <mode name="arithmetic">
+          <pb_type name="soft_adder" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="sumout" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <!-- Define special LUT marco to be used as adder -->
+            <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="lut2_out" num_pins="2"/>
+              <output name="lut4_out" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>
+            </pb_type>
+            <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>
+              <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>
+              <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>
+              </direct>
+              <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">
+                <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
+                     considered by packer -->
+                <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>
+              </direct>
+              <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
+              </direct>
+              <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>
+              </direct>
+              <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
+              </direct>
+              <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="soft_adder.in"/>
+            <direct name="direct2" input="fle.cin" output="soft_adder.cin">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>
+            </direct>
+            <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>
+            <direct name="direct4" input="soft_adder.cout" output="fle.cout">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Arithmetic mode definition end -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -681,226 +694,226 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="reg_in" num_pins="1"/>      
-                  <output name="ff_out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>       
-                     <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>       
-                     <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>      
-                  <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>      
-                  <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="reg_in" num_pins="1"/>
+            <output name="ff_out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>
+              <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>
+              <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <!-- FIXME: The implicit port definition results in I0[0] connected to
+          -->
+        <!-- FIXME: The implicit port definition results in I0[0] connected to
                     in[2]. Such twisted connection is not expected.
                     I[0] should be connected to in[0]
-          -->    
-            <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[7:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>     
-               <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
-        </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">     
-               <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define fracturable multiplier begin -->  
-      <pb_type name="mult_8">   
-         <input name="a" num_pins="8"/>   
-         <input name="b" num_pins="8"/>   
-         <output name="out" num_pins="16"/>   
-         <mode name="mult_8x8">    
-            <pb_type name="mult_8x8_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="8"/>     
-               <input name="B_cfg" num_pins="8"/>     
-               <output name="OUT_cfg" num_pins="16"/>     
-               <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">      
-                  <input name="A" num_pins="8"/>      
-                  <input name="B" num_pins="8"/>      
-                  <output name="Y" num_pins="16"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.A">
-            </direct>      
-                  <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.B">
-            </direct>      
-                  <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="a2a" input="mult_8.a" output="mult_8x8_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_8.a" out_port="mult_8x8_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_8.b" output="mult_8x8_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_8.b" out_port="mult_8x8_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_8x8_slice.OUT_cfg" output="mult_8.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice.OUT_cfg" out_port="mult_8.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
+          <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <pb_type name="mult_8">
+      <input name="a" num_pins="8"/>
+      <input name="b" num_pins="8"/>
+      <output name="out" num_pins="16"/>
+      <mode name="mult_8x8">
+        <pb_type name="mult_8x8_slice" num_pb="1">
+          <input name="A_cfg" num_pins="8"/>
+          <input name="B_cfg" num_pins="8"/>
+          <output name="OUT_cfg" num_pins="16"/>
+          <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">
+            <input name="A" num_pins="8"/>
+            <input name="B" num_pins="8"/>
+            <output name="Y" num_pins="16"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.A">
+            </direct>
+            <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.B">
+            </direct>
+            <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="a2a" input="mult_8.a" output="mult_8x8_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_8.a" out_port="mult_8x8_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_8.b" output="mult_8x8_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_8.b" out_port="mult_8x8_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_8x8_slice.OUT_cfg" output="mult_8.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice.OUT_cfg" out_port="mult_8.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_frac_dsp16_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_frac_dsp16_nonLR_caravel_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -14,8 +15,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -23,250 +25,262 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="mult_8">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-      <model name="mult_16">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <model name="adder_lut4">   
-         <input_ports>    
-            <port name="in" combinational_sink_ports="lut2_out lut4_out"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower_physical">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="reset" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <model name="mult_8">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <model name="mult_16">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="adder_lut4">
+      <input_ports>
+        <port name="in" combinational_sink_ports="lut2_out lut4_out"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower_physical">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="reset" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <!-- Top-side has 1 I/O per tile -->  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Right-side has 1 I/O per tile -->  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Bottom-side has 9 I/O per tile -->  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Left-side has 1 I/O per tile -->  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- CLB has most pins on the top and right sides -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="2" equivalent="full"/>    
-          <input name="I0i" num_pins="2" equivalent="none"/>    
-          <input name="I1" num_pins="2" equivalent="full"/>    
-          <input name="I1i" num_pins="2" equivalent="none"/>    
-          <input name="I2" num_pins="2" equivalent="full"/>    
-          <input name="I2i" num_pins="2" equivalent="none"/>    
-          <input name="I3" num_pins="2" equivalent="full"/>    
-          <input name="I3i" num_pins="2" equivalent="none"/>    
-          <input name="I4" num_pins="2" equivalent="full"/>    
-          <input name="I4i" num_pins="2" equivalent="none"/>    
-          <input name="I5" num_pins="2" equivalent="full"/>    
-          <input name="I5i" num_pins="2" equivalent="none"/>    
-          <input name="I6" num_pins="2" equivalent="full"/>    
-          <input name="I6i" num_pins="2" equivalent="none"/>    
-          <input name="I7" num_pins="2" equivalent="full"/>    
-          <input name="I7i" num_pins="2" equivalent="none"/>    
-          <input name="reg_in" num_pins="1"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="reg_out" num_pins="1"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk clb.reset</loc>     
-             <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>     
-             <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-             <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="mult_16" height="2" area="396000">   <sub_tile name="mult_16">    
-          <equivalent_sites>     
-             <site pb_type="mult_16" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="16"/>    
-          <input name="b" num_pins="16"/>    
-          <output name="out" num_pins="32"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left" yoffset="0">mult_16.a[0:2] mult_16.b[0:2] mult_16.out[0:5]</loc>     
-             <loc side="left" yoffset="1">mult_16.a[3:5] mult_16.b[3:5] mult_16.out[6:10]</loc>     
-             <loc side="top" yoffset="1">mult_16.a[6:7] mult_16.b[6:7] mult_16.out[11:15]</loc>     
-             <loc side="right" yoffset="0">mult_16.a[8:10] mult_16.b[8:10] mult_16.out[16:21]</loc>     
-             <loc side="right" yoffset="1">mult_16.a[11:13] mult_16.b[11:13] mult_16.out[22:26]</loc>     
-             <loc side="bottom">mult_16.a[14:15] mult_16.b[14:15] mult_16.out[27:31]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </auto_layout>  
-      <fixed_layout name="3x4" width="5" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </fixed_layout>  
-      <fixed_layout name="12x12" width="14" height="14">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Bottom-side has 9 I/O per tile -->
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="2" equivalent="full"/>
+        <input name="I0i" num_pins="2" equivalent="none"/>
+        <input name="I1" num_pins="2" equivalent="full"/>
+        <input name="I1i" num_pins="2" equivalent="none"/>
+        <input name="I2" num_pins="2" equivalent="full"/>
+        <input name="I2i" num_pins="2" equivalent="none"/>
+        <input name="I3" num_pins="2" equivalent="full"/>
+        <input name="I3i" num_pins="2" equivalent="none"/>
+        <input name="I4" num_pins="2" equivalent="full"/>
+        <input name="I4i" num_pins="2" equivalent="none"/>
+        <input name="I5" num_pins="2" equivalent="full"/>
+        <input name="I5i" num_pins="2" equivalent="none"/>
+        <input name="I6" num_pins="2" equivalent="full"/>
+        <input name="I6i" num_pins="2" equivalent="none"/>
+        <input name="I7" num_pins="2" equivalent="full"/>
+        <input name="I7i" num_pins="2" equivalent="none"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset</loc>
+          <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>
+          <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+          <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_16" height="2" area="396000">
+      <sub_tile name="mult_16">
+        <equivalent_sites>
+          <site pb_type="mult_16" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="16"/>
+        <input name="b" num_pins="16"/>
+        <output name="out" num_pins="32"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left" yoffset="0">mult_16.a[0:2] mult_16.b[0:2] mult_16.out[0:5]</loc>
+          <loc side="left" yoffset="1">mult_16.a[3:5] mult_16.b[3:5] mult_16.out[6:10]</loc>
+          <loc side="top" yoffset="1">mult_16.a[6:7] mult_16.b[6:7] mult_16.out[11:15]</loc>
+          <loc side="right" yoffset="0">mult_16.a[8:10] mult_16.b[8:10] mult_16.out[16:21]</loc>
+          <loc side="right" yoffset="1">mult_16.a[11:13] mult_16.b[11:13] mult_16.out[22:26]</loc>
+          <loc side="bottom">mult_16.a[14:15] mult_16.b[14:15] mult_16.out[27:31]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </auto_layout>
+    <fixed_layout name="3x4" width="5" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -280,21 +294,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -306,384 +320,383 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define input pads begin -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- -Due to the absence of local routing, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
          the 4 inputs of fracturable LUT4 are no longer equivalent, 
          because the 4th input can not be switched when the dual-LUT3 modes are used.
          So pin equivalence should be applied to the first 3 inputs only
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="2" equivalent="full"/>   
-         <input name="I0i" num_pins="2" equivalent="none"/>   
-         <input name="I1" num_pins="2" equivalent="full"/>   
-         <input name="I1i" num_pins="2" equivalent="none"/>   
-         <input name="I2" num_pins="2" equivalent="full"/>   
-         <input name="I2i" num_pins="2" equivalent="none"/>   
-         <input name="I3" num_pins="2" equivalent="full"/>   
-         <input name="I3i" num_pins="2" equivalent="none"/>   
-         <input name="I4" num_pins="2" equivalent="full"/>   
-         <input name="I4i" num_pins="2" equivalent="none"/>   
-         <input name="I5" num_pins="2" equivalent="full"/>   
-         <input name="I5i" num_pins="2" equivalent="none"/>   
-         <input name="I6" num_pins="2" equivalent="full"/>   
-         <input name="I6i" num_pins="2" equivalent="none"/>   
-         <input name="I7" num_pins="2" equivalent="full"/>   
-         <input name="I7i" num_pins="2" equivalent="none"/>   
-         <input name="reg_in" num_pins="1"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="reset" num_pins="1" is_non_clock_global="true"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="reg_out" num_pins="1"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="2" equivalent="full"/>
+      <input name="I0i" num_pins="2" equivalent="none"/>
+      <input name="I1" num_pins="2" equivalent="full"/>
+      <input name="I1i" num_pins="2" equivalent="none"/>
+      <input name="I2" num_pins="2" equivalent="full"/>
+      <input name="I2i" num_pins="2" equivalent="none"/>
+      <input name="I3" num_pins="2" equivalent="full"/>
+      <input name="I3i" num_pins="2" equivalent="none"/>
+      <input name="I4" num_pins="2" equivalent="full"/>
+      <input name="I4i" num_pins="2" equivalent="none"/>
+      <input name="I5" num_pins="2" equivalent="full"/>
+      <input name="I5i" num_pins="2" equivalent="none"/>
+      <input name="I6" num_pins="2" equivalent="full"/>
+      <input name="I6i" num_pins="2" equivalent="none"/>
+      <input name="I7" num_pins="2" equivalent="full"/>
+      <input name="I7i" num_pins="2" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="reg_in" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="reg_out" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reg_in" num_pins="1"/>      
-                  <input name="sc_in" num_pins="1"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <output name="sc_out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="2"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut2_out" num_pins="2"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">        
-                        <input name="a" num_pins="1"/>        
-                        <input name="b" num_pins="1"/>        
-                        <input name="cin" num_pins="1"/>        
-                        <output name="cout" num_pins="1"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>        
-                        <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>        
-                        <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>        
-                        <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>        
-                        <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>        
-                        <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>        
-                        <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                        <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.reset" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>       
-                     <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>       
-                     <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>       
-                     <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>       
-                     <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>      
-                  <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>      
-                  <direct name="direct4" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>      
-                  <direct name="direct8" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct10" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Arithmetic mode definition begin -->    
-            <mode name="arithmetic">     
-               <pb_type name="soft_adder" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="sumout" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <!-- Define special LUT marco to be used as adder -->      
-                  <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="lut2_out" num_pins="2"/>       
-                     <output name="lut4_out" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>       
-                  </pb_type>      
-                  <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>       
-                     <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>       
-                     <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>        
-                     </direct>       
-                     <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">        
-                        <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
-                     considered by packer -->        
-                        <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>        
-                     </direct>       
-                     <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
-              </direct>       
-                     <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>        
-                     </direct>       
-                     <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
-              </direct>       
-                     <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="soft_adder.in"/>      
-                  <direct name="direct2" input="fle.cin" output="soft_adder.cin">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>       
-                  </direct>      
-                  <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>      
-                  <direct name="direct4" input="soft_adder.cout" output="fle.cout">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Arithmetic mode definition end -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reg_in" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="cin" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="2"/>
+              <output name="cout" num_pins="1"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut2_out" num_pins="2"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">
+                <input name="a" num_pins="1"/>
+                <input name="b" num_pins="1"/>
+                <input name="cin" num_pins="1"/>
+                <output name="cout" num_pins="1"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>
+                <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>
+                <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>
+                <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
+                <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
+                <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
+                <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+                <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <input name="reset" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>
+              <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>
+              <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>
+              <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>
+              <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Arithmetic mode definition begin -->
+        <mode name="arithmetic">
+          <pb_type name="soft_adder" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="sumout" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <!-- Define special LUT marco to be used as adder -->
+            <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="lut2_out" num_pins="2"/>
+              <output name="lut4_out" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>
+            </pb_type>
+            <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>
+              <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>
+              <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>
+              </direct>
+              <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">
+                <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
+                     considered by packer -->
+                <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>
+              </direct>
+              <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
+              </direct>
+              <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>
+              </direct>
+              <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
+              </direct>
+              <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="soft_adder.in"/>
+            <direct name="direct2" input="fle.cin" output="soft_adder.cin">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>
+            </direct>
+            <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>
+            <direct name="direct4" input="soft_adder.cout" output="fle.cout">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Arithmetic mode definition end -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -691,273 +704,273 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="reg_in" num_pins="1"/>      
-                  <output name="ff_out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>       
-                     <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>       
-                     <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>      
-                  <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>      
-                  <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="reg_in" num_pins="1"/>
+            <output name="ff_out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>
+              <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>
+              <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <!-- FIXME: The implicit port definition results in I0[0] connected to
+          -->
+        <!-- FIXME: The implicit port definition results in I0[0] connected to
                     in[2]. Such twisted connection is not expected.
                     I[0] should be connected to in[0]
-          -->    
-            <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[7:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>     
-               <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
-        </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">     
-               <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define fracturable multiplier begin -->  
-      <pb_type name="mult_16">   
-         <input name="a" num_pins="16"/>   
-         <input name="b" num_pins="16"/>   
-         <output name="out" num_pins="32"/>   
-         <mode name="mult_8x8">    
-            <pb_type name="mult_8x8_slice" num_pb="2">     
-               <input name="A_cfg" num_pins="8"/>     
-               <input name="B_cfg" num_pins="8"/>     
-               <output name="OUT_cfg" num_pins="16"/>     
-               <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">      
-                  <input name="A" num_pins="8"/>      
-                  <input name="B" num_pins="8"/>      
-                  <output name="Y" num_pins="16"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.A">
-            </direct>      
-                  <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.B">
-            </direct>      
-                  <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="a2a_0" input="mult_16.a[0:7]" output="mult_8x8_slice[0].A_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[0:7]" out_port="mult_8x8_slice[0].A_cfg[0:7]"/>      
-               </direct>     
-               <direct name="a2a_1" input="mult_16.a[8:15]" output="mult_8x8_slice[1].A_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[8:15]" out_port="mult_8x8_slice[1].A_cfg[0:7]"/>      
-               </direct>     
-               <direct name="b2b_0" input="mult_16.b[0:7]" output="mult_8x8_slice[0].B_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[0:7]" out_port="mult_8x8_slice[0].B_cfg[0:7]"/>      
-               </direct>     
-               <direct name="b2b_1" input="mult_16.b[8:15]" output="mult_8x8_slice[1].B_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[8:15]" out_port="mult_8x8_slice[1].B_cfg[0:7]"/>      
-               </direct>     
-               <direct name="out2out_0" input="mult_8x8_slice[0].OUT_cfg[0:15]" output="mult_16.out[0:15]">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[0].OUT_cfg[0:15]" out_port="mult_16.out[0:15]"/>      
-               </direct>     
-               <direct name="out2out_1" input="mult_8x8_slice[1].OUT_cfg[0:15]" output="mult_16.out[16:31]">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[1].OUT_cfg[0:15]" out_port="mult_16.out[16:31]"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mult_16x16">    
-            <pb_type name="mult_16x16_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="16"/>     
-               <input name="B_cfg" num_pins="16"/>     
-               <output name="OUT_cfg" num_pins="32"/>     
-               <pb_type name="mult_16x16" blif_model=".subckt mult_16" num_pb="1">      
-                  <input name="A" num_pins="16"/>      
-                  <input name="B" num_pins="16"/>      
-                  <output name="Y" num_pins="32"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.A" out_port="mult_16x16.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.B" out_port="mult_16x16.Y"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_16x16_slice.A_cfg" output="mult_16x16.A">
-            </direct>      
-                  <direct name="b2b" input="mult_16x16_slice.B_cfg" output="mult_16x16.B">
-            </direct>      
-                  <direct name="out2out" input="mult_16x16.Y" output="mult_16x16_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="a2a" input="mult_16.a" output="mult_16x16_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a" out_port="mult_16x16_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_16.b" output="mult_16x16_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b" out_port="mult_16x16_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_16x16_slice.OUT_cfg" output="mult_16.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_16x16_slice.OUT_cfg" out_port="mult_16.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
+          <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <pb_type name="mult_16">
+      <input name="a" num_pins="16"/>
+      <input name="b" num_pins="16"/>
+      <output name="out" num_pins="32"/>
+      <mode name="mult_8x8">
+        <pb_type name="mult_8x8_slice" num_pb="2">
+          <input name="A_cfg" num_pins="8"/>
+          <input name="B_cfg" num_pins="8"/>
+          <output name="OUT_cfg" num_pins="16"/>
+          <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">
+            <input name="A" num_pins="8"/>
+            <input name="B" num_pins="8"/>
+            <output name="Y" num_pins="16"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.A">
+            </direct>
+            <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.B">
+            </direct>
+            <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="a2a_0" input="mult_16.a[0:7]" output="mult_8x8_slice[0].A_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[0:7]" out_port="mult_8x8_slice[0].A_cfg[0:7]"/>
+          </direct>
+          <direct name="a2a_1" input="mult_16.a[8:15]" output="mult_8x8_slice[1].A_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[8:15]" out_port="mult_8x8_slice[1].A_cfg[0:7]"/>
+          </direct>
+          <direct name="b2b_0" input="mult_16.b[0:7]" output="mult_8x8_slice[0].B_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[0:7]" out_port="mult_8x8_slice[0].B_cfg[0:7]"/>
+          </direct>
+          <direct name="b2b_1" input="mult_16.b[8:15]" output="mult_8x8_slice[1].B_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[8:15]" out_port="mult_8x8_slice[1].B_cfg[0:7]"/>
+          </direct>
+          <direct name="out2out_0" input="mult_8x8_slice[0].OUT_cfg[0:15]" output="mult_16.out[0:15]">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[0].OUT_cfg[0:15]" out_port="mult_16.out[0:15]"/>
+          </direct>
+          <direct name="out2out_1" input="mult_8x8_slice[1].OUT_cfg[0:15]" output="mult_16.out[16:31]">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[1].OUT_cfg[0:15]" out_port="mult_16.out[16:31]"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_16x16">
+        <pb_type name="mult_16x16_slice" num_pb="1">
+          <input name="A_cfg" num_pins="16"/>
+          <input name="B_cfg" num_pins="16"/>
+          <output name="OUT_cfg" num_pins="32"/>
+          <pb_type name="mult_16x16" blif_model=".subckt mult_16" num_pb="1">
+            <input name="A" num_pins="16"/>
+            <input name="B" num_pins="16"/>
+            <output name="Y" num_pins="32"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.A" out_port="mult_16x16.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.B" out_port="mult_16x16.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_16x16_slice.A_cfg" output="mult_16x16.A">
+            </direct>
+            <direct name="b2b" input="mult_16x16_slice.B_cfg" output="mult_16x16.B">
+            </direct>
+            <direct name="out2out" input="mult_16x16.Y" output="mult_16x16_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="a2a" input="mult_16.a" output="mult_16x16_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a" out_port="mult_16x16_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_16.b" output="mult_16x16_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b" out_port="mult_16x16_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_16x16_slice.OUT_cfg" output="mult_16.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_16x16_slice.OUT_cfg" out_port="mult_16.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -12,8 +13,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,207 +23,217 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <model name="adder_lut4">   
-         <input_ports>    
-            <port name="in" combinational_sink_ports="lut2_out lut4_out"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower_physical">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="reset" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="adder_lut4">
+      <input_ports>
+        <port name="in" combinational_sink_ports="lut2_out lut4_out"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower_physical">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="reset" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <!-- Top-side has 1 I/O per tile -->  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Right-side has 1 I/O per tile -->  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Bottom-side has 9 I/O per tile -->  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Left-side has 1 I/O per tile -->  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- CLB has most pins on the top and right sides -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="2" equivalent="none"/>    
-          <input name="I0i" num_pins="2" equivalent="none"/>    
-          <input name="I1" num_pins="2" equivalent="none"/>    
-          <input name="I1i" num_pins="2" equivalent="none"/>    
-          <input name="I2" num_pins="2" equivalent="none"/>    
-          <input name="I2i" num_pins="2" equivalent="none"/>    
-          <input name="I3" num_pins="2" equivalent="none"/>    
-          <input name="I3i" num_pins="2" equivalent="none"/>    
-          <input name="I4" num_pins="2" equivalent="none"/>    
-          <input name="I4i" num_pins="2" equivalent="none"/>    
-          <input name="I5" num_pins="2" equivalent="none"/>    
-          <input name="I5i" num_pins="2" equivalent="none"/>    
-          <input name="I6" num_pins="2" equivalent="none"/>    
-          <input name="I6i" num_pins="2" equivalent="none"/>    
-          <input name="I7" num_pins="2" equivalent="none"/>    
-          <input name="I7i" num_pins="2" equivalent="none"/>    
-          <input name="reg_in" num_pins="1"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="reg_out" num_pins="1"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk clb.reset</loc>     
-             <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>     
-             <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-             <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <fixed_layout name="12x12" width="14" height="14">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Bottom-side has 9 I/O per tile -->
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="2" equivalent="none"/>
+        <input name="I0i" num_pins="2" equivalent="none"/>
+        <input name="I1" num_pins="2" equivalent="none"/>
+        <input name="I1i" num_pins="2" equivalent="none"/>
+        <input name="I2" num_pins="2" equivalent="none"/>
+        <input name="I2i" num_pins="2" equivalent="none"/>
+        <input name="I3" num_pins="2" equivalent="none"/>
+        <input name="I3i" num_pins="2" equivalent="none"/>
+        <input name="I4" num_pins="2" equivalent="none"/>
+        <input name="I4i" num_pins="2" equivalent="none"/>
+        <input name="I5" num_pins="2" equivalent="none"/>
+        <input name="I5i" num_pins="2" equivalent="none"/>
+        <input name="I6" num_pins="2" equivalent="none"/>
+        <input name="I6i" num_pins="2" equivalent="none"/>
+        <input name="I7" num_pins="2" equivalent="none"/>
+        <input name="I7i" num_pins="2" equivalent="none"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset</loc>
+          <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>
+          <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+          <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -235,21 +247,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -261,384 +273,383 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define input pads begin -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- -Due to the absence of local routing, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
          the 4 inputs of fracturable LUT4 are no longer equivalent, 
          because the 4th input can not be switched when the dual-LUT3 modes are used.
          So pin equivalence should be applied to the first 3 inputs only
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="2" equivalent="none"/>   
-         <input name="I0i" num_pins="2" equivalent="none"/>   
-         <input name="I1" num_pins="2" equivalent="none"/>   
-         <input name="I1i" num_pins="2" equivalent="none"/>   
-         <input name="I2" num_pins="2" equivalent="none"/>   
-         <input name="I2i" num_pins="2" equivalent="none"/>   
-         <input name="I3" num_pins="2" equivalent="none"/>   
-         <input name="I3i" num_pins="2" equivalent="none"/>   
-         <input name="I4" num_pins="2" equivalent="none"/>   
-         <input name="I4i" num_pins="2" equivalent="none"/>   
-         <input name="I5" num_pins="2" equivalent="none"/>   
-         <input name="I5i" num_pins="2" equivalent="none"/>   
-         <input name="I6" num_pins="2" equivalent="none"/>   
-         <input name="I6i" num_pins="2" equivalent="none"/>   
-         <input name="I7" num_pins="2" equivalent="none"/>   
-         <input name="I7i" num_pins="2" equivalent="none"/>   
-         <input name="reg_in" num_pins="1"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="reset" num_pins="1" is_non_clock_global="true"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="reg_out" num_pins="1"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="2" equivalent="none"/>
+      <input name="I0i" num_pins="2" equivalent="none"/>
+      <input name="I1" num_pins="2" equivalent="none"/>
+      <input name="I1i" num_pins="2" equivalent="none"/>
+      <input name="I2" num_pins="2" equivalent="none"/>
+      <input name="I2i" num_pins="2" equivalent="none"/>
+      <input name="I3" num_pins="2" equivalent="none"/>
+      <input name="I3i" num_pins="2" equivalent="none"/>
+      <input name="I4" num_pins="2" equivalent="none"/>
+      <input name="I4i" num_pins="2" equivalent="none"/>
+      <input name="I5" num_pins="2" equivalent="none"/>
+      <input name="I5i" num_pins="2" equivalent="none"/>
+      <input name="I6" num_pins="2" equivalent="none"/>
+      <input name="I6i" num_pins="2" equivalent="none"/>
+      <input name="I7" num_pins="2" equivalent="none"/>
+      <input name="I7i" num_pins="2" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="reg_in" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="reg_out" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reg_in" num_pins="1"/>      
-                  <input name="sc_in" num_pins="1"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <output name="sc_out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="2"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut2_out" num_pins="2"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">        
-                        <input name="a" num_pins="1"/>        
-                        <input name="b" num_pins="1"/>        
-                        <input name="cin" num_pins="1"/>        
-                        <output name="cout" num_pins="1"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>        
-                        <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>        
-                        <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>        
-                        <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>        
-                        <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>        
-                        <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>        
-                        <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                        <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.reset" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>       
-                     <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>       
-                     <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>       
-                     <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>       
-                     <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>      
-                  <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>      
-                  <direct name="direct4" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>      
-                  <direct name="direct8" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct10" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Arithmetic mode definition begin -->    
-            <mode name="arithmetic">     
-               <pb_type name="soft_adder" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="sumout" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <!-- Define special LUT marco to be used as adder -->      
-                  <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="lut2_out" num_pins="2"/>       
-                     <output name="lut4_out" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>       
-                  </pb_type>      
-                  <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>       
-                     <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>       
-                     <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>        
-                     </direct>       
-                     <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">        
-                        <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
-                     considered by packer -->        
-                        <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>        
-                     </direct>       
-                     <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
-              </direct>       
-                     <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>        
-                     </direct>       
-                     <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
-              </direct>       
-                     <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="soft_adder.in"/>      
-                  <direct name="direct2" input="fle.cin" output="soft_adder.cin">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>       
-                  </direct>      
-                  <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>      
-                  <direct name="direct4" input="soft_adder.cout" output="fle.cout">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Arithmetic mode definition end -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reg_in" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="cin" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="2"/>
+              <output name="cout" num_pins="1"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut2_out" num_pins="2"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">
+                <input name="a" num_pins="1"/>
+                <input name="b" num_pins="1"/>
+                <input name="cin" num_pins="1"/>
+                <output name="cout" num_pins="1"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>
+                <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>
+                <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>
+                <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
+                <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
+                <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
+                <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+                <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <input name="reset" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>
+              <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>
+              <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>
+              <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>
+              <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Arithmetic mode definition begin -->
+        <mode name="arithmetic">
+          <pb_type name="soft_adder" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="sumout" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <!-- Define special LUT marco to be used as adder -->
+            <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="lut2_out" num_pins="2"/>
+              <output name="lut4_out" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>
+            </pb_type>
+            <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>
+              <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>
+              <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>
+              </direct>
+              <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">
+                <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
+                     considered by packer -->
+                <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>
+              </direct>
+              <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
+              </direct>
+              <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>
+              </direct>
+              <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
+              </direct>
+              <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="soft_adder.in"/>
+            <direct name="direct2" input="fle.cin" output="soft_adder.cin">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>
+            </direct>
+            <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>
+            <direct name="direct4" input="soft_adder.cout" output="fle.cout">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Arithmetic mode definition end -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -646,179 +657,179 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="reg_in" num_pins="1"/>      
-                  <output name="ff_out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>       
-                     <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>       
-                     <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>      
-                  <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>      
-                  <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="reg_in" num_pins="1"/>
+            <output name="ff_out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>
+              <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>
+              <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <!-- FIXME: The implicit port definition results in I0[0] connected to
+          -->
+        <!-- FIXME: The implicit port definition results in I0[0] connected to
                     in[2]. Such twisted connection is not expected.
                     I[0] should be connected to in[0]
-          -->    
-            <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[7:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>     
-               <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
-        </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">     
-               <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
+          <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_wide_frac_dsp16_nonLR_caravel_io_skywater130nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N8_tileable_reset_softadder_register_scan_chain_wide_frac_dsp16_nonLR_caravel_io_skywater130nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Low-cost homogeneous FPGA Architecture.
 
   - Skywater 130 nm technology
@@ -14,8 +15,9 @@
       - 100 routing tracks per channel
 
   Authors: Xifan Tang
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -23,252 +25,264 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="mult_8">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-      <model name="mult_16">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <model name="adder_lut4">   
-         <input_ports>    
-            <port name="in" combinational_sink_ports="lut2_out lut4_out"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <model name="frac_lut4">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut2_out"/>    
-            <port name="lut3_out"/>    
-            <port name="lut4_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="carry_follower_physical">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="cout"/>    
-            <port name="b" combinational_sink_ports="cout"/>    
-            <port name="cin" combinational_sink_ports="cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="reset" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <model name="mult_8">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <model name="mult_16">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="adder_lut4">
+      <input_ports>
+        <port name="in" combinational_sink_ports="lut2_out lut4_out"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut2_out"/>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="carry_follower_physical">
+      <input_ports>
+        <port name="a" combinational_sink_ports="cout"/>
+        <port name="b" combinational_sink_ports="cout"/>
+        <port name="cin" combinational_sink_ports="cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="reset" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <!-- Top-side has 1 I/O per tile -->  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Right-side has 1 I/O per tile -->  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Bottom-side has 9 I/O per tile -->  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Left-side has 1 I/O per tile -->  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="9">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- CLB has most pins on the top and right sides -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="2" equivalent="full"/>    
-          <input name="I0i" num_pins="2" equivalent="none"/>    
-          <input name="I1" num_pins="2" equivalent="full"/>    
-          <input name="I1i" num_pins="2" equivalent="none"/>    
-          <input name="I2" num_pins="2" equivalent="full"/>    
-          <input name="I2i" num_pins="2" equivalent="none"/>    
-          <input name="I3" num_pins="2" equivalent="full"/>    
-          <input name="I3i" num_pins="2" equivalent="none"/>    
-          <input name="I4" num_pins="2" equivalent="full"/>    
-          <input name="I4i" num_pins="2" equivalent="none"/>    
-          <input name="I5" num_pins="2" equivalent="full"/>    
-          <input name="I5i" num_pins="2" equivalent="none"/>    
-          <input name="I6" num_pins="2" equivalent="full"/>    
-          <input name="I6i" num_pins="2" equivalent="none"/>    
-          <input name="I7" num_pins="2" equivalent="full"/>    
-          <input name="I7i" num_pins="2" equivalent="none"/>    
-          <input name="reg_in" num_pins="1"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <output name="reg_out" num_pins="1"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk clb.reset</loc>     
-             <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>     
-             <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>     
-             <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="mult_16" height="2" width="2" area="396000">   <sub_tile name="mult_16">    
-          <equivalent_sites>     
-             <site pb_type="mult_16" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="16"/>    
-          <input name="b" num_pins="16"/>    
-          <output name="out" num_pins="32"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left" yoffset="0">mult_16.a[0:1] mult_16.b[0:1] mult_16.out[0:3]</loc>     
-             <loc side="left" yoffset="1">mult_16.a[2:3] mult_16.b[2:3] mult_16.out[4:7]</loc>     
-             <loc side="top" xoffset="0" yoffset="1">mult_16.a[4:5] mult_16.b[4:5] mult_16.out[8:11]</loc>     
-             <loc side="top" xoffset="1" yoffset="1">mult_16.a[6:7] mult_16.b[6:7] mult_16.out[12:15]</loc>     
-             <loc side="right" xoffset="1" yoffset="0">mult_16.a[8:9] mult_16.b[8:9] mult_16.out[16:19]</loc>     
-             <loc side="right" xoffset="1" yoffset="1">mult_16.a[10:11] mult_16.b[10:11] mult_16.out[20:23]</loc>     
-             <loc side="bottom" xoffset="0">mult_16.a[12:13] mult_16.b[12:13] mult_16.out[24:27]</loc>     
-             <loc side="bottom" xoffset="1">mult_16.a[14:15] mult_16.b[14:15] mult_16.out[28:31]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </auto_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </fixed_layout>  
-      <fixed_layout name="12x12" width="14" height="14">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <!-- Top-side has 1 I/O per tile -->
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Right-side has 1 I/O per tile -->
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Bottom-side has 9 I/O per tile -->
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Left-side has 1 I/O per tile -->
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="9">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- CLB has most pins on the top and right sides -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="2" equivalent="full"/>
+        <input name="I0i" num_pins="2" equivalent="none"/>
+        <input name="I1" num_pins="2" equivalent="full"/>
+        <input name="I1i" num_pins="2" equivalent="none"/>
+        <input name="I2" num_pins="2" equivalent="full"/>
+        <input name="I2i" num_pins="2" equivalent="none"/>
+        <input name="I3" num_pins="2" equivalent="full"/>
+        <input name="I3i" num_pins="2" equivalent="none"/>
+        <input name="I4" num_pins="2" equivalent="full"/>
+        <input name="I4i" num_pins="2" equivalent="none"/>
+        <input name="I5" num_pins="2" equivalent="full"/>
+        <input name="I5i" num_pins="2" equivalent="none"/>
+        <input name="I6" num_pins="2" equivalent="full"/>
+        <input name="I6i" num_pins="2" equivalent="none"/>
+        <input name="I7" num_pins="2" equivalent="full"/>
+        <input name="I7i" num_pins="2" equivalent="none"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset</loc>
+          <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I0 clb.I0i clb.I1 clb.I1i clb.I2 clb.I2i clb.I3 clb.I3i</loc>
+          <loc side="right">clb.O[15:8] clb.I4 clb.I4i clb.I5 clb.I5i clb.I6 clb.I6i clb.I7 clb.I7i</loc>
+          <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_16" height="2" width="2" area="396000">
+      <sub_tile name="mult_16">
+        <equivalent_sites>
+          <site pb_type="mult_16" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="16"/>
+        <input name="b" num_pins="16"/>
+        <output name="out" num_pins="32"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left" yoffset="0">mult_16.a[0:1] mult_16.b[0:1] mult_16.out[0:3]</loc>
+          <loc side="left" yoffset="1">mult_16.a[2:3] mult_16.b[2:3] mult_16.out[4:7]</loc>
+          <loc side="top" xoffset="0" yoffset="1">mult_16.a[4:5] mult_16.b[4:5] mult_16.out[8:11]</loc>
+          <loc side="top" xoffset="1" yoffset="1">mult_16.a[6:7] mult_16.b[6:7] mult_16.out[12:15]</loc>
+          <loc side="right" xoffset="1" yoffset="0">mult_16.a[8:9] mult_16.b[8:9] mult_16.out[16:19]</loc>
+          <loc side="right" xoffset="1" yoffset="1">mult_16.a[10:11] mult_16.b[10:11] mult_16.out[20:23]</loc>
+          <loc side="bottom" xoffset="0">mult_16.a[12:13] mult_16.b[12:13] mult_16.out[24:27]</loc>
+          <loc side="bottom" xoffset="1">mult_16.a[14:15] mult_16.b[14:15] mult_16.out[28:31]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </auto_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+    <fixed_layout name="12x12" width="14" height="14">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_8' with 'EMPTY' blocks wherever a 'mult_8' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_16" startx="2" starty="1" repeatx="8" priority="20"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -282,21 +296,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -308,384 +322,383 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L1_mux"/>   
-         <sb type="pattern">1 1</sb>   
-         <cb type="pattern">1</cb>   
-      </segment>  
-      <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L2_mux"/>   
-         <sb type="pattern">1 1 1</sb>   
-         <cb type="pattern">1 1</cb>   
-      </segment>  
-      <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="L4_mux"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define input pads begin -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="0.10" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1_mux"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2_mux"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="0.80" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4_mux"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define input pads begin -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!-- -Due to the absence of local routing, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!-- -Due to the absence of local routing, 
          the 4 inputs of fracturable LUT4 are no longer equivalent, 
          because the 4th input can not be switched when the dual-LUT3 modes are used.
          So pin equivalence should be applied to the first 3 inputs only
-	  -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="2" equivalent="full"/>   
-         <input name="I0i" num_pins="2" equivalent="none"/>   
-         <input name="I1" num_pins="2" equivalent="full"/>   
-         <input name="I1i" num_pins="2" equivalent="none"/>   
-         <input name="I2" num_pins="2" equivalent="full"/>   
-         <input name="I2i" num_pins="2" equivalent="none"/>   
-         <input name="I3" num_pins="2" equivalent="full"/>   
-         <input name="I3i" num_pins="2" equivalent="none"/>   
-         <input name="I4" num_pins="2" equivalent="full"/>   
-         <input name="I4i" num_pins="2" equivalent="none"/>   
-         <input name="I5" num_pins="2" equivalent="full"/>   
-         <input name="I5i" num_pins="2" equivalent="none"/>   
-         <input name="I6" num_pins="2" equivalent="full"/>   
-         <input name="I6i" num_pins="2" equivalent="none"/>   
-         <input name="I7" num_pins="2" equivalent="full"/>   
-         <input name="I7i" num_pins="2" equivalent="none"/>   
-         <input name="reg_in" num_pins="1"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="reset" num_pins="1" is_non_clock_global="true"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <output name="reg_out" num_pins="1"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	  -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="2" equivalent="full"/>
+      <input name="I0i" num_pins="2" equivalent="none"/>
+      <input name="I1" num_pins="2" equivalent="full"/>
+      <input name="I1i" num_pins="2" equivalent="none"/>
+      <input name="I2" num_pins="2" equivalent="full"/>
+      <input name="I2i" num_pins="2" equivalent="none"/>
+      <input name="I3" num_pins="2" equivalent="full"/>
+      <input name="I3i" num_pins="2" equivalent="none"/>
+      <input name="I4" num_pins="2" equivalent="full"/>
+      <input name="I4i" num_pins="2" equivalent="none"/>
+      <input name="I5" num_pins="2" equivalent="full"/>
+      <input name="I5i" num_pins="2" equivalent="none"/>
+      <input name="I6" num_pins="2" equivalent="full"/>
+      <input name="I6i" num_pins="2" equivalent="none"/>
+      <input name="I7" num_pins="2" equivalent="full"/>
+      <input name="I7i" num_pins="2" equivalent="none"/>
+      <input name="reg_in" num_pins="1"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <output name="reg_out" num_pins="1"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="4"/>    
-            <input name="reg_in" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="reg_out" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="reg_in" num_pins="1"/>      
-                  <input name="sc_in" num_pins="1"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <output name="sc_out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="2"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">        
-                        <input name="in" num_pins="4"/>        
-                        <output name="lut2_out" num_pins="2"/>        
-                        <output name="lut3_out" num_pins="2"/>        
-                        <output name="lut4_out" num_pins="1"/>        
-                     </pb_type>       
-                     <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">        
-                        <input name="a" num_pins="1"/>        
-                        <input name="b" num_pins="1"/>        
-                        <input name="cin" num_pins="1"/>        
-                        <output name="cout" num_pins="1"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>        
-                        <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>        
-                        <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>        
-                        <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>        
-                        <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>        
-                        <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>        
-                        <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>        
-                        <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>        
-                        <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <input name="reset" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.reset" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>       
-                     <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>       
-                     <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>       
-                     <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>       
-                     <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>       
-                     <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>        
-                        <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>        
-                        <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>      
-                  <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>      
-                  <direct name="direct4" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>      
-                  <direct name="direct8" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct10" input="fle.reset" output="fabric.reset"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Arithmetic mode definition begin -->    
-            <mode name="arithmetic">     
-               <pb_type name="soft_adder" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="sumout" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <!-- Define special LUT marco to be used as adder -->      
-                  <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">       
-                     <input name="in" num_pins="4"/>       
-                     <output name="lut2_out" num_pins="2"/>       
-                     <output name="lut4_out" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>       
-                  </pb_type>      
-                  <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>       
-                     <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>       
-                     <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>        
-                     </direct>       
-                     <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">        
-                        <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
-                     considered by packer -->        
-                        <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>        
-                     </direct>       
-                     <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
-              </direct>       
-                     <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">        
-                        <!-- Pack pattern to build an adder chain connection considered by packer -->        
-                        <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>        
-                     </direct>       
-                     <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
-              </direct>       
-                     <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="soft_adder.in"/>      
-                  <direct name="direct2" input="fle.cin" output="soft_adder.cin">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>       
-                  </direct>      
-                  <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>      
-                  <direct name="direct4" input="soft_adder.cout" output="fle.cout">       
-                     <!-- Pack pattern to build an adder chain connection considered by packer -->       
-                     <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Arithmetic mode definition end -->    
-            <!-- Dual 3-LUT mode definition begin -->    
-            <mode name="n2_lut3">     
-               <pb_type name="lut3inter" num_pb="1">      
-                  <input name="in" num_pins="3"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble3" num_pb="2">       
-                     <input name="in" num_pins="3"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="3" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="4"/>
+        <input name="reg_in" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="reg_out" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="reg_in" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="cin" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="2"/>
+              <output name="cout" num_pins="1"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut2_out" num_pins="2"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <pb_type name="carry_follower" blif_model=".subckt carry_follower_physical" num_pb="1">
+                <input name="a" num_pins="1"/>
+                <input name="b" num_pins="1"/>
+                <input name="cin" num_pins="1"/>
+                <output name="cout" num_pins="1"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+                <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>
+                <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>
+                <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>
+                <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
+                <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
+                <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
+                <direct name="direct7" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+                <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <input name="reset" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="frac_logic.cin"/>
+              <direct name="direct3" input="fabric.sc_in" output="ff[0].DI"/>
+              <direct name="direct4" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct5" input="ff[1].Q" output="fabric.sc_out"/>
+              <direct name="direct6" input="ff[1].Q" output="fabric.reg_out"/>
+              <direct name="direct7" input="frac_logic.cout" output="fabric.cout"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <complete name="complete2" input="fabric.reset" output="ff[1:0].reset"/>
+              <mux name="mux1" input="frac_logic.out[0:0] fabric.reg_in" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] ff[0:0].Q" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Arithmetic mode definition begin -->
+        <mode name="arithmetic">
+          <pb_type name="soft_adder" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="sumout" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <!-- Define special LUT marco to be used as adder -->
+            <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="lut2_out" num_pins="2"/>
+              <output name="lut4_out" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut2_out"/>
+              <delay_constant max="0.3e-9" in_port="adder_lut4.in" out_port="adder_lut4.lut4_out"/>
+            </pb_type>
+            <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.a" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.b" out_port="carry_follower.cout"/>
+              <delay_constant max="0.3e-9" in_port="carry_follower.cin" out_port="carry_follower.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="soft_adder.in[0:1]" output="adder_lut4.in[0:1]"/>
+              <direct name="direct2" input="soft_adder.in[3:3]" output="adder_lut4.in[3:3]"/>
+              <direct name="direct3" input="soft_adder.cin" output="carry_follower.b">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="soft_adder.cin" out_port="carry_follower.b"/>
+              </direct>
+              <direct name="direct4" input="adder_lut4.lut2_out[1:1]" output="carry_follower.a">
+                <!-- Pack pattern to pair adder_lut4 and carry_follower into a molecule 
+                     considered by packer -->
+                <pack_pattern name="lut_follower" in_port="adder_lut4.lut2_out[1:1]" out_port="carry_follower.a"/>
+              </direct>
+              <direct name="direct5" input="adder_lut4.lut2_out[0:0]" output="carry_follower.cin">
+              </direct>
+              <direct name="direct6" input="carry_follower.cout" output="soft_adder.cout">
+                <!-- Pack pattern to build an adder chain connection considered by packer -->
+                <pack_pattern name="chain" in_port="carry_follower.cout" out_port="soft_adder.cout"/>
+              </direct>
+              <direct name="direct7" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
+              </direct>
+              <mux name="mux1" input="soft_adder.cin soft_adder.in[2:2]" output="adder_lut4.in[2:2]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="soft_adder.in"/>
+            <direct name="direct2" input="fle.cin" output="soft_adder.cin">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>
+            </direct>
+            <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>
+            <direct name="direct4" input="soft_adder.cout" output="fle.cout">
+              <!-- Pack pattern to build an adder chain connection considered by packer -->
+              <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Arithmetic mode definition end -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>        
-                        <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>       
-                     <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>       
-                     <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>       
-                     <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>      
-                  <direct name="direct2" input="lut3inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 3-LUT mode definition end -->    
-            <!-- 4-LUT mode definition begin -->    
-            <mode name="n1_lut4">     
-               <!-- Define 4-LUT mode -->     
-               <pb_type name="ble4" num_pb="1">      
-                  <input name="in" num_pins="4"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -693,273 +706,273 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>       
-                     <direct name="direct2" input="lut4.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble4.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble4.in"/>      
-                  <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble4.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 4-LUT mode definition end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="reg_in" num_pins="1"/>      
-                  <output name="ff_out" num_pins="2"/>      
-                  <output name="reg_out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>       
-                     <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>       
-                     <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>      
-                  <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>      
-                  <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>      
-                  <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use direct connections to reduce the area to the most
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="reg_in" num_pins="1"/>
+            <output name="ff_out" num_pins="2"/>
+            <output name="reg_out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.reg_in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.reg_out"/>
+              <direct name="direct4" input="ff[0].Q" output="shift_reg.ff_out[0:0]"/>
+              <direct name="direct5" input="ff[1].Q" output="shift_reg.ff_out[1:1]"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use direct connections to reduce the area to the most
              The global local routing is going to compensate the loss in routability
-          -->    
-            <!-- FIXME: The implicit port definition results in I0[0] connected to
+          -->
+        <!-- FIXME: The implicit port definition results in I0[0] connected to
                     in[2]. Such twisted connection is not expected.
                     I[0] should be connected to in[0]
-          -->    
-            <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">     
-               <!-- TODO: Timing should be backannotated from post-PnR results -->     
-            </direct>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[7:0].reset">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+          -->
+        <direct name="direct_fle0" input="clb.I0[0:1]" output="fle[0:0].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle0i" input="clb.I0i[0:1]" output="fle[0:0].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1" input="clb.I1[0:1]" output="fle[1:1].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle1i" input="clb.I1i[0:1]" output="fle[1:1].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2" input="clb.I2[0:1]" output="fle[2:2].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle2i" input="clb.I2i[0:1]" output="fle[2:2].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3" input="clb.I3[0:1]" output="fle[3:3].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle3i" input="clb.I3i[0:1]" output="fle[3:3].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4" input="clb.I4[0:1]" output="fle[4:4].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle4i" input="clb.I4i[0:1]" output="fle[4:4].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5" input="clb.I5[0:1]" output="fle[5:5].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle5i" input="clb.I5i[0:1]" output="fle[5:5].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6" input="clb.I6[0:1]" output="fle[6:6].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle6i" input="clb.I6i[0:1]" output="fle[6:6].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7" input="clb.I7[0:1]" output="fle[7:7].in[0:1]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <direct name="direct_fle7i" input="clb.I7i[0:1]" output="fle[7:7].in[2:3]">
+          <!-- TODO: Timing should be backannotated from post-PnR results -->
+        </direct>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>     
-               <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->     
-            </direct>    
-            <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">     
-               <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->     
-            </direct>    
-            <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">     
-               <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
-        </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">     
-               <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>     
-            </direct>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define fracturable multiplier begin -->  
-      <pb_type name="mult_16">   
-         <input name="a" num_pins="16"/>   
-         <input name="b" num_pins="16"/>   
-         <output name="out" num_pins="32"/>   
-         <mode name="mult_8x8">    
-            <pb_type name="mult_8x8_slice" num_pb="2">     
-               <input name="A_cfg" num_pins="8"/>     
-               <input name="B_cfg" num_pins="8"/>     
-               <output name="OUT_cfg" num_pins="16"/>     
-               <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">      
-                  <input name="A" num_pins="8"/>      
-                  <input name="B" num_pins="8"/>      
-                  <output name="Y" num_pins="16"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.A">
-            </direct>      
-                  <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.B">
-            </direct>      
-                  <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="a2a_0" input="mult_16.a[0:7]" output="mult_8x8_slice[0].A_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[0:7]" out_port="mult_8x8_slice[0].A_cfg[0:7]"/>      
-               </direct>     
-               <direct name="a2a_1" input="mult_16.a[8:15]" output="mult_8x8_slice[1].A_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[8:15]" out_port="mult_8x8_slice[1].A_cfg[0:7]"/>      
-               </direct>     
-               <direct name="b2b_0" input="mult_16.b[0:7]" output="mult_8x8_slice[0].B_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[0:7]" out_port="mult_8x8_slice[0].B_cfg[0:7]"/>      
-               </direct>     
-               <direct name="b2b_1" input="mult_16.b[8:15]" output="mult_8x8_slice[1].B_cfg[0:7]">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[8:15]" out_port="mult_8x8_slice[1].B_cfg[0:7]"/>      
-               </direct>     
-               <direct name="out2out_0" input="mult_8x8_slice[0].OUT_cfg[0:15]" output="mult_16.out[0:15]">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[0].OUT_cfg[0:15]" out_port="mult_16.out[0:15]"/>      
-               </direct>     
-               <direct name="out2out_1" input="mult_8x8_slice[1].OUT_cfg[0:15]" output="mult_16.out[16:31]">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[1].OUT_cfg[0:15]" out_port="mult_16.out[16:31]"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mult_16x16">    
-            <pb_type name="mult_16x16_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="16"/>     
-               <input name="B_cfg" num_pins="16"/>     
-               <output name="OUT_cfg" num_pins="32"/>     
-               <pb_type name="mult_16x16" blif_model=".subckt mult_16" num_pb="1">      
-                  <input name="A" num_pins="16"/>      
-                  <input name="B" num_pins="16"/>      
-                  <output name="Y" num_pins="32"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.A" out_port="mult_16x16.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.B" out_port="mult_16x16.Y"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_16x16_slice.A_cfg" output="mult_16x16.A">
-            </direct>      
-                  <direct name="b2b" input="mult_16x16_slice.B_cfg" output="mult_16x16.B">
-            </direct>      
-                  <direct name="out2out" input="mult_16x16.Y" output="mult_16x16_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="a2a" input="mult_16.a" output="mult_16x16_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a" out_port="mult_16x16_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_16.b" output="mult_16x16_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b" out_port="mult_16x16_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_16x16_slice.OUT_cfg" output="mult_16.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_16x16_slice.OUT_cfg" out_port="mult_16.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:1]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:4].out[0:1]" output="clb.O[15:8]"/>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+        </direct>
+        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+        </direct>
+        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[7:7].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
+          <pack_pattern name="chain" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <pb_type name="mult_16">
+      <input name="a" num_pins="16"/>
+      <input name="b" num_pins="16"/>
+      <output name="out" num_pins="32"/>
+      <mode name="mult_8x8">
+        <pb_type name="mult_8x8_slice" num_pb="2">
+          <input name="A_cfg" num_pins="8"/>
+          <input name="B_cfg" num_pins="8"/>
+          <output name="OUT_cfg" num_pins="16"/>
+          <pb_type name="mult_8x8" blif_model=".subckt mult_8" num_pb="1">
+            <input name="A" num_pins="8"/>
+            <input name="B" num_pins="8"/>
+            <output name="Y" num_pins="16"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.A" out_port="mult_8x8.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_8x8.B" out_port="mult_8x8.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_8x8_slice.A_cfg" output="mult_8x8.A">
+            </direct>
+            <direct name="b2b" input="mult_8x8_slice.B_cfg" output="mult_8x8.B">
+            </direct>
+            <direct name="out2out" input="mult_8x8.Y" output="mult_8x8_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="a2a_0" input="mult_16.a[0:7]" output="mult_8x8_slice[0].A_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[0:7]" out_port="mult_8x8_slice[0].A_cfg[0:7]"/>
+          </direct>
+          <direct name="a2a_1" input="mult_16.a[8:15]" output="mult_8x8_slice[1].A_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a[8:15]" out_port="mult_8x8_slice[1].A_cfg[0:7]"/>
+          </direct>
+          <direct name="b2b_0" input="mult_16.b[0:7]" output="mult_8x8_slice[0].B_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[0:7]" out_port="mult_8x8_slice[0].B_cfg[0:7]"/>
+          </direct>
+          <direct name="b2b_1" input="mult_16.b[8:15]" output="mult_8x8_slice[1].B_cfg[0:7]">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b[8:15]" out_port="mult_8x8_slice[1].B_cfg[0:7]"/>
+          </direct>
+          <direct name="out2out_0" input="mult_8x8_slice[0].OUT_cfg[0:15]" output="mult_16.out[0:15]">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[0].OUT_cfg[0:15]" out_port="mult_16.out[0:15]"/>
+          </direct>
+          <direct name="out2out_1" input="mult_8x8_slice[1].OUT_cfg[0:15]" output="mult_16.out[16:31]">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_8x8_slice[1].OUT_cfg[0:15]" out_port="mult_16.out[16:31]"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_16x16">
+        <pb_type name="mult_16x16_slice" num_pb="1">
+          <input name="A_cfg" num_pins="16"/>
+          <input name="B_cfg" num_pins="16"/>
+          <output name="OUT_cfg" num_pins="32"/>
+          <pb_type name="mult_16x16" blif_model=".subckt mult_16" num_pb="1">
+            <input name="A" num_pins="16"/>
+            <input name="B" num_pins="16"/>
+            <output name="Y" num_pins="32"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.A" out_port="mult_16x16.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_16x16.B" out_port="mult_16x16.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_16x16_slice.A_cfg" output="mult_16x16.A">
+            </direct>
+            <direct name="b2b" input="mult_16x16_slice.B_cfg" output="mult_16x16.B">
+            </direct>
+            <direct name="out2out" input="mult_16x16.Y" output="mult_16x16_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="a2a" input="mult_16.a" output="mult_16x16_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.a" out_port="mult_16x16_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_16.b" output="mult_16x16_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_16.b" out_port="mult_16x16_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_16x16_slice.OUT_cfg" output="mult_16.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_16x16_slice.OUT_cfg" out_port="mult_16.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_N10_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_N10_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,57 +23,61 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <output name="O" num_pins="10" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <output name="O" num_pins="10" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -85,21 +91,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -111,81 +117,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -193,31 +199,31 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <output name="O" num_pins="10" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <output name="O" num_pins="10" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 6-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 6-LUT mode definition begin -->    
-            <mode name="n1_lut6">     
-               <!-- Define 6-LUT mode -->     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 6-LUT mode definition begin -->
+        <mode name="n1_lut6">
+          <!-- Define 6-LUT mode -->
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -225,48 +231,48 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -274,23 +280,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Architecture with no fracturable LUTs
 
   - 40 nm technology
@@ -12,8 +13,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,65 +23,69 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <output name="O" num_pins="10" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="6" height="6">   
-         <!-- Perimeter of 'EMPTY' blocks -->   
-         <perimeter type="EMPTY" priority="100"/>   
-         <!--Fill with 'io'-->   
-         <fill type="io" priority="10"/>   
-         <!-- Build an inner region of clbs -->   
-         <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/>    
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <output name="O" num_pins="10" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="6" height="6">
+      <!-- Perimeter of 'EMPTY' blocks -->
+      <perimeter type="EMPTY" priority="100"/>
+      <!--Fill with 'io'-->
+      <fill type="io" priority="10"/>
+      <!-- Build an inner region of clbs -->
+      <region type="clb" startx="2" endx="W-3" starty="2" endy="H-3" priority="101"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -93,21 +99,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -119,81 +125,81 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- A mode denotes the physical implementation of an I/O 
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -201,31 +207,31 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <output name="O" num_pins="10" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe basic logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <output name="O" num_pins="10" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
              Each basic logic element has a 6-LUT that can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <output name="out" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- 6-LUT mode definition begin -->    
-            <mode name="n1_lut6">     
-               <!-- Define 6-LUT mode -->     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 6-LUT mode definition begin -->
+        <mode name="n1_lut6">
+          <!-- Define 6-LUT mode -->
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -233,48 +239,48 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -282,23 +288,23 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out" output="clb.O"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!--
+<?xml version="1.0"?>
+<!--
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k6_frac_N10_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!--
+-->
+<architecture>
+  <!--
        ODIN II specific config begins
        Describes the types of user-specified netlist blocks (in blif, this corresponds to
        ".model [type_of_block]") that this architecture supports.
@@ -21,78 +23,82 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are
        already special structures in blif (.names, .input, .output, and .latch)
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of
@@ -106,21 +112,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -132,87 +138,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O
+       -->
+      <!-- A mode denotes the physical implementation of an I/O
            This mode will be not packable but is mainly used for fabric verilog generation
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency,
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency,
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -220,152 +225,152 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range.
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs.
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 5-LUT mode definition begin -->    
-            <mode name="n2_lut5">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="5" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 5-LUT mode definition begin -->
+        <mode name="n2_lut5">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="5" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                      -->
+                <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                   235e-12
                   235e-12
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble5.in[4:0]" output="lut5[0:0].in[4:0]"/>        
-                        <direct name="direct2" input="lut5[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble5" in_port="lut5[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble5.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut5.out[0:0]" output="ble5.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut5.out[0:0]" out_port="ble5.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 5-LUT mode definition end -->    
-            <!-- 6-LUT mode definition begin -->    
-            <mode name="n1_lut6">     
-               <!-- Define 6-LUT mode -->     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble5.in[4:0]" output="lut5[0:0].in[4:0]"/>
+                <direct name="direct2" input="lut5[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble5" in_port="lut5[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble5.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut5.out[0:0]" output="ble5.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut5.out[0:0]" out_port="ble5.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 5-LUT mode definition end -->
+        <!-- 6-LUT mode definition begin -->
+        <mode name="n1_lut6">
+          <!-- Define 6-LUT mode -->
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -373,48 +378,48 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -422,24 +427,24 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs,
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,98 +86,102 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -189,21 +195,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -215,91 +221,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -307,255 +311,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -563,45 +567,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -609,35 +613,34 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_adder_chain_mem16K_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,144 +86,150 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dpram_2048x8">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="12"/>    
-          <input name="raddr" num_pins="12"/>    
-          <input name="data_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="data_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left" yoffset="0">memory.clk</loc>     
-             <loc side="top" yoffset="1"/>     
-             <loc side="right" yoffset="0">memory.wen memory.waddr[0:3] memory.raddr[0:3] memory.data_in[0:2] memory.data_out[0:2]</loc>     
-             <loc side="right" yoffset="1">memory.ren memory.waddr[4:7] memory.raddr[4:7] memory.data_in[3:5] memory.data_out[3:5]</loc>     
-             <loc side="bottom" yoffset="0">memory.waddr[8:11] memory.raddr[8:11] memory.data_in[6:7] memory.data_out[6:7]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="4x4" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dpram_2048x8">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="12"/>
+        <input name="raddr" num_pins="12"/>
+        <input name="data_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="data_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left" yoffset="0">memory.clk</loc>
+          <loc side="top" yoffset="1"/>
+          <loc side="right" yoffset="0">memory.wen memory.waddr[0:3] memory.raddr[0:3] memory.data_in[0:2] memory.data_out[0:2]</loc>
+          <loc side="right" yoffset="1">memory.ren memory.waddr[4:7] memory.raddr[4:7] memory.data_in[3:5] memory.data_out[3:5]</loc>
+          <loc side="bottom" yoffset="0">memory.waddr[8:11] memory.raddr[8:11] memory.data_in[6:7] memory.data_out[6:7]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="4x4" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -235,21 +243,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -261,91 +269,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -353,255 +359,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -609,45 +615,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -655,93 +661,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="12"/>   
-         <input name="raddr" num_pins="12"/>   
-         <input name="data_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="data_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 2048x8=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="12"/>
+      <input name="raddr" num_pins="12"/>
+      <input name="data_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="data_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 2048x8=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_2048x8_dp">    
-            <pb_type name="mem_2048x8_dp" blif_model=".subckt dpram_2048x8" num_pb="1">     
-               <input name="waddr" num_pins="12" port_class="address1"/>     
-               <input name="raddr" num_pins="12" port_class="address2"/>     
-               <input name="data_in" num_pins="8" port_class="data_in1"/>     
-               <input name="wen" num_pins="1" port_class="write_en1"/>     
-               <input name="ren" num_pins="1" port_class="write_en2"/>     
-               <output name="data_out" num_pins="8" port_class="data_out1"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_2048x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x8_dp.data_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_2048x8_dp.data_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_2048x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_2048x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_2048x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_2048x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.data_in" output="mem_2048x8_dp.data_in">      
-                  <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_2048x8_dp.data_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_2048x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_2048x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_2048x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_2048x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_2048x8_dp.data_out" output="memory.data_out">      
-                  <delay_constant max="40e-12" in_port="mem_2048x8_dp.data_out" out_port="memory.data_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_2048x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_2048x8_dp">
+        <pb_type name="mem_2048x8_dp" blif_model=".subckt dpram_2048x8" num_pb="1">
+          <input name="waddr" num_pins="12" port_class="address1"/>
+          <input name="raddr" num_pins="12" port_class="address2"/>
+          <input name="data_in" num_pins="8" port_class="data_in1"/>
+          <input name="wen" num_pins="1" port_class="write_en1"/>
+          <input name="ren" num_pins="1" port_class="write_en2"/>
+          <output name="data_out" num_pins="8" port_class="data_out1"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.data_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_2048x8_dp.data_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_2048x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_2048x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_2048x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_2048x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.data_in" output="mem_2048x8_dp.data_in">
+            <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_2048x8_dp.data_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_2048x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_2048x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_2048x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_2048x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_2048x8_dp.data_out" output="memory.data_out">
+            <delay_constant max="40e-12" in_port="mem_2048x8_dp.data_out" out_port="memory.data_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k6_frac_N10_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,78 +23,82 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -106,21 +112,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -132,87 +138,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -220,152 +225,152 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 5-LUT mode definition begin -->    
-            <mode name="n2_lut5">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="5" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 5-LUT mode definition begin -->
+        <mode name="n2_lut5">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="5" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                      -->
+                <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                   235e-12
                   235e-12
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble5.in[4:0]" output="lut5[0:0].in[4:0]"/>        
-                        <direct name="direct2" input="lut5[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble5" in_port="lut5[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble5.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut5.out[0:0]" output="ble5.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut5.out[0:0]" out_port="ble5.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 5-LUT mode definition end -->    
-            <!-- 6-LUT mode definition begin -->    
-            <mode name="n1_lut6">     
-               <!-- Define 6-LUT mode -->     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble5.in[4:0]" output="lut5[0:0].in[4:0]"/>
+                <direct name="direct2" input="lut5[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble5" in_port="lut5[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble5.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut5.out[0:0]" output="ble5.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut5.out[0:0]" out_port="ble5.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 5-LUT mode definition end -->
+        <!-- 6-LUT mode definition begin -->
+        <mode name="n1_lut6">
+          <!-- Define 6-LUT mode -->
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -373,48 +378,48 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -422,24 +427,24 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,98 +86,102 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -189,21 +195,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -215,91 +221,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -307,255 +311,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -563,45 +567,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -609,35 +613,34 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,172 +86,180 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dpram_1024x8">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <model name="mult_36">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="data_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="data_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">memory.clk</loc>     
-             <loc side="top"/>     
-             <loc side="right">memory.waddr[4:0] memory.raddr[4:0] memory.data_in[3:0] memory.wen memory.data_out[3:0]</loc>     
-             <loc side="bottom">memory.waddr[9:5] memory.raddr[9:5] memory.data_in[7:4] memory.ren memory.data_out[7:4]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="mult_36" height="6" area="396000">   <sub_tile name="mult_36">    
-          <equivalent_sites>     
-             <site pb_type="mult_36" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="36"/>    
-          <input name="b" num_pins="36"/>    
-          <output name="out" num_pins="72"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!-- pinlocations are designed to spread pin on 4 sides evenly -->    
-          <pinlocations pattern="custom">     
-             <loc side="left">mult_36.b[0:9] mult_36.b[10:35] mult_36.out[36:71]</loc>     
-             <loc side="top"/>     
-             <loc side="right">mult_36.a[0:9] mult_36.a[10:35] mult_36.out[0:35]</loc>     
-             <loc side="bottom"/>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dpram_1024x8">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_out" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="mult_36">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="data_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="data_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">memory.clk</loc>
+          <loc side="top"/>
+          <loc side="right">memory.waddr[4:0] memory.raddr[4:0] memory.data_in[3:0] memory.wen memory.data_out[3:0]</loc>
+          <loc side="bottom">memory.waddr[9:5] memory.raddr[9:5] memory.data_in[7:4] memory.ren memory.data_out[7:4]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_36" height="6" area="396000">
+      <sub_tile name="mult_36">
+        <equivalent_sites>
+          <site pb_type="mult_36" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="36"/>
+        <input name="b" num_pins="36"/>
+        <output name="out" num_pins="72"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- pinlocations are designed to spread pin on 4 sides evenly -->
+        <pinlocations pattern="custom">
+          <loc side="left">mult_36.b[0:9] mult_36.b[10:35] mult_36.out[36:71]</loc>
+          <loc side="top"/>
+          <loc side="right">mult_36.a[0:9] mult_36.a[10:35] mult_36.out[0:35]</loc>
+          <loc side="bottom"/>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -263,21 +273,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -289,91 +299,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -381,255 +389,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -637,45 +645,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -683,145 +691,144 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define 36-bit multiplier begin -->  
-      <pb_type name="mult_36">   
-         <input name="a" num_pins="36"/>   
-         <input name="b" num_pins="36"/>   
-         <output name="out" num_pins="72"/>   
-         <mode name="mult_36x36">    
-            <pb_type name="mult_36x36_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="36"/>     
-               <input name="B_cfg" num_pins="36"/>     
-               <output name="OUT_cfg" num_pins="72"/>     
-               <pb_type name="mult_36x36" blif_model=".subckt mult_36" num_pb="1">      
-                  <input name="A" num_pins="36"/>      
-                  <input name="B" num_pins="36"/>      
-                  <output name="Y" num_pins="72"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.A" out_port="mult_36x36.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.B" out_port="mult_36x36.Y"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.A">
-            </direct>      
-                  <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.B">
-            </direct>      
-                  <direct name="out2out" input="mult_36x36.Y" output="mult_36x36_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define 36-bit multiplier begin -->
+    <pb_type name="mult_36">
+      <input name="a" num_pins="36"/>
+      <input name="b" num_pins="36"/>
+      <output name="out" num_pins="72"/>
+      <mode name="mult_36x36">
+        <pb_type name="mult_36x36_slice" num_pb="1">
+          <input name="A_cfg" num_pins="36"/>
+          <input name="B_cfg" num_pins="36"/>
+          <output name="OUT_cfg" num_pins="72"/>
+          <pb_type name="mult_36x36" blif_model=".subckt mult_36" num_pb="1">
+            <input name="A" num_pins="36"/>
+            <input name="B" num_pins="36"/>
+            <output name="Y" num_pins="72"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.A" out_port="mult_36x36.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.B" out_port="mult_36x36.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.A">
+            </direct>
+            <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.B">
+            </direct>
+            <direct name="out2out" input="mult_36x36.Y" output="mult_36x36_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
 		   to a 134 ps delay.
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="data_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="data_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 1024x8=8Kbit memory block
+              -->
+          <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="data_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="data_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 1024x8=8Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_1024x8_dp">    
-            <pb_type name="mem_1024x8_dp" blif_model=".subckt dpram_1024x8" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address1"/>     
-               <input name="raddr" num_pins="10" port_class="address2"/>     
-               <input name="data_in" num_pins="8" port_class="data_in1"/>     
-               <input name="wen" num_pins="1" port_class="write_en1"/>     
-               <input name="ren" num_pins="1" port_class="write_en2"/>     
-               <output name="data_out" num_pins="8" port_class="data_out1"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.data_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_1024x8_dp.data_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_1024x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_1024x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_1024x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_1024x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.data_in" output="mem_1024x8_dp.data_in">      
-                  <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_1024x8_dp.data_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_1024x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_1024x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_1024x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_1024x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_1024x8_dp.data_out" output="memory.data_out">      
-                  <delay_constant max="40e-12" in_port="mem_1024x8_dp.data_out" out_port="memory.data_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_1024x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_1024x8_dp">
+        <pb_type name="mem_1024x8_dp" blif_model=".subckt dpram_1024x8" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address1"/>
+          <input name="raddr" num_pins="10" port_class="address2"/>
+          <input name="data_in" num_pins="8" port_class="data_in1"/>
+          <input name="wen" num_pins="1" port_class="write_en1"/>
+          <input name="ren" num_pins="1" port_class="write_en2"/>
+          <output name="data_out" num_pins="8" port_class="data_out1"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.data_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_1024x8_dp.data_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_1024x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_1024x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_1024x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_1024x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.data_in" output="mem_1024x8_dp.data_in">
+            <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_1024x8_dp.data_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_1024x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_1024x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_1024x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_1024x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_1024x8_dp.data_out" output="memory.data_out">
+            <delay_constant max="40e-12" in_port="mem_1024x8_dp.data_out" out_port="memory.data_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,250 +86,258 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dpram_1024x8">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <model name="mult_36">   
-         <input_ports>    
-            <port name="A" combinational_sink_ports="Y"/>    
-            <port name="B" combinational_sink_ports="Y"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Y"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for flip-flops -->  
-      <model name="dff">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <model name="dffsr">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="R" clock="C"/>    
-            <port name="S" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <model name="dffr">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="R" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <model name="dffs">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="S" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <model name="dffrn">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="RN" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-      <model name="dffsn">   
-         <input_ports>    
-            <port name="D" clock="C"/>    
-            <port name="SN" clock="C"/>    
-            <port name="C" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="C"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="set" num_pins="1" is_non_clock_global="true"/>    
-          <input name="reset" num_pins="1" is_non_clock_global="true"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="set" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="reset" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk clb.reset clb.set</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="data_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="data_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">memory.clk</loc>     
-             <loc side="top"/>     
-             <loc side="right">memory.waddr[4:0] memory.raddr[4:0] memory.data_in[3:0] memory.wen memory.data_out[3:0]</loc>     
-             <loc side="bottom">memory.waddr[9:5] memory.raddr[9:5] memory.data_in[7:4] memory.ren memory.data_out[7:4]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="mult_36" height="6" area="396000">   <sub_tile name="mult_36">    
-          <equivalent_sites>     
-             <site pb_type="mult_36" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="36"/>    
-          <input name="b" num_pins="36"/>    
-          <output name="out" num_pins="72"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!-- pinlocations are designed to spread pin on 4 sides evenly -->    
-          <pinlocations pattern="custom">     
-             <loc side="left">mult_36.b[0:9] mult_36.b[10:35] mult_36.out[36:71]</loc>     
-             <loc side="top"/>     
-             <loc side="right">mult_36.a[0:9] mult_36.a[10:35] mult_36.out[0:35]</loc>     
-             <loc side="bottom"/>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-      <fixed_layout name="48x48" width="50" height="50">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dpram_1024x8">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_out" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="mult_36">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for flip-flops -->
+    <model name="dff">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffsr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="S" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffs">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="S" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffrn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="RN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffsn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="SN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <input name="set" num_pins="1" is_non_clock_global="true"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="set" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset clb.set</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="data_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="data_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">memory.clk</loc>
+          <loc side="top"/>
+          <loc side="right">memory.waddr[4:0] memory.raddr[4:0] memory.data_in[3:0] memory.wen memory.data_out[3:0]</loc>
+          <loc side="bottom">memory.waddr[9:5] memory.raddr[9:5] memory.data_in[7:4] memory.ren memory.data_out[7:4]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_36" height="6" area="396000">
+      <sub_tile name="mult_36">
+        <equivalent_sites>
+          <site pb_type="mult_36" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="36"/>
+        <input name="b" num_pins="36"/>
+        <output name="out" num_pins="72"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- pinlocations are designed to spread pin on 4 sides evenly -->
+        <pinlocations pattern="custom">
+          <loc side="left">mult_36.b[0:9] mult_36.b[10:35] mult_36.out[36:71]</loc>
+          <loc side="top"/>
+          <loc side="right">mult_36.a[0:9] mult_36.a[10:35] mult_36.out[0:35]</loc>
+          <loc side="bottom"/>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -341,21 +351,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -367,91 +377,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -459,477 +467,477 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="set" num_pins="1" is_non_clock_global="true"/>   
-         <input name="reset" num_pins="1" is_non_clock_global="true"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <input name="set" num_pins="1" is_non_clock_global="true"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="set" num_pins="1"/>    
-            <input name="reset" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="set" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".subckt dffsr" num_pb="2">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <input name="R" num_pins="1"/>       
-                     <input name="S" num_pins="1"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="C" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="C"/>       
-                     <T_setup value="66e-12" port="ff.R" clock="C"/>       
-                     <T_setup value="66e-12" port="ff.S" clock="C"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>       
-                  </pb_type>       
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].C"/>       
-                     <complete name="direct11" input="fabric.reset" output="ff[1:0].R"/>       
-                     <complete name="direct12" input="fabric.set" output="ff[1:0].S"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-                  <direct name="direct6" input="fle.reset" output="fabric.reset"/>      
-                  <direct name="direct7" input="fle.set" output="fabric.set"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <input name="set" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="set" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".subckt dffsr" num_pb="2">
+              <input name="D" num_pins="1" port_class="D"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="C" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="C"/>
+              <T_setup value="66e-12" port="ff.R" clock="C"/>
+              <T_setup value="66e-12" port="ff.S" clock="C"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].C"/>
+              <complete name="direct11" input="fabric.reset" output="ff[1:0].R"/>
+              <complete name="direct12" input="fabric.set" output="ff[1:0].S"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct6" input="fle.reset" output="fabric.reset"/>
+            <direct name="direct7" input="fle.set" output="fabric.set"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define multi-mode flip-flop -->      
-                  <pb_type name="ff" num_pb="1">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="R" num_pins="1"/>       
-                     <input name="S" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="C" num_pins="1"/>       
-                     <mode name="latch">        
-                        <pb_type name="latch" blif_model=".latch" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="clk" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="latch.D" clock="clk"/>         
-                           <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="latch.D"/>         
-                           <direct name="direct2" input="ff.C" output="latch.clk"/>         
-                           <direct name="direct3" input="latch.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dff">        
-                        <pb_type name="dff" blif_model=".subckt dff" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dff.D" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dff.D"/>         
-                           <direct name="direct2" input="ff.C" output="dff.C"/>         
-                           <direct name="direct3" input="dff.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffr">        
-                        <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffr.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffr.R" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffr.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffr.R"/>         
-                           <direct name="direct4" input="dffr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffrn">        
-                        <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffrn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffrn.RN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffrn.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffrn.RN"/>         
-                           <direct name="direct4" input="dffrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffs">        
-                        <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="S" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffs.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffs.S" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffs.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffs.C"/>         
-                           <direct name="direct3" input="ff.S" output="dffs.S"/>         
-                           <direct name="direct4" input="dffs.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffsn">        
-                        <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="SN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffsn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffsn.SN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffsn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffsn.C"/>         
-                           <direct name="direct3" input="ff.S" output="dffsn.SN"/>         
-                           <direct name="direct4" input="dffsn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>       
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.C"/>       
-                     <direct name="direct4" input="ble5.reset" output="ff.R"/>       
-                     <direct name="direct5" input="ble5.set" output="ff.S"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-                  <complete name="direct5" input="fle.reset" output="ble5.reset"/>      
-                  <complete name="direct6" input="fle.set" output="ble5.set"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="set" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <!-- Define multi-mode flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffs">
+                <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="S" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffs.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffs.S" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffs.D"/>
+                  <direct name="direct2" input="ff.C" output="dffs.C"/>
+                  <direct name="direct3" input="ff.S" output="dffs.S"/>
+                  <direct name="direct4" input="dffs.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffsn">
+                <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="SN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffsn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffsn.SN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffsn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffsn.C"/>
+                  <direct name="direct3" input="ff.S" output="dffsn.SN"/>
+                  <direct name="direct4" input="dffsn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.C"/>
+              <direct name="direct4" input="ble5.reset" output="ff.R"/>
+              <direct name="direct5" input="ble5.set" output="ff.S"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+            <complete name="direct5" input="fle.reset" output="ble5.reset"/>
+            <complete name="direct6" input="fle.set" output="ble5.set"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <!-- Define multi-mode flip-flop -->      
-                  <pb_type name="ff" num_pb="1">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="R" num_pins="1"/>       
-                     <input name="S" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="C" num_pins="1"/>       
-                     <mode name="latch">        
-                        <pb_type name="latch" blif_model=".latch" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="clk" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="latch.D" clock="clk"/>         
-                           <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="latch.D"/>         
-                           <direct name="direct2" input="ff.C" output="latch.clk"/>         
-                           <direct name="direct3" input="latch.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dff">        
-                        <pb_type name="dff" blif_model=".subckt dff" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dff.D" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dff.D"/>         
-                           <direct name="direct2" input="ff.C" output="dff.C"/>         
-                           <direct name="direct3" input="dff.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffr">        
-                        <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffr.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffr.R" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffr.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffr.R"/>         
-                           <direct name="direct4" input="dffr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffrn">        
-                        <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffrn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffrn.RN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffrn.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffrn.RN"/>         
-                           <direct name="direct4" input="dffrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffs">        
-                        <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="S" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffs.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffs.S" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffs.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffs.C"/>         
-                           <direct name="direct3" input="ff.S" output="dffs.S"/>         
-                           <direct name="direct4" input="dffs.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffsn">        
-                        <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="SN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffsn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffsn.SN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffsn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffsn.C"/>         
-                           <direct name="direct3" input="ff.S" output="dffsn.SN"/>         
-                           <direct name="direct4" input="dffsn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>       
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.C"/>       
-                     <direct name="set" input="arithmetic.set" output="ff.S"/>       
-                     <direct name="reset" input="arithmetic.reset" output="ff.R"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <complete name="direct4" input="fle.reset" output="arithmetic.reset"/>      
-                  <complete name="direct5" input="fle.set" output="arithmetic.set"/>      
-                  <direct name="direct6" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="set" num_pins="1"/>      
-                  <input name="reset" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <!-- Define multi-mode flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffs">
+                <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="S" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffs.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffs.S" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffs.D"/>
+                  <direct name="direct2" input="ff.C" output="dffs.C"/>
+                  <direct name="direct3" input="ff.S" output="dffs.S"/>
+                  <direct name="direct4" input="dffs.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffsn">
+                <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="SN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffsn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffsn.SN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffsn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffsn.C"/>
+                  <direct name="direct3" input="ff.S" output="dffsn.SN"/>
+                  <direct name="direct4" input="dffsn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.C"/>
+              <direct name="set" input="arithmetic.set" output="ff.S"/>
+              <direct name="reset" input="arithmetic.reset" output="ff.R"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <complete name="direct4" input="fle.reset" output="arithmetic.reset"/>
+            <complete name="direct5" input="fle.set" output="arithmetic.set"/>
+            <direct name="direct6" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -937,146 +945,146 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define multi-mode flip-flop -->      
-                  <pb_type name="ff" num_pb="1">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="R" num_pins="1"/>       
-                     <input name="S" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="C" num_pins="1"/>       
-                     <mode name="latch">        
-                        <pb_type name="latch" blif_model=".latch" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="clk" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="latch.D" clock="clk"/>         
-                           <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="latch.D"/>         
-                           <direct name="direct2" input="ff.C" output="latch.clk"/>         
-                           <direct name="direct3" input="latch.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dff">        
-                        <pb_type name="dff" blif_model=".subckt dff" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dff.D" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dff.D"/>         
-                           <direct name="direct2" input="ff.C" output="dff.C"/>         
-                           <direct name="direct3" input="dff.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffr">        
-                        <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="R" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffr.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffr.R" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffr.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffr.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffr.R"/>         
-                           <direct name="direct4" input="dffr.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffrn">        
-                        <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="RN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffrn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffrn.RN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffrn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffrn.C"/>         
-                           <direct name="direct3" input="ff.R" output="dffrn.RN"/>         
-                           <direct name="direct4" input="dffrn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffs">        
-                        <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="S" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffs.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffs.S" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffs.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffs.C"/>         
-                           <direct name="direct3" input="ff.S" output="dffs.S"/>         
-                           <direct name="direct4" input="dffs.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="dffsn">        
-                        <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">         
-                           <input name="D" num_pins="1" port_class="D"/>         
-                           <input name="SN" num_pins="1"/>         
-                           <output name="Q" num_pins="1" port_class="Q"/>         
-                           <clock name="C" num_pins="1" port_class="clock"/>         
-                           <T_setup value="66e-12" port="dffsn.D" clock="C"/>         
-                           <T_setup value="66e-12" port="dffsn.SN" clock="C"/>         
-                           <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>         
-                        </pb_type>         
-                        <interconnect>         
-                           <direct name="direct1" input="ff.D" output="dffsn.D"/>         
-                           <direct name="direct2" input="ff.C" output="dffsn.C"/>         
-                           <direct name="direct3" input="ff.S" output="dffsn.SN"/>         
-                           <direct name="direct4" input="dffsn.Q" output="ff.Q"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>       
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.C"/>       
-                     <direct name="direct4" input="ble6.reset" output="ff.R"/>       
-                     <direct name="direct5" input="ble6.set" output="ff.S"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-                  <direct name="direct4" input="fle.reset" output="ble6.reset"/>      
-                  <direct name="direct5" input="fle.set" output="ble6.set"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <!-- Define multi-mode flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffs">
+                <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="S" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffs.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffs.S" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffs.D"/>
+                  <direct name="direct2" input="ff.C" output="dffs.C"/>
+                  <direct name="direct3" input="ff.S" output="dffs.S"/>
+                  <direct name="direct4" input="dffs.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffsn">
+                <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="SN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffsn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffsn.SN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffsn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffsn.C"/>
+                  <direct name="direct3" input="ff.S" output="dffsn.SN"/>
+                  <direct name="direct4" input="dffsn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.C"/>
+              <direct name="direct4" input="ble6.reset" output="ff.R"/>
+              <direct name="direct5" input="ble6.set" output="ff.S"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+            <direct name="direct4" input="fle.reset" output="ble6.reset"/>
+            <direct name="direct5" input="fle.set" output="ble6.set"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -1084,149 +1092,148 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <complete name="resets" input="clb.reset" output="fle[9:0].reset">
-        </complete>    
-            <complete name="sets" input="clb.set" output="fle[9:0].set">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[9:0].reset">
+        </complete>
+        <complete name="sets" input="clb.set" output="fle[9:0].set">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define 36-bit multiplier begin -->  
-      <pb_type name="mult_36">   
-         <input name="a" num_pins="36"/>   
-         <input name="b" num_pins="36"/>   
-         <output name="out" num_pins="72"/>   
-         <mode name="mult_36x36">    
-            <pb_type name="mult_36x36_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="36"/>     
-               <input name="B_cfg" num_pins="36"/>     
-               <output name="OUT_cfg" num_pins="72"/>     
-               <pb_type name="mult_36x36" blif_model=".subckt mult_36" num_pb="1">      
-                  <input name="A" num_pins="36"/>      
-                  <input name="B" num_pins="36"/>      
-                  <output name="Y" num_pins="72"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.A" out_port="mult_36x36.Y"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.B" out_port="mult_36x36.Y"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.A">
-            </direct>      
-                  <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.B">
-            </direct>      
-                  <direct name="out2out" input="mult_36x36.Y" output="mult_36x36_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define 36-bit multiplier begin -->
+    <pb_type name="mult_36">
+      <input name="a" num_pins="36"/>
+      <input name="b" num_pins="36"/>
+      <output name="out" num_pins="72"/>
+      <mode name="mult_36x36">
+        <pb_type name="mult_36x36_slice" num_pb="1">
+          <input name="A_cfg" num_pins="36"/>
+          <input name="B_cfg" num_pins="36"/>
+          <output name="OUT_cfg" num_pins="72"/>
+          <pb_type name="mult_36x36" blif_model=".subckt mult_36" num_pb="1">
+            <input name="A" num_pins="36"/>
+            <input name="B" num_pins="36"/>
+            <output name="Y" num_pins="72"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.A" out_port="mult_36x36.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.B" out_port="mult_36x36.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.A">
+            </direct>
+            <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.B">
+            </direct>
+            <direct name="out2out" input="mult_36x36.Y" output="mult_36x36_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
 		   to a 134 ps delay.
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="data_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="data_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 1024x8=8Kbit memory block
+              -->
+          <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="data_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="data_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 1024x8=8Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_1024x8_dp">    
-            <pb_type name="mem_1024x8_dp" blif_model=".subckt dpram_1024x8" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address1"/>     
-               <input name="raddr" num_pins="10" port_class="address2"/>     
-               <input name="data_in" num_pins="8" port_class="data_in1"/>     
-               <input name="wen" num_pins="1" port_class="write_en1"/>     
-               <input name="ren" num_pins="1" port_class="write_en2"/>     
-               <output name="data_out" num_pins="8" port_class="data_out1"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.data_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_1024x8_dp.data_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_1024x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_1024x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_1024x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_1024x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.data_in" output="mem_1024x8_dp.data_in">      
-                  <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_1024x8_dp.data_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_1024x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_1024x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_1024x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_1024x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_1024x8_dp.data_out" output="memory.data_out">      
-                  <delay_constant max="40e-12" in_port="mem_1024x8_dp.data_out" out_port="memory.data_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_1024x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_1024x8_dp">
+        <pb_type name="mem_1024x8_dp" blif_model=".subckt dpram_1024x8" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address1"/>
+          <input name="raddr" num_pins="10" port_class="address2"/>
+          <input name="data_in" num_pins="8" port_class="data_in1"/>
+          <input name="wen" num_pins="1" port_class="write_en1"/>
+          <input name="ren" num_pins="1" port_class="write_en2"/>
+          <output name="data_out" num_pins="8" port_class="data_out1"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.data_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_1024x8_dp.data_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_1024x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_1024x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_1024x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_1024x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.data_in" output="mem_1024x8_dp.data_in">
+            <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_1024x8_dp.data_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_1024x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_1024x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_1024x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_1024x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_1024x8_dp.data_out" output="memory.data_out">
+            <delay_constant max="40e-12" in_port="mem_1024x8_dp.data_out" out_port="memory.data_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_frac_mem32K_frac_dsp36_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_frac_mem32K_frac_dsp36_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -84,8 +85,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -93,185 +95,193 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="multiply">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="out"/>    
-            <port name="b" combinational_sink_ports="out"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="out"/>    
-         </output_ports>   
-      </model>  
-      <model name="single_port_ram">   
-         <input_ports>    
-            <port name="we" clock="clk"/>    
-            <!-- control -->    
-            <port name="addr" clock="clk"/>    
-            <!-- address lines -->    
-            <port name="data" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="clk" is_clock="1"/>    
-            <!-- memories are often clocked -->    
-         </input_ports>   
-         <output_ports>    
-            <port name="out" clock="clk"/>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <port name="we1" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="we2" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="addr1" clock="clk"/>    
-            <!-- address lines -->    
-            <port name="addr2" clock="clk"/>    
-            <!-- address lines -->    
-            <port name="data1" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data2" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="clk" is_clock="1"/>    
-            <!-- memories are often clocked -->    
-         </input_ports>   
-         <output_ports>    
-            <port name="out1" clock="clk"/>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="out2" clock="clk"/>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-         </output_ports>   
-      </model>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- The original XML does have a default capacity (=1). Set 8 here for best architecture evaluation -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="mult_36" height="4" area="396000">   <sub_tile name="mult_36">    
-          <equivalent_sites>     
-             <site pb_type="mult_36" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="36"/>    
-          <input name="b" num_pins="36"/>    
-          <output name="out" num_pins="72"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top"/>     
-             <loc side="right">mult_36.a[0:17] mult_36.b[0:17] mult_36.out[0:35]</loc>     
-             <loc side="bottom">mult_36.a[18:35] mult_36.b[18:35] mult_36.out[36:71]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="6" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="addr1" num_pins="15"/>    
-          <input name="addr2" num_pins="15"/>    
-          <input name="data" num_pins="64"/>    
-          <input name="we1" num_pins="1"/>    
-          <input name="we2" num_pins="1"/>    
-          <output name="out" num_pins="64"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">memory.clk</loc>     
-             <loc side="right">memory.addr1[0:14] memory.data[0:31] memory.we1 memory.out[0:31]</loc>     
-             <loc side="bottom">memory.addr2[0:14] memory.data[32:63] memory.we2 memory.out[32:63]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="multiply">
+      <input_ports>
+        <port name="a" combinational_sink_ports="out"/>
+        <port name="b" combinational_sink_ports="out"/>
+      </input_ports>
+      <output_ports>
+        <port name="out"/>
+      </output_ports>
+    </model>
+    <model name="single_port_ram">
+      <input_ports>
+        <port name="we" clock="clk"/>
+        <!-- control -->
+        <port name="addr" clock="clk"/>
+        <!-- address lines -->
+        <port name="data" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <port name="we1" clock="clk"/>
+        <!-- write enable -->
+        <port name="we2" clock="clk"/>
+        <!-- write enable -->
+        <port name="addr1" clock="clk"/>
+        <!-- address lines -->
+        <port name="addr2" clock="clk"/>
+        <!-- address lines -->
+        <port name="data1" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data2" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out1" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="out2" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- The original XML does have a default capacity (=1). Set 8 here for best architecture evaluation -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_36" height="4" area="396000">
+      <sub_tile name="mult_36">
+        <equivalent_sites>
+          <site pb_type="mult_36" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="36"/>
+        <input name="b" num_pins="36"/>
+        <output name="out" num_pins="72"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top"/>
+          <loc side="right">mult_36.a[0:17] mult_36.b[0:17] mult_36.out[0:35]</loc>
+          <loc side="bottom">mult_36.a[18:35] mult_36.b[18:35] mult_36.out[36:71]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="6" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="addr1" num_pins="15"/>
+        <input name="addr2" num_pins="15"/>
+        <input name="data" num_pins="64"/>
+        <input name="we1" num_pins="1"/>
+        <input name="we2" num_pins="1"/>
+        <output name="out" num_pins="64"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">memory.clk</loc>
+          <loc side="right">memory.addr1[0:14] memory.data[0:31] memory.we1 memory.out[0:31]</loc>
+          <loc side="bottom">memory.addr2[0:14] memory.data[32:63] memory.we2 memory.out[32:63]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -285,21 +295,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -311,55 +321,53 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Maximum delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
@@ -369,38 +377,38 @@
 			inpad delay:  0.9239
 			outpad delay: 0.9545
 
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" min="3.92e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" min="1.331e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" min="3.92e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" min="1.331e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -408,257 +416,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-       
-           <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -666,45 +672,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -715,37 +721,37 @@
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
            to get the part that should be marked on the crossbar. For the minimum delay,
-  		   the value in Stratix IV is 93 ps, subtracting the 24 ps leaves 69 ps.-->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" min="72e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" min="69e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-          </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+  		   the value in Stratix IV is 93 ps, subtracting the 24 ps leaves 69 ps.-->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" min="72e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" min="69e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+          </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" min="0.11e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define fracturable multiplier begin -->  
-      <!-- This multiplier can operate as a 36x36 multiplier that can fracture to two 18x18 multipliers each of which can further fracture to two 9x9 multipliers 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" min="0.11e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <!-- This multiplier can operate as a 36x36 multiplier that can fracture to two 18x18 multipliers each of which can further fracture to two 9x9 multipliers 
 	   For delay modelling, the 36x36 DSP multiplier in Stratix IV has a maximum delay of 1.523 ns + 1.93 ns
 	    = 3.45 ns. The average difference between the maximum and minimum values of a dsp mac out in 36 bit multiply
 		mode is 0.51. Hence, the minimum delay is modeled as 0.776 ns + 0.984 ns = 1.760 ns.
@@ -768,156 +774,156 @@
 		  block (single tile). It also includes 3.6x the outputs of a logic block, and 1.8x the inputs. Hence a slight overestimate of the routing
 		  area associated with our DSP block is four times that of a logic tile, where the routing area of a logic tile was calculated above (at W = 300)
 		  as 30481 MWTAs. Hence the (core, non-routing) area our DSP block is approximately 518,000 - 4 * 30,481 = 396,000 MWTUs.
-      -->  
-      <pb_type name="mult_36">   
-         <input name="a" num_pins="36"/>   
-         <input name="b" num_pins="36"/>   
-         <output name="out" num_pins="72"/>   
-         <mode name="two_divisible_mult_18x18">    
-            <pb_type name="divisible_mult_18x18" num_pb="2">     
-               <input name="a" num_pins="18"/>     
-               <input name="b" num_pins="18"/>     
-               <output name="out" num_pins="36"/>     
-               <!-- Model 9x9 delay and 18x18 delay as the same.  9x9 could be faster, but in Stratix IV
+      -->
+    <pb_type name="mult_36">
+      <input name="a" num_pins="36"/>
+      <input name="b" num_pins="36"/>
+      <output name="out" num_pins="72"/>
+      <mode name="two_divisible_mult_18x18">
+        <pb_type name="divisible_mult_18x18" num_pb="2">
+          <input name="a" num_pins="18"/>
+          <input name="b" num_pins="18"/>
+          <output name="out" num_pins="36"/>
+          <!-- Model 9x9 delay and 18x18 delay as the same.  9x9 could be faster, but in Stratix IV
 	          isn't, presumably because the multiplier layout is really optimized for 18x18.
-		        -->     
-               <mode name="two_mult_9x9">      
-                  <pb_type name="mult_9x9_slice" num_pb="2">       
-                     <input name="A_cfg" num_pins="9"/>       
-                     <input name="B_cfg" num_pins="9"/>       
-                     <output name="OUT_cfg" num_pins="18"/>       
-                     <pb_type name="mult_9x9" blif_model=".subckt multiply" num_pb="1">        
-                        <input name="a" num_pins="9"/>        
-                        <input name="b" num_pins="9"/>        
-                        <output name="out" num_pins="18"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.a" out_port="mult_9x9.out"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.b" out_port="mult_9x9.out"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="a2a" input="mult_9x9_slice.A_cfg" output="mult_9x9.a">
-                </direct>        
-                        <direct name="b2b" input="mult_9x9_slice.B_cfg" output="mult_9x9.b">
-                </direct>        
-                        <direct name="out2out" input="mult_9x9.out" output="mult_9x9_slice.OUT_cfg">
-                </direct>        
-                     </interconnect>       
-                     <power method="pin-toggle">        
-                        <port name="A_cfg" energy_per_toggle="1.45e-12"/>        
-                        <port name="B_cfg" energy_per_toggle="1.45e-12"/>        
-                        <static_power power_per_instance="0.0"/>        
-                     </power>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="a2a" input="divisible_mult_18x18.a" output="mult_9x9_slice[1:0].A_cfg">
-              </direct>       
-                     <direct name="b2b" input="divisible_mult_18x18.b" output="mult_9x9_slice[1:0].B_cfg">
-              </direct>       
-                     <direct name="out2out" input="mult_9x9_slice[1:0].OUT_cfg" output="divisible_mult_18x18.out">
-              </direct>       
-                  </interconnect>      
-               </mode>     
-               <mode name="mult_18x18">      
-                  <pb_type name="mult_18x18_slice" num_pb="1">       
-                     <input name="A_cfg" num_pins="18"/>       
-                     <input name="B_cfg" num_pins="18"/>       
-                     <output name="OUT_cfg" num_pins="36"/>       
-                     <pb_type name="mult_18x18" blif_model=".subckt multiply" num_pb="1">        
-                        <input name="a" num_pins="18"/>        
-                        <input name="b" num_pins="18"/>        
-                        <output name="out" num_pins="36"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.a" out_port="mult_18x18.out"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.b" out_port="mult_18x18.out"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="a2a" input="mult_18x18_slice.A_cfg" output="mult_18x18.a">
-                </direct>        
-                        <direct name="b2b" input="mult_18x18_slice.B_cfg" output="mult_18x18.b">
-                </direct>        
-                        <direct name="out2out" input="mult_18x18.out" output="mult_18x18_slice.OUT_cfg">
-                </direct>        
-                     </interconnect>       
-                     <power method="pin-toggle">        
-                        <port name="A_cfg" energy_per_toggle="1.09e-12"/>        
-                        <port name="B_cfg" energy_per_toggle="1.09e-12"/>        
-                        <static_power power_per_instance="0.0"/>        
-                     </power>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="a2a" input="divisible_mult_18x18.a" output="mult_18x18_slice.A_cfg">
-              </direct>       
-                     <direct name="b2b" input="divisible_mult_18x18.b" output="mult_18x18_slice.B_cfg">
-              </direct>       
-                     <direct name="out2out" input="mult_18x18_slice.OUT_cfg" output="divisible_mult_18x18.out">
-              </direct>       
-                  </interconnect>      
-               </mode>     
-               <power method="sum-of-children"/>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		        -->
+          <mode name="two_mult_9x9">
+            <pb_type name="mult_9x9_slice" num_pb="2">
+              <input name="A_cfg" num_pins="9"/>
+              <input name="B_cfg" num_pins="9"/>
+              <output name="OUT_cfg" num_pins="18"/>
+              <pb_type name="mult_9x9" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="9"/>
+                <input name="b" num_pins="9"/>
+                <output name="out" num_pins="18"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.a" out_port="mult_9x9.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.b" out_port="mult_9x9.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_9x9_slice.A_cfg" output="mult_9x9.a">
+                </direct>
+                <direct name="b2b" input="mult_9x9_slice.B_cfg" output="mult_9x9.b">
+                </direct>
+                <direct name="out2out" input="mult_9x9.out" output="mult_9x9_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.45e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.45e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_9x9_slice[1:0].A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_9x9_slice[1:0].B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_9x9_slice[1:0].OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <mode name="mult_18x18">
+            <pb_type name="mult_18x18_slice" num_pb="1">
+              <input name="A_cfg" num_pins="18"/>
+              <input name="B_cfg" num_pins="18"/>
+              <output name="OUT_cfg" num_pins="36"/>
+              <pb_type name="mult_18x18" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="18"/>
+                <input name="b" num_pins="18"/>
+                <output name="out" num_pins="36"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.a" out_port="mult_18x18.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.b" out_port="mult_18x18.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_18x18_slice.A_cfg" output="mult_18x18.a">
+                </direct>
+                <direct name="b2b" input="mult_18x18_slice.B_cfg" output="mult_18x18.b">
+                </direct>
+                <direct name="out2out" input="mult_18x18.out" output="mult_18x18_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.09e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.09e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_18x18_slice.A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_18x18_slice.B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_18x18_slice.OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <power method="sum-of-children"/>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading 134 ps
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_36.a" output="divisible_mult_18x18[1:0].a">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="divisible_mult_18x18[1:0].a"/>      
-               </direct>     
-               <direct name="b2b" input="mult_36.b" output="divisible_mult_18x18[1:0].b">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="divisible_mult_18x18[1:0].b"/>      
-               </direct>     
-               <direct name="out2out" input="divisible_mult_18x18[1:0].out" output="mult_36.out">      
-                  <delay_constant max="1.09e-9" min="74e-12" in_port="divisible_mult_18x18[1:0].out" out_port="mult_36.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mult_36x36">    
-            <pb_type name="mult_36x36_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="36"/>     
-               <input name="B_cfg" num_pins="36"/>     
-               <output name="OUT_cfg" num_pins="72"/>     
-               <pb_type name="mult_36x36" blif_model=".subckt multiply" num_pb="1">      
-                  <input name="a" num_pins="36"/>      
-                  <input name="b" num_pins="36"/>      
-                  <output name="out" num_pins="72"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.a" out_port="mult_36x36.out"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.b" out_port="mult_36x36.out"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.a">
-            </direct>      
-                  <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.b">
-            </direct>      
-                  <direct name="out2out" input="mult_36x36.out" output="mult_36x36_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+              -->
+          <direct name="a2a" input="mult_36.a" output="divisible_mult_18x18[1:0].a">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="divisible_mult_18x18[1:0].a"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="divisible_mult_18x18[1:0].b">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="divisible_mult_18x18[1:0].b"/>
+          </direct>
+          <direct name="out2out" input="divisible_mult_18x18[1:0].out" output="mult_36.out">
+            <delay_constant max="1.09e-9" min="74e-12" in_port="divisible_mult_18x18[1:0].out" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_36x36">
+        <pb_type name="mult_36x36_slice" num_pb="1">
+          <input name="A_cfg" num_pins="36"/>
+          <input name="B_cfg" num_pins="36"/>
+          <output name="OUT_cfg" num_pins="72"/>
+          <pb_type name="mult_36x36" blif_model=".subckt multiply" num_pb="1">
+            <input name="a" num_pins="36"/>
+            <input name="b" num_pins="36"/>
+            <output name="out" num_pins="72"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.a" out_port="mult_36x36.out"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.b" out_port="mult_36x36.out"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.a">
+            </direct>
+            <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.b">
+            </direct>
+            <direct name="out2out" input="mult_36x36.out" output="mult_36x36_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
 		   to a 134 ps delay.
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-      <!-- Define fracturable memory begin -->  
-      <!-- 32 Kb Memory that can operate from 512x64 to 32Kx1 for single-port mode and 1024x32 to 32Kx1 for dual-port mode.  
+              -->
+          <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+    <!-- Define fracturable memory begin -->
+    <!-- 32 Kb Memory that can operate from 512x64 to 32Kx1 for single-port mode and 1024x32 to 32Kx1 for dual-port mode.  
            Area and max delay based off Stratix IV 9K and 144K memories (delay from linear interpolation, Tsu(483 ps, 636 ps) Tco(1084ps, 1969ps)).  
 
 		   uTh/Tsu ratio = 0.468, uTco min/max ratio = 0.97
@@ -940,667 +946,666 @@
 		   bits to 32 kb yields 2.2 routing tiles incorporated in the area number above. The inter-block routing represents 30% of the area of a logic 
 		   tile according to D. Lewis et al, "Architectural Enhancements in Stratix V," FPGA 2013. Hence we should subtract 0.3 * 2.2 * 84,375 MWTUs to
 		   obtain a RAM core area (not including inter-block routing) of 548,000 MWTU areas for our 32 kb RAM in a 40 nm process.
-      -->  
-      <pb_type name="memory">   
-         <input name="addr1" num_pins="15"/>   
-         <input name="addr2" num_pins="15"/>   
-         <input name="data" num_pins="64"/>   
-         <input name="we1" num_pins="1"/>   
-         <input name="we2" num_pins="1"/>   
-         <output name="out" num_pins="64"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Physical mode of the fracturable memory -->   
-         <mode name="physical">    
-             <pb_type name="frac_mem_32k" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-                <input name="addr1" num_pins="15" port_class="address1"/>     
-                <input name="addr2" num_pins="15" port_class="address2"/>     
-                <input name="data1" num_pins="32" port_class="data_in1"/>     
-                <input name="data2" num_pins="32" port_class="data_in2"/>     
-                <input name="we1" num_pins="1" port_class="write_en1"/>     
-                <input name="we2" num_pins="1" port_class="write_en2"/>     
-                <output name="out1" num_pins="32" port_class="data_out1"/>     
-                <output name="out2" num_pins="32" port_class="data_out2"/>     
-                <clock name="clk" num_pins="1" port_class="clock"/>     
-
-                <T_setup value="509e-12" port="frac_mem_32k.addr1" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.addr2" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.data1" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.data2" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.we1" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.we2" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.addr1" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.addr2" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.data1" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.data2" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.we1" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.we2" clock="clk"/>     
-                <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out1" clock="clk"/>     
-                <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out2" clock="clk"/>     
-             </pb_type>    
-             <interconnect>     
-               <direct name="address1" input="memory.addr1[14:0]" output="frac_mem_32k.addr1[14:0]"/>     
-               <direct name="address2" input="memory.addr2[14:0]" output="frac_mem_32k.addr2[14:0]"/>     
-               <direct name="data1" input="memory.data[31:0]" output="frac_mem_32k.data1"/>     
-               <direct name="data2" input="memory.data[63:32]" output="frac_mem_32k.data2"/>     
-               <direct name="writeen1" input="memory.we1" output="frac_mem_32k.we1"/>     
-               <direct name="writeen2" input="memory.we2" output="frac_mem_32k.we2"/>     
-               <direct name="dataout1" input="frac_mem_32k.out1" output="memory.out[31:0]"/>     
-               <direct name="dataout2" input="frac_mem_32k.out2" output="memory.out[63:32]"/>     
-               <direct name="clk" input="memory.clk" output="frac_mem_32k.clk"/>     
-            </interconnect>    
-         </mode>   
-         <!-- Specify single port mode first -->   
-         <mode name="mem_512x64_sp">    
-            <pb_type name="mem_512x64_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="9" port_class="address"/>     
-               <input name="data" num_pins="64" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="64" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_512x64_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x64_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x64_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_512x64_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_512x64_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_512x64_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_512x64_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[8:0]" output="mem_512x64_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[8:0]" out_port="mem_512x64_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[63:0]" output="mem_512x64_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:0]" out_port="mem_512x64_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_512x64_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_512x64_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_512x64_sp.out" output="memory.out[63:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_512x64_sp.out" out_port="memory.out[63:0]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_512x64_sp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_1024x32_sp">    
-            <pb_type name="mem_1024x32_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="10" port_class="address"/>     
-               <input name="data" num_pins="32" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_1024x32_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_1024x32_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_1024x32_sp.out" output="memory.out[31:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_sp.out" out_port="memory.out[31:0]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_1024x32_sp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_2048x16_sp">    
-            <pb_type name="mem_2048x16_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="11" port_class="address"/>     
-               <input name="data" num_pins="16" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="16" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_2048x16_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_2048x16_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_2048x16_sp.out" output="memory.out[15:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_sp.out" out_port="memory.out[15:0]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_2048x16_sp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_4096x8_sp">    
-            <pb_type name="mem_4096x8_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="12" port_class="address"/>     
-               <input name="data" num_pins="8" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="8" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_4096x8_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_4096x8_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_4096x8_sp.out" output="memory.out[7:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_sp.out" out_port="memory.out[7:0]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_4096x8_sp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_8192x4_sp">    
-            <pb_type name="mem_8192x4_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="13" port_class="address"/>     
-               <input name="data" num_pins="4" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="4" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_8192x4_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_8192x4_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_8192x4_sp.out" output="memory.out[3:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_sp.out" out_port="memory.out[3:0]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_8192x4_sp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_16384x2_sp">    
-            <pb_type name="mem_16384x2_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="14" port_class="address"/>     
-               <input name="data" num_pins="2" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="2" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_16384x2_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_16384x2_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_16384x2_sp.out" output="memory.out[1:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_sp.out" out_port="memory.out[1:0]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_16384x2_sp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_32768x1_sp">    
-            <pb_type name="mem_32768x1_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="15" port_class="address"/>     
-               <input name="data" num_pins="1" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="1" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_32768x1_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_32768x1_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_32768x1_sp.out" output="memory.out[0:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_sp.out" out_port="memory.out[0:0]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_32768x1_sp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Specify true dual port mode next -->   
-         <mode name="mem_1024x32_dp">    
-            <pb_type name="mem_1024x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="10" port_class="address1"/>     
-               <input name="addr2" num_pins="10" port_class="address2"/>     
-               <input name="data1" num_pins="32" port_class="data_in1"/>     
-               <input name="data2" num_pins="32" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="32" port_class="data_out1"/>     
-               <output name="out2" num_pins="32" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[9:0]" output="mem_1024x32_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[9:0]" out_port="mem_1024x32_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[63:32]" output="mem_1024x32_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:32]" out_port="mem_1024x32_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_1024x32_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_1024x32_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_1024x32_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_1024x32_dp.out1" output="memory.out[31:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out1" out_port="memory.out[31:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_1024x32_dp.out2" output="memory.out[63:32]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out2" out_port="memory.out[63:32]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_1024x32_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_2048x16_dp">    
-            <pb_type name="mem_2048x16_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="11" port_class="address1"/>     
-               <input name="addr2" num_pins="11" port_class="address2"/>     
-               <input name="data1" num_pins="16" port_class="data_in1"/>     
-               <input name="data2" num_pins="16" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="16" port_class="data_out1"/>     
-               <output name="out2" num_pins="16" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[10:0]" output="mem_2048x16_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[10:0]" out_port="mem_2048x16_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[31:16]" output="mem_2048x16_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:16]" out_port="mem_2048x16_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_2048x16_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_2048x16_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_2048x16_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_2048x16_dp.out1" output="memory.out[15:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out1" out_port="memory.out[15:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_2048x16_dp.out2" output="memory.out[31:16]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out2" out_port="memory.out[31:16]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_2048x16_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_4096x8_dp">    
-            <pb_type name="mem_4096x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="12" port_class="address1"/>     
-               <input name="addr2" num_pins="12" port_class="address2"/>     
-               <input name="data1" num_pins="8" port_class="data_in1"/>     
-               <input name="data2" num_pins="8" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="8" port_class="data_out1"/>     
-               <output name="out2" num_pins="8" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[11:0]" output="mem_4096x8_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[11:0]" out_port="mem_4096x8_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[15:8]" output="mem_4096x8_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:8]" out_port="mem_4096x8_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_4096x8_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_4096x8_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_4096x8_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_4096x8_dp.out1" output="memory.out[7:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out1" out_port="memory.out[7:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_4096x8_dp.out2" output="memory.out[15:8]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out2" out_port="memory.out[15:8]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_4096x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_8192x4_dp">    
-            <pb_type name="mem_8192x4_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="13" port_class="address1"/>     
-               <input name="addr2" num_pins="13" port_class="address2"/>     
-               <input name="data1" num_pins="4" port_class="data_in1"/>     
-               <input name="data2" num_pins="4" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="4" port_class="data_out1"/>     
-               <output name="out2" num_pins="4" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[12:0]" output="mem_8192x4_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[12:0]" out_port="mem_8192x4_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[7:4]" output="mem_8192x4_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:4]" out_port="mem_8192x4_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_8192x4_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_8192x4_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_8192x4_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_8192x4_dp.out1" output="memory.out[3:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out1" out_port="memory.out[3:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_8192x4_dp.out2" output="memory.out[7:4]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out2" out_port="memory.out[7:4]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_8192x4_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_16384x2_dp">    
-            <pb_type name="mem_16384x2_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="14" port_class="address1"/>     
-               <input name="addr2" num_pins="14" port_class="address2"/>     
-               <input name="data1" num_pins="2" port_class="data_in1"/>     
-               <input name="data2" num_pins="2" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="2" port_class="data_out1"/>     
-               <output name="out2" num_pins="2" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[13:0]" output="mem_16384x2_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[13:0]" out_port="mem_16384x2_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[3:2]" output="mem_16384x2_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:2]" out_port="mem_16384x2_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_16384x2_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_16384x2_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_16384x2_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_16384x2_dp.out1" output="memory.out[1:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out1" out_port="memory.out[1:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_16384x2_dp.out2" output="memory.out[3:2]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out2" out_port="memory.out[3:2]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_16384x2_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_32768x1_dp">    
-            <pb_type name="mem_32768x1_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="15" port_class="address1"/>     
-               <input name="addr2" num_pins="15" port_class="address2"/>     
-               <input name="data1" num_pins="1" port_class="data_in1"/>     
-               <input name="data2" num_pins="1" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="1" port_class="data_out1"/>     
-               <output name="out2" num_pins="1" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[14:0]" output="mem_32768x1_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[14:0]" out_port="mem_32768x1_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[1:1]" output="mem_32768x1_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:1]" out_port="mem_32768x1_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_32768x1_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_32768x1_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_32768x1_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_32768x1_dp.out1" output="memory.out[0:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out1" out_port="memory.out[0:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_32768x1_dp.out2" output="memory.out[1:1]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out2" out_port="memory.out[1:1]"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_32768x1_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this memory block every 8 columns from (and including) the second column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable memory end -->  
-   </complexblocklist> 
+      -->
+    <pb_type name="memory">
+      <input name="addr1" num_pins="15"/>
+      <input name="addr2" num_pins="15"/>
+      <input name="data" num_pins="64"/>
+      <input name="we1" num_pins="1"/>
+      <input name="we2" num_pins="1"/>
+      <output name="out" num_pins="64"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Physical mode of the fracturable memory -->
+      <mode name="physical">
+        <pb_type name="frac_mem_32k" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="15" port_class="address1"/>
+          <input name="addr2" num_pins="15" port_class="address2"/>
+          <input name="data1" num_pins="32" port_class="data_in1"/>
+          <input name="data2" num_pins="32" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="32" port_class="data_out1"/>
+          <output name="out2" num_pins="32" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="frac_mem_32k.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.data1" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.data2" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.we1" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.we2" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.data1" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.data2" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.we1" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out2" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="frac_mem_32k.addr1[14:0]"/>
+          <direct name="address2" input="memory.addr2[14:0]" output="frac_mem_32k.addr2[14:0]"/>
+          <direct name="data1" input="memory.data[31:0]" output="frac_mem_32k.data1"/>
+          <direct name="data2" input="memory.data[63:32]" output="frac_mem_32k.data2"/>
+          <direct name="writeen1" input="memory.we1" output="frac_mem_32k.we1"/>
+          <direct name="writeen2" input="memory.we2" output="frac_mem_32k.we2"/>
+          <direct name="dataout1" input="frac_mem_32k.out1" output="memory.out[31:0]"/>
+          <direct name="dataout2" input="frac_mem_32k.out2" output="memory.out[63:32]"/>
+          <direct name="clk" input="memory.clk" output="frac_mem_32k.clk"/>
+        </interconnect>
+      </mode>
+      <!-- Specify single port mode first -->
+      <mode name="mem_512x64_sp">
+        <pb_type name="mem_512x64_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="9" port_class="address"/>
+          <input name="data" num_pins="64" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="64" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_512x64_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[8:0]" output="mem_512x64_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[8:0]" out_port="mem_512x64_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[63:0]" output="mem_512x64_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:0]" out_port="mem_512x64_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_512x64_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_512x64_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_512x64_sp.out" output="memory.out[63:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_512x64_sp.out" out_port="memory.out[63:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x64_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_1024x32_sp">
+        <pb_type name="mem_1024x32_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="10" port_class="address"/>
+          <input name="data" num_pins="32" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_sp.out" output="memory.out[31:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_sp.out" out_port="memory.out[31:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x32_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_sp">
+        <pb_type name="mem_2048x16_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="11" port_class="address"/>
+          <input name="data" num_pins="16" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="16" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_sp.out" output="memory.out[15:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_sp.out" out_port="memory.out[15:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x16_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_4096x8_sp">
+        <pb_type name="mem_4096x8_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="12" port_class="address"/>
+          <input name="data" num_pins="8" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_4096x8_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_4096x8_sp.out" output="memory.out[7:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_sp.out" out_port="memory.out[7:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_4096x8_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_sp">
+        <pb_type name="mem_8192x4_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="13" port_class="address"/>
+          <input name="data" num_pins="4" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="4" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_sp.out" output="memory.out[3:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_sp.out" out_port="memory.out[3:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_8192x4_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_sp">
+        <pb_type name="mem_16384x2_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="14" port_class="address"/>
+          <input name="data" num_pins="2" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="2" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_sp.out" output="memory.out[1:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_sp.out" out_port="memory.out[1:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_16384x2_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_sp">
+        <pb_type name="mem_32768x1_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="15" port_class="address"/>
+          <input name="data" num_pins="1" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="1" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_sp.out" output="memory.out[0:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_sp.out" out_port="memory.out[0:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_32768x1_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Specify true dual port mode next -->
+      <mode name="mem_1024x32_dp">
+        <pb_type name="mem_1024x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="10" port_class="address1"/>
+          <input name="addr2" num_pins="10" port_class="address2"/>
+          <input name="data1" num_pins="32" port_class="data_in1"/>
+          <input name="data2" num_pins="32" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="32" port_class="data_out1"/>
+          <output name="out2" num_pins="32" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[9:0]" output="mem_1024x32_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[9:0]" out_port="mem_1024x32_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[63:32]" output="mem_1024x32_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:32]" out_port="mem_1024x32_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_1024x32_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_1024x32_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_dp.out1" output="memory.out[31:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out1" out_port="memory.out[31:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_1024x32_dp.out2" output="memory.out[63:32]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out2" out_port="memory.out[63:32]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_dp">
+        <pb_type name="mem_2048x16_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="11" port_class="address1"/>
+          <input name="addr2" num_pins="11" port_class="address2"/>
+          <input name="data1" num_pins="16" port_class="data_in1"/>
+          <input name="data2" num_pins="16" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="16" port_class="data_out1"/>
+          <output name="out2" num_pins="16" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[10:0]" output="mem_2048x16_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[10:0]" out_port="mem_2048x16_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[31:16]" output="mem_2048x16_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:16]" out_port="mem_2048x16_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_2048x16_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_2048x16_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_dp.out1" output="memory.out[15:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out1" out_port="memory.out[15:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_2048x16_dp.out2" output="memory.out[31:16]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out2" out_port="memory.out[31:16]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x16_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_4096x8_dp">
+        <pb_type name="mem_4096x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="12" port_class="address1"/>
+          <input name="addr2" num_pins="12" port_class="address2"/>
+          <input name="data1" num_pins="8" port_class="data_in1"/>
+          <input name="data2" num_pins="8" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="8" port_class="data_out1"/>
+          <output name="out2" num_pins="8" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[11:0]" output="mem_4096x8_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[11:0]" out_port="mem_4096x8_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[15:8]" output="mem_4096x8_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:8]" out_port="mem_4096x8_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_4096x8_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_4096x8_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_4096x8_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_4096x8_dp.out1" output="memory.out[7:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out1" out_port="memory.out[7:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_4096x8_dp.out2" output="memory.out[15:8]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out2" out_port="memory.out[15:8]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_4096x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_dp">
+        <pb_type name="mem_8192x4_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="13" port_class="address1"/>
+          <input name="addr2" num_pins="13" port_class="address2"/>
+          <input name="data1" num_pins="4" port_class="data_in1"/>
+          <input name="data2" num_pins="4" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="4" port_class="data_out1"/>
+          <output name="out2" num_pins="4" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[12:0]" output="mem_8192x4_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[12:0]" out_port="mem_8192x4_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[7:4]" output="mem_8192x4_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:4]" out_port="mem_8192x4_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_8192x4_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_8192x4_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_dp.out1" output="memory.out[3:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out1" out_port="memory.out[3:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_8192x4_dp.out2" output="memory.out[7:4]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out2" out_port="memory.out[7:4]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_8192x4_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_dp">
+        <pb_type name="mem_16384x2_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="14" port_class="address1"/>
+          <input name="addr2" num_pins="14" port_class="address2"/>
+          <input name="data1" num_pins="2" port_class="data_in1"/>
+          <input name="data2" num_pins="2" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="2" port_class="data_out1"/>
+          <output name="out2" num_pins="2" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[13:0]" output="mem_16384x2_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[13:0]" out_port="mem_16384x2_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[3:2]" output="mem_16384x2_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:2]" out_port="mem_16384x2_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_16384x2_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_16384x2_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_dp.out1" output="memory.out[1:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out1" out_port="memory.out[1:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_16384x2_dp.out2" output="memory.out[3:2]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out2" out_port="memory.out[3:2]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_16384x2_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_dp">
+        <pb_type name="mem_32768x1_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="15" port_class="address1"/>
+          <input name="addr2" num_pins="15" port_class="address2"/>
+          <input name="data1" num_pins="1" port_class="data_in1"/>
+          <input name="data2" num_pins="1" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="1" port_class="data_out1"/>
+          <output name="out2" num_pins="1" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[14:0]" output="mem_32768x1_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[14:0]" out_port="mem_32768x1_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[1:1]" output="mem_32768x1_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:1]" out_port="mem_32768x1_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_32768x1_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_32768x1_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_dp.out1" output="memory.out[0:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out1" out_port="memory.out[0:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_32768x1_dp.out2" output="memory.out[1:1]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out2" out_port="memory.out[1:1]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_32768x1_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this memory block every 8 columns from (and including) the second column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_frac_mem32K_frac_dsp36_GlobalTile8Clk_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_frac_mem32K_frac_dsp36_GlobalTile8Clk_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -84,8 +85,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -93,201 +95,209 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="multiply">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="out"/>    
-            <port name="b" combinational_sink_ports="out"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="out"/>    
-         </output_ports>   
-      </model>  
-      <model name="single_port_ram">   
-         <input_ports>    
-            <port name="we" clock="clk"/>    
-            <!-- control -->    
-            <port name="addr" clock="clk"/>    
-            <!-- address lines -->    
-            <port name="data" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="clk" is_clock="1"/>    
-            <!-- memories are often clocked -->    
-         </input_ports>   
-         <output_ports>    
-            <port name="out" clock="clk"/>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <port name="we1" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="we2" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="addr1" clock="clk"/>    
-            <!-- address lines -->    
-            <port name="addr2" clock="clk"/>    
-            <!-- address lines -->    
-            <port name="data1" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data2" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="clk" is_clock="1"/>    
-            <!-- memories are often clocked -->    
-         </input_ports>   
-         <output_ports>    
-            <port name="out1" clock="clk"/>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="out2" clock="clk"/>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-         </output_ports>   
-      </model>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- The original XML does have a default capacity (=1). Set 8 here for best architecture evaluation -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="8"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!-- Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="mult_36" height="4" area="396000">   <sub_tile name="mult_36">    
-          <equivalent_sites>     
-             <site pb_type="mult_36" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="a" num_pins="36"/>    
-          <input name="b" num_pins="36"/>    
-          <output name="out" num_pins="72"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top"/>     
-             <loc side="right">mult_36.a[0:17] mult_36.b[0:17] mult_36.out[0:35]</loc>     
-             <loc side="bottom">mult_36.a[18:35] mult_36.b[18:35] mult_36.out[36:71]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="6" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory" pin_mapping="direct"/>     
-          </equivalent_sites>    
-          <input name="addr1" num_pins="15"/>    
-          <input name="addr2" num_pins="15"/>    
-          <input name="data" num_pins="64"/>    
-          <input name="we1" num_pins="1"/>    
-          <input name="we2" num_pins="1"/>    
-          <output name="out" num_pins="64"/>    
-          <clock name="clk" num_pins="8"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">memory.clk</loc>     
-             <loc side="right">memory.addr1[0:14] memory.data[0:31] memory.we1 memory.out[0:31]</loc>     
-             <loc side="bottom">memory.addr2[0:14] memory.data[32:63] memory.we2 memory.out[32:63]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="32x32" width="34" height="34">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="multiply">
+      <input_ports>
+        <port name="a" combinational_sink_ports="out"/>
+        <port name="b" combinational_sink_ports="out"/>
+      </input_ports>
+      <output_ports>
+        <port name="out"/>
+      </output_ports>
+    </model>
+    <model name="single_port_ram">
+      <input_ports>
+        <port name="we" clock="clk"/>
+        <!-- control -->
+        <port name="addr" clock="clk"/>
+        <!-- address lines -->
+        <port name="data" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <port name="we1" clock="clk"/>
+        <!-- write enable -->
+        <port name="we2" clock="clk"/>
+        <!-- write enable -->
+        <port name="addr1" clock="clk"/>
+        <!-- address lines -->
+        <port name="addr2" clock="clk"/>
+        <!-- address lines -->
+        <port name="data1" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data2" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out1" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="out2" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- The original XML does have a default capacity (=1). Set 8 here for best architecture evaluation -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="8"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!-- Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_36" height="4" area="396000">
+      <sub_tile name="mult_36">
+        <equivalent_sites>
+          <site pb_type="mult_36" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="36"/>
+        <input name="b" num_pins="36"/>
+        <output name="out" num_pins="72"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top"/>
+          <loc side="right">mult_36.a[0:17] mult_36.b[0:17] mult_36.out[0:35]</loc>
+          <loc side="bottom">mult_36.a[18:35] mult_36.b[18:35] mult_36.out[36:71]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="6" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="addr1" num_pins="15"/>
+        <input name="addr2" num_pins="15"/>
+        <input name="data" num_pins="64"/>
+        <input name="we1" num_pins="1"/>
+        <input name="we2" num_pins="1"/>
+        <output name="out" num_pins="64"/>
+        <clock name="clk" num_pins="8"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">memory.clk</loc>
+          <loc side="right">memory.addr1[0:14] memory.data[0:31] memory.we1 memory.out[0:31]</loc>
+          <loc side="bottom">memory.addr2[0:14] memory.data[32:63] memory.we2 memory.out[32:63]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="32x32" width="34" height="34">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -301,21 +311,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -327,55 +337,53 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Maximum delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
@@ -385,38 +393,38 @@
 			inpad delay:  0.9239
 			outpad delay: 0.9545
 
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" min="3.92e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" min="1.331e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" min="3.92e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" min="1.331e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -424,257 +432,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="8"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="8"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-       
-           <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -682,45 +688,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -731,37 +737,37 @@
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
            to get the part that should be marked on the crossbar. For the minimum delay,
-  		   the value in Stratix IV is 93 ps, subtracting the 24 ps leaves 69 ps.-->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" min="72e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" min="69e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-          </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+  		   the value in Stratix IV is 93 ps, subtracting the 24 ps leaves 69 ps.-->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" min="72e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" min="69e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+          </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" min="0.11e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define fracturable multiplier begin -->  
-      <!-- This multiplier can operate as a 36x36 multiplier that can fracture to two 18x18 multipliers each of which can further fracture to two 9x9 multipliers 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" min="0.11e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <!-- This multiplier can operate as a 36x36 multiplier that can fracture to two 18x18 multipliers each of which can further fracture to two 9x9 multipliers 
 	   For delay modelling, the 36x36 DSP multiplier in Stratix IV has a maximum delay of 1.523 ns + 1.93 ns
 	    = 3.45 ns. The average difference between the maximum and minimum values of a dsp mac out in 36 bit multiply
 		mode is 0.51. Hence, the minimum delay is modeled as 0.776 ns + 0.984 ns = 1.760 ns.
@@ -784,156 +790,156 @@
 		  block (single tile). It also includes 3.6x the outputs of a logic block, and 1.8x the inputs. Hence a slight overestimate of the routing
 		  area associated with our DSP block is four times that of a logic tile, where the routing area of a logic tile was calculated above (at W = 300)
 		  as 30481 MWTAs. Hence the (core, non-routing) area our DSP block is approximately 518,000 - 4 * 30,481 = 396,000 MWTUs.
-      -->  
-      <pb_type name="mult_36">   
-         <input name="a" num_pins="36"/>   
-         <input name="b" num_pins="36"/>   
-         <output name="out" num_pins="72"/>   
-         <mode name="two_divisible_mult_18x18">    
-            <pb_type name="divisible_mult_18x18" num_pb="2">     
-               <input name="a" num_pins="18"/>     
-               <input name="b" num_pins="18"/>     
-               <output name="out" num_pins="36"/>     
-               <!-- Model 9x9 delay and 18x18 delay as the same.  9x9 could be faster, but in Stratix IV
+      -->
+    <pb_type name="mult_36">
+      <input name="a" num_pins="36"/>
+      <input name="b" num_pins="36"/>
+      <output name="out" num_pins="72"/>
+      <mode name="two_divisible_mult_18x18">
+        <pb_type name="divisible_mult_18x18" num_pb="2">
+          <input name="a" num_pins="18"/>
+          <input name="b" num_pins="18"/>
+          <output name="out" num_pins="36"/>
+          <!-- Model 9x9 delay and 18x18 delay as the same.  9x9 could be faster, but in Stratix IV
 	          isn't, presumably because the multiplier layout is really optimized for 18x18.
-		        -->     
-               <mode name="two_mult_9x9">      
-                  <pb_type name="mult_9x9_slice" num_pb="2">       
-                     <input name="A_cfg" num_pins="9"/>       
-                     <input name="B_cfg" num_pins="9"/>       
-                     <output name="OUT_cfg" num_pins="18"/>       
-                     <pb_type name="mult_9x9" blif_model=".subckt multiply" num_pb="1">        
-                        <input name="a" num_pins="9"/>        
-                        <input name="b" num_pins="9"/>        
-                        <output name="out" num_pins="18"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.a" out_port="mult_9x9.out"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.b" out_port="mult_9x9.out"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="a2a" input="mult_9x9_slice.A_cfg" output="mult_9x9.a">
-                </direct>        
-                        <direct name="b2b" input="mult_9x9_slice.B_cfg" output="mult_9x9.b">
-                </direct>        
-                        <direct name="out2out" input="mult_9x9.out" output="mult_9x9_slice.OUT_cfg">
-                </direct>        
-                     </interconnect>       
-                     <power method="pin-toggle">        
-                        <port name="A_cfg" energy_per_toggle="1.45e-12"/>        
-                        <port name="B_cfg" energy_per_toggle="1.45e-12"/>        
-                        <static_power power_per_instance="0.0"/>        
-                     </power>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="a2a" input="divisible_mult_18x18.a" output="mult_9x9_slice[1:0].A_cfg">
-              </direct>       
-                     <direct name="b2b" input="divisible_mult_18x18.b" output="mult_9x9_slice[1:0].B_cfg">
-              </direct>       
-                     <direct name="out2out" input="mult_9x9_slice[1:0].OUT_cfg" output="divisible_mult_18x18.out">
-              </direct>       
-                  </interconnect>      
-               </mode>     
-               <mode name="mult_18x18">      
-                  <pb_type name="mult_18x18_slice" num_pb="1">       
-                     <input name="A_cfg" num_pins="18"/>       
-                     <input name="B_cfg" num_pins="18"/>       
-                     <output name="OUT_cfg" num_pins="36"/>       
-                     <pb_type name="mult_18x18" blif_model=".subckt multiply" num_pb="1">        
-                        <input name="a" num_pins="18"/>        
-                        <input name="b" num_pins="18"/>        
-                        <output name="out" num_pins="36"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.a" out_port="mult_18x18.out"/>        
-                        <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.b" out_port="mult_18x18.out"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="a2a" input="mult_18x18_slice.A_cfg" output="mult_18x18.a">
-                </direct>        
-                        <direct name="b2b" input="mult_18x18_slice.B_cfg" output="mult_18x18.b">
-                </direct>        
-                        <direct name="out2out" input="mult_18x18.out" output="mult_18x18_slice.OUT_cfg">
-                </direct>        
-                     </interconnect>       
-                     <power method="pin-toggle">        
-                        <port name="A_cfg" energy_per_toggle="1.09e-12"/>        
-                        <port name="B_cfg" energy_per_toggle="1.09e-12"/>        
-                        <static_power power_per_instance="0.0"/>        
-                     </power>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="a2a" input="divisible_mult_18x18.a" output="mult_18x18_slice.A_cfg">
-              </direct>       
-                     <direct name="b2b" input="divisible_mult_18x18.b" output="mult_18x18_slice.B_cfg">
-              </direct>       
-                     <direct name="out2out" input="mult_18x18_slice.OUT_cfg" output="divisible_mult_18x18.out">
-              </direct>       
-                  </interconnect>      
-               </mode>     
-               <power method="sum-of-children"/>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		        -->
+          <mode name="two_mult_9x9">
+            <pb_type name="mult_9x9_slice" num_pb="2">
+              <input name="A_cfg" num_pins="9"/>
+              <input name="B_cfg" num_pins="9"/>
+              <output name="OUT_cfg" num_pins="18"/>
+              <pb_type name="mult_9x9" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="9"/>
+                <input name="b" num_pins="9"/>
+                <output name="out" num_pins="18"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.a" out_port="mult_9x9.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.b" out_port="mult_9x9.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_9x9_slice.A_cfg" output="mult_9x9.a">
+                </direct>
+                <direct name="b2b" input="mult_9x9_slice.B_cfg" output="mult_9x9.b">
+                </direct>
+                <direct name="out2out" input="mult_9x9.out" output="mult_9x9_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.45e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.45e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_9x9_slice[1:0].A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_9x9_slice[1:0].B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_9x9_slice[1:0].OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <mode name="mult_18x18">
+            <pb_type name="mult_18x18_slice" num_pb="1">
+              <input name="A_cfg" num_pins="18"/>
+              <input name="B_cfg" num_pins="18"/>
+              <output name="OUT_cfg" num_pins="36"/>
+              <pb_type name="mult_18x18" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="18"/>
+                <input name="b" num_pins="18"/>
+                <output name="out" num_pins="36"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.a" out_port="mult_18x18.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.b" out_port="mult_18x18.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_18x18_slice.A_cfg" output="mult_18x18.a">
+                </direct>
+                <direct name="b2b" input="mult_18x18_slice.B_cfg" output="mult_18x18.b">
+                </direct>
+                <direct name="out2out" input="mult_18x18.out" output="mult_18x18_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.09e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.09e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_18x18_slice.A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_18x18_slice.B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_18x18_slice.OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <power method="sum-of-children"/>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading 134 ps
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_36.a" output="divisible_mult_18x18[1:0].a">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="divisible_mult_18x18[1:0].a"/>      
-               </direct>     
-               <direct name="b2b" input="mult_36.b" output="divisible_mult_18x18[1:0].b">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="divisible_mult_18x18[1:0].b"/>      
-               </direct>     
-               <direct name="out2out" input="divisible_mult_18x18[1:0].out" output="mult_36.out">      
-                  <delay_constant max="1.09e-9" min="74e-12" in_port="divisible_mult_18x18[1:0].out" out_port="mult_36.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="mult_36x36">    
-            <pb_type name="mult_36x36_slice" num_pb="1">     
-               <input name="A_cfg" num_pins="36"/>     
-               <input name="B_cfg" num_pins="36"/>     
-               <output name="OUT_cfg" num_pins="72"/>     
-               <pb_type name="mult_36x36" blif_model=".subckt multiply" num_pb="1">      
-                  <input name="a" num_pins="36"/>      
-                  <input name="b" num_pins="36"/>      
-                  <output name="out" num_pins="72"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.a" out_port="mult_36x36.out"/>      
-                  <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.b" out_port="mult_36x36.out"/>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.a">
-            </direct>      
-                  <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.b">
-            </direct>      
-                  <direct name="out2out" input="mult_36x36.out" output="mult_36x36_slice.OUT_cfg">
-            </direct>      
-               </interconnect>     
-               <power method="pin-toggle">      
-                  <port name="A_cfg" energy_per_toggle="2.13e-12"/>      
-                  <port name="B_cfg" energy_per_toggle="2.13e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+              -->
+          <direct name="a2a" input="mult_36.a" output="divisible_mult_18x18[1:0].a">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="divisible_mult_18x18[1:0].a"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="divisible_mult_18x18[1:0].b">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="divisible_mult_18x18[1:0].b"/>
+          </direct>
+          <direct name="out2out" input="divisible_mult_18x18[1:0].out" output="mult_36.out">
+            <delay_constant max="1.09e-9" min="74e-12" in_port="divisible_mult_18x18[1:0].out" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_36x36">
+        <pb_type name="mult_36x36_slice" num_pb="1">
+          <input name="A_cfg" num_pins="36"/>
+          <input name="B_cfg" num_pins="36"/>
+          <output name="OUT_cfg" num_pins="72"/>
+          <pb_type name="mult_36x36" blif_model=".subckt multiply" num_pb="1">
+            <input name="a" num_pins="36"/>
+            <input name="b" num_pins="36"/>
+            <output name="out" num_pins="72"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.a" out_port="mult_36x36.out"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.b" out_port="mult_36x36.out"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.a">
+            </direct>
+            <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.b">
+            </direct>
+            <direct name="out2out" input="mult_36x36.out" output="mult_36x36_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
 		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
 		   to a 134 ps delay.
 				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
-              -->     
-               <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>      
-               </direct>     
-               <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">      
-                  <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>      
-               </direct>     
-               <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">      
-                  <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable multiplier end -->  
-      <!-- Define fracturable memory begin -->  
-      <!-- 32 Kb Memory that can operate from 512x64 to 32Kx1 for single-port mode and 1024x32 to 32Kx1 for dual-port mode.  
+              -->
+          <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+    <!-- Define fracturable memory begin -->
+    <!-- 32 Kb Memory that can operate from 512x64 to 32Kx1 for single-port mode and 1024x32 to 32Kx1 for dual-port mode.  
            Area and max delay based off Stratix IV 9K and 144K memories (delay from linear interpolation, Tsu(483 ps, 636 ps) Tco(1084ps, 1969ps)).  
 
 		   uTh/Tsu ratio = 0.468, uTco min/max ratio = 0.97
@@ -956,667 +962,666 @@
 		   bits to 32 kb yields 2.2 routing tiles incorporated in the area number above. The inter-block routing represents 30% of the area of a logic 
 		   tile according to D. Lewis et al, "Architectural Enhancements in Stratix V," FPGA 2013. Hence we should subtract 0.3 * 2.2 * 84,375 MWTUs to
 		   obtain a RAM core area (not including inter-block routing) of 548,000 MWTU areas for our 32 kb RAM in a 40 nm process.
-      -->  
-      <pb_type name="memory">   
-         <input name="addr1" num_pins="15"/>   
-         <input name="addr2" num_pins="15"/>   
-         <input name="data" num_pins="64"/>   
-         <input name="we1" num_pins="1"/>   
-         <input name="we2" num_pins="1"/>   
-         <output name="out" num_pins="64"/>   
-         <clock name="clk" num_pins="8"/>   
-         <!-- Physical mode of the fracturable memory -->   
-         <mode name="physical">    
-             <pb_type name="frac_mem_32k" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-                <input name="addr1" num_pins="15" port_class="address1"/>     
-                <input name="addr2" num_pins="15" port_class="address2"/>     
-                <input name="data1" num_pins="32" port_class="data_in1"/>     
-                <input name="data2" num_pins="32" port_class="data_in2"/>     
-                <input name="we1" num_pins="1" port_class="write_en1"/>     
-                <input name="we2" num_pins="1" port_class="write_en2"/>     
-                <output name="out1" num_pins="32" port_class="data_out1"/>     
-                <output name="out2" num_pins="32" port_class="data_out2"/>     
-                <clock name="clk" num_pins="1" port_class="clock"/>     
-
-                <T_setup value="509e-12" port="frac_mem_32k.addr1" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.addr2" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.data1" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.data2" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.we1" clock="clk"/>     
-                <T_setup value="509e-12" port="frac_mem_32k.we2" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.addr1" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.addr2" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.data1" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.data2" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.we1" clock="clk"/>     
-                <T_hold value="238e-12" port="frac_mem_32k.we2" clock="clk"/>     
-                <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out1" clock="clk"/>     
-                <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out2" clock="clk"/>     
-             </pb_type>    
-             <interconnect>     
-               <direct name="address1" input="memory.addr1[14:0]" output="frac_mem_32k.addr1[14:0]"/>     
-               <direct name="address2" input="memory.addr2[14:0]" output="frac_mem_32k.addr2[14:0]"/>     
-               <direct name="data1" input="memory.data[31:0]" output="frac_mem_32k.data1"/>     
-               <direct name="data2" input="memory.data[63:32]" output="frac_mem_32k.data2"/>     
-               <direct name="writeen1" input="memory.we1" output="frac_mem_32k.we1"/>     
-               <direct name="writeen2" input="memory.we2" output="frac_mem_32k.we2"/>     
-               <direct name="dataout1" input="frac_mem_32k.out1" output="memory.out[31:0]"/>     
-               <direct name="dataout2" input="frac_mem_32k.out2" output="memory.out[63:32]"/>     
-               <complete name="clk" input="memory.clk" output="frac_mem_32k.clk"/>     
-            </interconnect>    
-         </mode>   
-         <!-- Specify single port mode first -->   
-         <mode name="mem_512x64_sp">    
-            <pb_type name="mem_512x64_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="9" port_class="address"/>     
-               <input name="data" num_pins="64" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="64" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_512x64_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x64_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x64_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_512x64_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_512x64_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_512x64_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_512x64_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[8:0]" output="mem_512x64_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[8:0]" out_port="mem_512x64_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[63:0]" output="mem_512x64_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:0]" out_port="mem_512x64_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_512x64_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_512x64_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_512x64_sp.out" output="memory.out[63:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_512x64_sp.out" out_port="memory.out[63:0]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_512x64_sp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_1024x32_sp">    
-            <pb_type name="mem_1024x32_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="10" port_class="address"/>     
-               <input name="data" num_pins="32" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_1024x32_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_1024x32_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_1024x32_sp.out" output="memory.out[31:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_sp.out" out_port="memory.out[31:0]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_1024x32_sp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_2048x16_sp">    
-            <pb_type name="mem_2048x16_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="11" port_class="address"/>     
-               <input name="data" num_pins="16" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="16" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_2048x16_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_2048x16_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_2048x16_sp.out" output="memory.out[15:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_sp.out" out_port="memory.out[15:0]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_2048x16_sp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_4096x8_sp">    
-            <pb_type name="mem_4096x8_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="12" port_class="address"/>     
-               <input name="data" num_pins="8" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="8" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_4096x8_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_4096x8_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_4096x8_sp.out" output="memory.out[7:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_sp.out" out_port="memory.out[7:0]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_4096x8_sp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_8192x4_sp">    
-            <pb_type name="mem_8192x4_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="13" port_class="address"/>     
-               <input name="data" num_pins="4" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="4" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_8192x4_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_8192x4_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_8192x4_sp.out" output="memory.out[3:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_sp.out" out_port="memory.out[3:0]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_8192x4_sp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_16384x2_sp">    
-            <pb_type name="mem_16384x2_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="14" port_class="address"/>     
-               <input name="data" num_pins="2" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="2" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_16384x2_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_16384x2_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_16384x2_sp.out" output="memory.out[1:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_sp.out" out_port="memory.out[1:0]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_16384x2_sp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_32768x1_sp">    
-            <pb_type name="mem_32768x1_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">     
-               <input name="addr" num_pins="15" port_class="address"/>     
-               <input name="data" num_pins="1" port_class="data_in"/>     
-               <input name="we" num_pins="1" port_class="write_en"/>     
-               <output name="out" num_pins="1" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_32768x1_sp.addr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_sp.data" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_sp.we" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_sp.addr" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_sp.data" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_sp.we" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_sp.out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="9.0e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_sp.addr">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_sp.addr"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_sp.data">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_sp.data"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_32768x1_sp.we">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_sp.we"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_32768x1_sp.out" output="memory.out[0:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_sp.out" out_port="memory.out[0:0]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_32768x1_sp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <!-- Specify true dual port mode next -->   
-         <mode name="mem_1024x32_dp">    
-            <pb_type name="mem_1024x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="10" port_class="address1"/>     
-               <input name="addr2" num_pins="10" port_class="address2"/>     
-               <input name="data1" num_pins="32" port_class="data_in1"/>     
-               <input name="data2" num_pins="32" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="32" port_class="data_out1"/>     
-               <output name="out2" num_pins="32" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_1024x32_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_1024x32_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[9:0]" output="mem_1024x32_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[9:0]" out_port="mem_1024x32_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[63:32]" output="mem_1024x32_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:32]" out_port="mem_1024x32_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_1024x32_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_1024x32_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_1024x32_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_1024x32_dp.out1" output="memory.out[31:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out1" out_port="memory.out[31:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_1024x32_dp.out2" output="memory.out[63:32]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out2" out_port="memory.out[63:32]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_1024x32_dp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_2048x16_dp">    
-            <pb_type name="mem_2048x16_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="11" port_class="address1"/>     
-               <input name="addr2" num_pins="11" port_class="address2"/>     
-               <input name="data1" num_pins="16" port_class="data_in1"/>     
-               <input name="data2" num_pins="16" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="16" port_class="data_out1"/>     
-               <output name="out2" num_pins="16" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_2048x16_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_2048x16_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[10:0]" output="mem_2048x16_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[10:0]" out_port="mem_2048x16_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[31:16]" output="mem_2048x16_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:16]" out_port="mem_2048x16_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_2048x16_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_2048x16_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_2048x16_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_2048x16_dp.out1" output="memory.out[15:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out1" out_port="memory.out[15:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_2048x16_dp.out2" output="memory.out[31:16]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out2" out_port="memory.out[31:16]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_2048x16_dp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_4096x8_dp">    
-            <pb_type name="mem_4096x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="12" port_class="address1"/>     
-               <input name="addr2" num_pins="12" port_class="address2"/>     
-               <input name="data1" num_pins="8" port_class="data_in1"/>     
-               <input name="data2" num_pins="8" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="8" port_class="data_out1"/>     
-               <output name="out2" num_pins="8" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_4096x8_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_4096x8_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[11:0]" output="mem_4096x8_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[11:0]" out_port="mem_4096x8_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[15:8]" output="mem_4096x8_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:8]" out_port="mem_4096x8_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_4096x8_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_4096x8_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_4096x8_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_4096x8_dp.out1" output="memory.out[7:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out1" out_port="memory.out[7:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_4096x8_dp.out2" output="memory.out[15:8]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out2" out_port="memory.out[15:8]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_4096x8_dp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_8192x4_dp">    
-            <pb_type name="mem_8192x4_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="13" port_class="address1"/>     
-               <input name="addr2" num_pins="13" port_class="address2"/>     
-               <input name="data1" num_pins="4" port_class="data_in1"/>     
-               <input name="data2" num_pins="4" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="4" port_class="data_out1"/>     
-               <output name="out2" num_pins="4" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_8192x4_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_8192x4_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[12:0]" output="mem_8192x4_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[12:0]" out_port="mem_8192x4_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[7:4]" output="mem_8192x4_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:4]" out_port="mem_8192x4_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_8192x4_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_8192x4_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_8192x4_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_8192x4_dp.out1" output="memory.out[3:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out1" out_port="memory.out[3:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_8192x4_dp.out2" output="memory.out[7:4]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out2" out_port="memory.out[7:4]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_8192x4_dp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_16384x2_dp">    
-            <pb_type name="mem_16384x2_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="14" port_class="address1"/>     
-               <input name="addr2" num_pins="14" port_class="address2"/>     
-               <input name="data1" num_pins="2" port_class="data_in1"/>     
-               <input name="data2" num_pins="2" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="2" port_class="data_out1"/>     
-               <output name="out2" num_pins="2" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_16384x2_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_16384x2_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[13:0]" output="mem_16384x2_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[13:0]" out_port="mem_16384x2_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[3:2]" output="mem_16384x2_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:2]" out_port="mem_16384x2_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_16384x2_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_16384x2_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_16384x2_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_16384x2_dp.out1" output="memory.out[1:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out1" out_port="memory.out[1:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_16384x2_dp.out2" output="memory.out[3:2]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out2" out_port="memory.out[3:2]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_16384x2_dp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <mode name="mem_32768x1_dp">    
-            <pb_type name="mem_32768x1_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="addr1" num_pins="15" port_class="address1"/>     
-               <input name="addr2" num_pins="15" port_class="address2"/>     
-               <input name="data1" num_pins="1" port_class="data_in1"/>     
-               <input name="data2" num_pins="1" port_class="data_in2"/>     
-               <input name="we1" num_pins="1" port_class="write_en1"/>     
-               <input name="we2" num_pins="1" port_class="write_en2"/>     
-               <output name="out1" num_pins="1" port_class="data_out1"/>     
-               <output name="out2" num_pins="1" port_class="data_out2"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.addr1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.data1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.we1" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.addr2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.data2" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_32768x1_dp.we2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.addr1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.data1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.we1" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.addr2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.data2" clock="clk"/>     
-               <T_hold value="238e-12" port="mem_32768x1_dp.we2" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out1" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out2" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_dp.addr1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_dp.addr1"/>      
-               </direct>     
-               <direct name="address2" input="memory.addr2[14:0]" output="mem_32768x1_dp.addr2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[14:0]" out_port="mem_32768x1_dp.addr2"/>      
-               </direct>     
-               <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_dp.data1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_dp.data1"/>      
-               </direct>     
-               <direct name="data2" input="memory.data[1:1]" output="mem_32768x1_dp.data2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:1]" out_port="mem_32768x1_dp.data2"/>      
-               </direct>     
-               <direct name="writeen1" input="memory.we1" output="mem_32768x1_dp.we1">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_dp.we1"/>      
-               </direct>     
-               <direct name="writeen2" input="memory.we2" output="mem_32768x1_dp.we2">      
-                  <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_32768x1_dp.we2"/>      
-               </direct>     
-               <direct name="dataout1" input="mem_32768x1_dp.out1" output="memory.out[0:0]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out1" out_port="memory.out[0:0]"/>      
-               </direct>     
-               <direct name="dataout2" input="mem_32768x1_dp.out2" output="memory.out[1:1]">      
-                  <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out2" out_port="memory.out[1:1]"/>      
-               </direct>     
-               <complete name="clk" input="memory.clk" output="mem_32768x1_dp.clk">
-          </complete>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this memory block every 8 columns from (and including) the second column -->   
-         <power method="sum-of-children"/>   
-      </pb_type>  
-      <!-- Define fracturable memory end -->  
-   </complexblocklist> 
+      -->
+    <pb_type name="memory">
+      <input name="addr1" num_pins="15"/>
+      <input name="addr2" num_pins="15"/>
+      <input name="data" num_pins="64"/>
+      <input name="we1" num_pins="1"/>
+      <input name="we2" num_pins="1"/>
+      <output name="out" num_pins="64"/>
+      <clock name="clk" num_pins="8"/>
+      <!-- Physical mode of the fracturable memory -->
+      <mode name="physical">
+        <pb_type name="frac_mem_32k" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="15" port_class="address1"/>
+          <input name="addr2" num_pins="15" port_class="address2"/>
+          <input name="data1" num_pins="32" port_class="data_in1"/>
+          <input name="data2" num_pins="32" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="32" port_class="data_out1"/>
+          <output name="out2" num_pins="32" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="frac_mem_32k.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.data1" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.data2" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.we1" clock="clk"/>
+          <T_setup value="509e-12" port="frac_mem_32k.we2" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.data1" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.data2" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.we1" clock="clk"/>
+          <T_hold value="238e-12" port="frac_mem_32k.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="frac_mem_32k.out2" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="frac_mem_32k.addr1[14:0]"/>
+          <direct name="address2" input="memory.addr2[14:0]" output="frac_mem_32k.addr2[14:0]"/>
+          <direct name="data1" input="memory.data[31:0]" output="frac_mem_32k.data1"/>
+          <direct name="data2" input="memory.data[63:32]" output="frac_mem_32k.data2"/>
+          <direct name="writeen1" input="memory.we1" output="frac_mem_32k.we1"/>
+          <direct name="writeen2" input="memory.we2" output="frac_mem_32k.we2"/>
+          <direct name="dataout1" input="frac_mem_32k.out1" output="memory.out[31:0]"/>
+          <direct name="dataout2" input="frac_mem_32k.out2" output="memory.out[63:32]"/>
+          <complete name="clk" input="memory.clk" output="frac_mem_32k.clk"/>
+        </interconnect>
+      </mode>
+      <!-- Specify single port mode first -->
+      <mode name="mem_512x64_sp">
+        <pb_type name="mem_512x64_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="9" port_class="address"/>
+          <input name="data" num_pins="64" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="64" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_512x64_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[8:0]" output="mem_512x64_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[8:0]" out_port="mem_512x64_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[63:0]" output="mem_512x64_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:0]" out_port="mem_512x64_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_512x64_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_512x64_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_512x64_sp.out" output="memory.out[63:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_512x64_sp.out" out_port="memory.out[63:0]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_512x64_sp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_1024x32_sp">
+        <pb_type name="mem_1024x32_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="10" port_class="address"/>
+          <input name="data" num_pins="32" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_sp.out" output="memory.out[31:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_sp.out" out_port="memory.out[31:0]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_1024x32_sp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_sp">
+        <pb_type name="mem_2048x16_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="11" port_class="address"/>
+          <input name="data" num_pins="16" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="16" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_sp.out" output="memory.out[15:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_sp.out" out_port="memory.out[15:0]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_2048x16_sp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_4096x8_sp">
+        <pb_type name="mem_4096x8_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="12" port_class="address"/>
+          <input name="data" num_pins="8" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_4096x8_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_4096x8_sp.out" output="memory.out[7:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_sp.out" out_port="memory.out[7:0]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_4096x8_sp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_sp">
+        <pb_type name="mem_8192x4_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="13" port_class="address"/>
+          <input name="data" num_pins="4" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="4" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_sp.out" output="memory.out[3:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_sp.out" out_port="memory.out[3:0]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_8192x4_sp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_sp">
+        <pb_type name="mem_16384x2_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="14" port_class="address"/>
+          <input name="data" num_pins="2" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="2" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_sp.out" output="memory.out[1:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_sp.out" out_port="memory.out[1:0]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_16384x2_sp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_sp">
+        <pb_type name="mem_32768x1_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="15" port_class="address"/>
+          <input name="data" num_pins="1" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="1" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_sp.out" output="memory.out[0:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_sp.out" out_port="memory.out[0:0]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_32768x1_sp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <!-- Specify true dual port mode next -->
+      <mode name="mem_1024x32_dp">
+        <pb_type name="mem_1024x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="10" port_class="address1"/>
+          <input name="addr2" num_pins="10" port_class="address2"/>
+          <input name="data1" num_pins="32" port_class="data_in1"/>
+          <input name="data2" num_pins="32" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="32" port_class="data_out1"/>
+          <output name="out2" num_pins="32" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[9:0]" output="mem_1024x32_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[9:0]" out_port="mem_1024x32_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[63:32]" output="mem_1024x32_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:32]" out_port="mem_1024x32_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_1024x32_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_1024x32_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_dp.out1" output="memory.out[31:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out1" out_port="memory.out[31:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_1024x32_dp.out2" output="memory.out[63:32]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out2" out_port="memory.out[63:32]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_1024x32_dp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_dp">
+        <pb_type name="mem_2048x16_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="11" port_class="address1"/>
+          <input name="addr2" num_pins="11" port_class="address2"/>
+          <input name="data1" num_pins="16" port_class="data_in1"/>
+          <input name="data2" num_pins="16" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="16" port_class="data_out1"/>
+          <output name="out2" num_pins="16" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[10:0]" output="mem_2048x16_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[10:0]" out_port="mem_2048x16_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[31:16]" output="mem_2048x16_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:16]" out_port="mem_2048x16_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_2048x16_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_2048x16_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_dp.out1" output="memory.out[15:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out1" out_port="memory.out[15:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_2048x16_dp.out2" output="memory.out[31:16]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out2" out_port="memory.out[31:16]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_2048x16_dp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_4096x8_dp">
+        <pb_type name="mem_4096x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="12" port_class="address1"/>
+          <input name="addr2" num_pins="12" port_class="address2"/>
+          <input name="data1" num_pins="8" port_class="data_in1"/>
+          <input name="data2" num_pins="8" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="8" port_class="data_out1"/>
+          <output name="out2" num_pins="8" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[11:0]" output="mem_4096x8_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[11:0]" out_port="mem_4096x8_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[15:8]" output="mem_4096x8_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:8]" out_port="mem_4096x8_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_4096x8_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_4096x8_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_4096x8_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_4096x8_dp.out1" output="memory.out[7:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out1" out_port="memory.out[7:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_4096x8_dp.out2" output="memory.out[15:8]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_dp.out2" out_port="memory.out[15:8]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_4096x8_dp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_dp">
+        <pb_type name="mem_8192x4_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="13" port_class="address1"/>
+          <input name="addr2" num_pins="13" port_class="address2"/>
+          <input name="data1" num_pins="4" port_class="data_in1"/>
+          <input name="data2" num_pins="4" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="4" port_class="data_out1"/>
+          <output name="out2" num_pins="4" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[12:0]" output="mem_8192x4_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[12:0]" out_port="mem_8192x4_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[7:4]" output="mem_8192x4_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:4]" out_port="mem_8192x4_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_8192x4_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_8192x4_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_dp.out1" output="memory.out[3:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out1" out_port="memory.out[3:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_8192x4_dp.out2" output="memory.out[7:4]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out2" out_port="memory.out[7:4]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_8192x4_dp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_dp">
+        <pb_type name="mem_16384x2_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="14" port_class="address1"/>
+          <input name="addr2" num_pins="14" port_class="address2"/>
+          <input name="data1" num_pins="2" port_class="data_in1"/>
+          <input name="data2" num_pins="2" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="2" port_class="data_out1"/>
+          <output name="out2" num_pins="2" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[13:0]" output="mem_16384x2_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[13:0]" out_port="mem_16384x2_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[3:2]" output="mem_16384x2_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:2]" out_port="mem_16384x2_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_16384x2_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_16384x2_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_dp.out1" output="memory.out[1:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out1" out_port="memory.out[1:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_16384x2_dp.out2" output="memory.out[3:2]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out2" out_port="memory.out[3:2]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_16384x2_dp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_dp">
+        <pb_type name="mem_32768x1_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="15" port_class="address1"/>
+          <input name="addr2" num_pins="15" port_class="address2"/>
+          <input name="data1" num_pins="1" port_class="data_in1"/>
+          <input name="data2" num_pins="1" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="1" port_class="data_out1"/>
+          <output name="out2" num_pins="1" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[14:0]" output="mem_32768x1_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[14:0]" out_port="mem_32768x1_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[1:1]" output="mem_32768x1_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:1]" out_port="mem_32768x1_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_32768x1_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_32768x1_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_dp.out1" output="memory.out[0:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out1" out_port="memory.out[0:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_32768x1_dp.out2" output="memory.out[1:1]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out2" out_port="memory.out[1:1]"/>
+          </direct>
+          <complete name="clk" input="memory.clk" output="mem_32768x1_dp.clk">
+          </complete>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this memory block every 8 columns from (and including) the second column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_aib_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_aib_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,172 +86,180 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <!-- AIB interface model -->  
-      <model name="aib">   
-         <input_ports>    
-            <port name="tx_clk" is_clock="1"/>    
-            <port name="rx_clk" is_clock="1"/>    
-            <port name="tx_data" clock="tx_clk"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="rx_data" clock="rx_clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- A mini AIB interface to be located at the right side of the FPGA
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+    <!-- AIB interface model -->
+    <model name="aib">
+      <input_ports>
+        <port name="tx_clk" is_clock="1"/>
+        <port name="rx_clk" is_clock="1"/>
+        <port name="tx_data" clock="tx_clk"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="rx_data" clock="rx_clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- A mini AIB interface to be located at the right side of the FPGA
          All the port will be accessible to the left side of the tile
          TODO: add full control signals
          TODO: add analog bus ports to the right side which should be GPIOs
-      -->  
-      <tile name="aib" width="1" height="4" area="0">   <sub_tile name="aib">    
-          <equivalent_sites>     
-             <site pb_type="aib"/>     
-          </equivalent_sites>    
-          <clock name="tx_clk" num_pins="1"/>    
-          <input name="tx_data" num_pins="80"/>    
-          <clock name="rx_clk" num_pins="1"/>    
-          <output name="rx_data" num_pins="80"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">aib.tx_clk aib.tx_data aib.rx_clk aib.rx_data</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="d_in" num_pins="32"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="32"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="10"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="1"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-         <!-- Single instance of an AIB interface -->   
-         <single type="aib" x="4" y="1" priority="20"/>   
-      </auto_layout>  
-      <fixed_layout name="3x4" width="5" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="10"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="1"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-         <!-- Single instance of an AIB interface -->   
-         <single type="aib" x="4" y="1" priority="20"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+      -->
+    <tile name="aib" width="1" height="4" area="0">
+      <sub_tile name="aib">
+        <equivalent_sites>
+          <site pb_type="aib"/>
+        </equivalent_sites>
+        <clock name="tx_clk" num_pins="1"/>
+        <input name="tx_data" num_pins="80"/>
+        <clock name="rx_clk" num_pins="1"/>
+        <output name="rx_data" num_pins="80"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">aib.tx_clk aib.tx_data aib.rx_clk aib.rx_data</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="d_in" num_pins="32"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="32"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="10"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="1"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+      <!-- Single instance of an AIB interface -->
+      <single type="aib" x="4" y="1" priority="20"/>
+    </auto_layout>
+    <fixed_layout name="3x4" width="5" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="10"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="1"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+      <!-- Single instance of an AIB interface -->
+      <single type="aib" x="4" y="1" priority="20"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -263,21 +273,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -289,125 +299,122 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define AIB begin -->  
-      <pb_type name="aib">   
-         <clock name="tx_clk" num_pins="1"/>   
-         <input name="tx_data" num_pins="80"/>   
-         <clock name="rx_clk" num_pins="1"/>   
-         <output name="rx_data" num_pins="80"/>   
-         <mode name="physical">    
-            <pb_type name="aib_core" blif_model=".subckt aib" num_pb="1">     
-               <clock name="tx_clk" num_pins="1"/>     
-               <input name="tx_data" num_pins="80"/>     
-               <clock name="rx_clk" num_pins="1"/>     
-               <output name="rx_data" num_pins="80"/>     
-               <T_setup value="509e-12" port="aib_core.tx_data" clock="tx_clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="aib_core.tx_data" clock="tx_clk"/>     
-               <T_setup value="509e-12" port="aib_core.rx_data" clock="rx_clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="aib_core.rx_data" clock="rx_clk"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="tx_clk" input="aib.tx_clk" output="aib_core.tx_clk">      
-                  <delay_constant max="1.394e-11" in_port="aib.tx_clk" out_port="aib_core.tx_clk"/>      
-               </direct>     
-               <direct name="rx_clk" input="aib.rx_clk" output="aib_core.rx_clk">      
-                  <delay_constant max="1.394e-11" in_port="aib.rx_clk" out_port="aib_core.rx_clk"/>      
-               </direct>     
-               <direct name="tx_data" input="aib.tx_data" output="aib_core.tx_data">      
-                  <delay_constant max="1.394e-11" in_port="aib.tx_data" out_port="aib_core.tx_data"/>      
-               </direct>     
-               <direct name="rx_data" input="aib_core.rx_data" output="aib.rx_data">      
-                  <delay_constant max="4.243e-11" in_port="aib_core.rx_data" out_port="aib.rx_data"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-      </pb_type>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define AIB begin -->
+    <pb_type name="aib">
+      <clock name="tx_clk" num_pins="1"/>
+      <input name="tx_data" num_pins="80"/>
+      <clock name="rx_clk" num_pins="1"/>
+      <output name="rx_data" num_pins="80"/>
+      <mode name="physical">
+        <pb_type name="aib_core" blif_model=".subckt aib" num_pb="1">
+          <clock name="tx_clk" num_pins="1"/>
+          <input name="tx_data" num_pins="80"/>
+          <clock name="rx_clk" num_pins="1"/>
+          <output name="rx_data" num_pins="80"/>
+          <T_setup value="509e-12" port="aib_core.tx_data" clock="tx_clk"/>
+          <T_clock_to_Q max="1.234e-9" port="aib_core.tx_data" clock="tx_clk"/>
+          <T_setup value="509e-12" port="aib_core.rx_data" clock="rx_clk"/>
+          <T_clock_to_Q max="1.234e-9" port="aib_core.rx_data" clock="rx_clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="tx_clk" input="aib.tx_clk" output="aib_core.tx_clk">
+            <delay_constant max="1.394e-11" in_port="aib.tx_clk" out_port="aib_core.tx_clk"/>
+          </direct>
+          <direct name="rx_clk" input="aib.rx_clk" output="aib_core.rx_clk">
+            <delay_constant max="1.394e-11" in_port="aib.rx_clk" out_port="aib_core.rx_clk"/>
+          </direct>
+          <direct name="tx_data" input="aib.tx_data" output="aib_core.tx_data">
+            <delay_constant max="1.394e-11" in_port="aib.tx_data" out_port="aib_core.tx_data"/>
+          </direct>
+          <direct name="rx_data" input="aib_core.rx_data" output="aib.rx_data">
+            <delay_constant max="4.243e-11" in_port="aib_core.rx_data" out_port="aib.rx_data"/>
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -415,255 +422,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -671,45 +678,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -717,93 +724,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="d_in" num_pins="32"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="32"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 512x32=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="d_in" num_pins="32"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="32"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 512x32=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_512x32_dp">    
-            <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address"/>     
-               <input name="raddr" num_pins="10" port_class="address"/>     
-               <input name="d_in" num_pins="32" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_512x32_dp">
+        <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address"/>
+          <input name="raddr" num_pins="10" port_class="address"/>
+          <input name="d_in" num_pins="32" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_multi_io_capacity_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_multi_io_capacity_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,175 +86,186 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io_top" area="0">   <sub_tile name="io_top" capacity="3">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="bottom">io_top.outpad io_top.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="io_right" area="0">   <sub_tile name="io_right" capacity="2">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io_right.outpad io_right.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="io_bottom" area="0">   <sub_tile name="io_bottom" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="top">io_bottom.outpad io_bottom.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="io_left" area="0">   <sub_tile name="io_left" capacity="4">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="right">io_left.outpad io_left.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="d_in" num_pins="32"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="32"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <row type="io_top" starty="H-1" priority="100"/>   
-         <row type="io_bottom" starty="0" priority="100"/>   
-         <col type="io_left" startx="0" priority="100"/>   
-         <col type="io_right" startx="W-1" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io_top" area="0">
+      <sub_tile name="io_top" capacity="3">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_right" area="0">
+      <sub_tile name="io_right" capacity="2">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io_right.outpad io_right.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_bottom" area="0">
+      <sub_tile name="io_bottom" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_left" area="0">
+      <sub_tile name="io_left" capacity="4">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="right">io_left.outpad io_left.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="d_in" num_pins="32"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="32"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="100"/>
+      <row type="io_bottom" starty="0" priority="100"/>
+      <col type="io_left" startx="0" priority="100"/>
+      <col type="io_right" startx="W-1" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -266,21 +279,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -292,91 +305,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -384,255 +395,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -640,45 +651,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -686,93 +697,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="d_in" num_pins="32"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="32"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 512x32=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="d_in" num_pins="32"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="32"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 512x32=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_512x32_dp">    
-            <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address"/>     
-               <input name="raddr" num_pins="10" port_class="address"/>     
-               <input name="d_in" num_pins="32" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_512x32_dp">
+        <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address"/>
+          <input name="raddr" num_pins="10" port_class="address"/>
+          <input name="d_in" num_pins="32" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_reduced_io_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem16K_reduced_io_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,142 +86,148 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="d_in" num_pins="32"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="32"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="10"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="1"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-         <row type="EMPTY" starty="H-1" priority="11"/>   
-         <row type="EMPTY" starty="0" priority="11"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="10"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="1"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-         <row type="EMPTY" starty="H-1" priority="11"/>   
-         <row type="EMPTY" starty="0" priority="11"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="d_in" num_pins="32"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="32"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="10"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="1"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+      <row type="EMPTY" starty="H-1" priority="11"/>
+      <row type="EMPTY" starty="0" priority="11"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="10"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="1"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+      <row type="EMPTY" starty="H-1" priority="11"/>
+      <row type="EMPTY" starty="0" priority="11"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -233,21 +241,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -259,91 +267,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -351,255 +357,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -607,45 +613,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -653,93 +659,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="d_in" num_pins="32"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="32"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 512x32=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="d_in" num_pins="32"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="32"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 512x32=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_512x32_dp">    
-            <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address"/>     
-               <input name="raddr" num_pins="10" port_class="address"/>     
-               <input name="d_in" num_pins="32" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_512x32_dp">
+        <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address"/>
+          <input name="raddr" num_pins="10" port_class="address"/>
+          <input name="d_in" num_pins="32" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem1K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_mem1K_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,147 +86,153 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dpram_128x8">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="7"/>    
-          <input name="raddr" num_pins="7"/>    
-          <input name="data_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="data_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="custom">     
-             <loc side="left" yoffset="0">memory.clk</loc>     
-             <loc side="top" yoffset="1"/>     
-             <loc side="right" yoffset="0">memory.wen memory.waddr[0:2] memory.raddr[0:2] memory.data_in[0:2] memory.data_out[0:2]</loc>     
-             <loc side="right" yoffset="1">memory.ren memory.waddr[3:5] memory.raddr[3:5] memory.data_in[3:5] memory.data_out[3:5]</loc>     
-             <loc side="bottom" yoffset="0">memory.waddr[6:6] memory.raddr[6:6] memory.data_in[6:7] memory.data_out[6:7]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="3x2" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dpram_128x8">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="7"/>
+        <input name="raddr" num_pins="7"/>
+        <input name="data_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="data_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left" yoffset="0">memory.clk</loc>
+          <loc side="top" yoffset="1"/>
+          <loc side="right" yoffset="0">memory.wen memory.waddr[0:2] memory.raddr[0:2] memory.data_in[0:2] memory.data_out[0:2]</loc>
+          <loc side="right" yoffset="1">memory.ren memory.waddr[3:5] memory.raddr[3:5] memory.data_in[3:5] memory.data_out[3:5]</loc>
+          <loc side="bottom" yoffset="0">memory.waddr[6:6] memory.raddr[6:6] memory.data_in[6:7] memory.data_out[6:7]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -238,21 +246,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -264,91 +272,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -356,255 +362,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -612,45 +618,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -658,93 +664,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="7"/>   
-         <input name="raddr" num_pins="7"/>   
-         <input name="data_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="data_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 128x8=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="7"/>
+      <input name="raddr" num_pins="7"/>
+      <input name="data_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="data_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 128x8=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_128x8_dp">    
-            <pb_type name="mem_128x8_dp" blif_model=".subckt dpram_128x8" num_pb="1">     
-               <input name="waddr" num_pins="7" port_class="address1"/>     
-               <input name="raddr" num_pins="7" port_class="address2"/>     
-               <input name="data_in" num_pins="8" port_class="data_in1"/>     
-               <input name="wen" num_pins="1" port_class="write_en1"/>     
-               <input name="ren" num_pins="1" port_class="write_en2"/>     
-               <output name="data_out" num_pins="8" port_class="data_out1"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.data_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.data_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.data_in" output="mem_128x8_dp.data_in">      
-                  <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_128x8_dp.data_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_128x8_dp.data_out" output="memory.data_out">      
-                  <delay_constant max="40e-12" in_port="mem_128x8_dp.data_out" out_port="memory.data_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_128x8_dp">
+        <pb_type name="mem_128x8_dp" blif_model=".subckt dpram_128x8" num_pb="1">
+          <input name="waddr" num_pins="7" port_class="address1"/>
+          <input name="raddr" num_pins="7" port_class="address2"/>
+          <input name="data_in" num_pins="8" port_class="data_in1"/>
+          <input name="wen" num_pins="1" port_class="write_en1"/>
+          <input name="ren" num_pins="1" port_class="write_en2"/>
+          <output name="data_out" num_pins="8" port_class="data_out1"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.data_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.data_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.data_in" output="mem_128x8_dp.data_in">
+            <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_128x8_dp.data_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_128x8_dp.data_out" output="memory.data_out">
+            <delay_constant max="40e-12" in_port="mem_128x8_dp.data_out" out_port="memory.data_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_wide_mem1K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_wide_mem1K_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,150 +86,156 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dpram_128x8">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="data_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" width="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="7"/>    
-          <input name="raddr" num_pins="7"/>    
-          <input name="data_in" num_pins="8"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="data_out" num_pins="8"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="clk" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <pinlocations pattern="custom">     
-             <loc side="left" yoffset="0">memory.clk memory.waddr[0:0] memory.raddr[0:0] memory.data_in[0:0] memory.data_out[0:0]</loc>     
-             <loc side="left" yoffset="1">memory.waddr[1:1] memory.raddr[1:1] memory.data_in[1:1] memory.data_out[1:1]</loc>     
-             <loc side="top" xoffset="0" yoffset="1">memory.waddr[2:2] memory.raddr[2:2] memory.data_in[2:2] memory.data_out[2:2]</loc>     
-             <loc side="top" xoffset="1" yoffset="1">memory.waddr[3:3] memory.raddr[3:3] memory.data_in[3:3] memory.data_out[3:3]</loc>     
-             <loc side="right" xoffset="1" yoffset="0">memory.waddr[4:4] memory.raddr[4:4] memory.data_in[4:4] memory.data_out[4:4]</loc>     
-             <loc side="right" xoffset="1" yoffset="1">memory.waddr[5:5] memory.raddr[5:5] memory.data_in[5:5] memory.data_out[5:5]</loc>     
-             <loc side="bottom" xoffset="0">memory.wen memory.waddr[6:6] memory.raddr[6:6] memory.data_in[6:6] memory.data_out[6:6]</loc>     
-             <loc side="bottom" xoffset="1">memory.ren memory.data_in[7:7] memory.data_out[7:7]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="false">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="4x2" width="6" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dpram_128x8">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" width="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="7"/>
+        <input name="raddr" num_pins="7"/>
+        <input name="data_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="data_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left" yoffset="0">memory.clk memory.waddr[0:0] memory.raddr[0:0] memory.data_in[0:0] memory.data_out[0:0]</loc>
+          <loc side="left" yoffset="1">memory.waddr[1:1] memory.raddr[1:1] memory.data_in[1:1] memory.data_out[1:1]</loc>
+          <loc side="top" xoffset="0" yoffset="1">memory.waddr[2:2] memory.raddr[2:2] memory.data_in[2:2] memory.data_out[2:2]</loc>
+          <loc side="top" xoffset="1" yoffset="1">memory.waddr[3:3] memory.raddr[3:3] memory.data_in[3:3] memory.data_out[3:3]</loc>
+          <loc side="right" xoffset="1" yoffset="0">memory.waddr[4:4] memory.raddr[4:4] memory.data_in[4:4] memory.data_out[4:4]</loc>
+          <loc side="right" xoffset="1" yoffset="1">memory.waddr[5:5] memory.raddr[5:5] memory.data_in[5:5] memory.data_out[5:5]</loc>
+          <loc side="bottom" xoffset="0">memory.wen memory.waddr[6:6] memory.raddr[6:6] memory.data_in[6:6] memory.data_out[6:6]</loc>
+          <loc side="bottom" xoffset="1">memory.ren memory.data_in[7:7] memory.data_out[7:7]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="4x2" width="6" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -241,21 +249,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -267,91 +275,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -359,255 +365,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -615,45 +621,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -661,93 +667,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="7"/>   
-         <input name="raddr" num_pins="7"/>   
-         <input name="data_in" num_pins="8"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="data_out" num_pins="8"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 128x8=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="7"/>
+      <input name="raddr" num_pins="7"/>
+      <input name="data_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="data_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 128x8=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_128x8_dp">    
-            <pb_type name="mem_128x8_dp" blif_model=".subckt dpram_128x8" num_pb="1">     
-               <input name="waddr" num_pins="7" port_class="address1"/>     
-               <input name="raddr" num_pins="7" port_class="address2"/>     
-               <input name="data_in" num_pins="8" port_class="data_in1"/>     
-               <input name="wen" num_pins="1" port_class="write_en1"/>     
-               <input name="ren" num_pins="1" port_class="write_en2"/>     
-               <output name="data_out" num_pins="8" port_class="data_out1"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.data_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.data_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.data_in" output="mem_128x8_dp.data_in">      
-                  <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_128x8_dp.data_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_128x8_dp.data_out" output="memory.data_out">      
-                  <delay_constant max="40e-12" in_port="mem_128x8_dp.data_out" out_port="memory.data_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_128x8_dp">
+        <pb_type name="mem_128x8_dp" blif_model=".subckt dpram_128x8" num_pb="1">
+          <input name="waddr" num_pins="7" port_class="address1"/>
+          <input name="raddr" num_pins="7" port_class="address2"/>
+          <input name="data_in" num_pins="8" port_class="data_in1"/>
+          <input name="wen" num_pins="1" port_class="write_en1"/>
+          <input name="ren" num_pins="1" port_class="write_en2"/>
+          <output name="data_out" num_pins="8" port_class="data_out1"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.data_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.data_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.data_in" output="mem_128x8_dp.data_in">
+            <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_128x8_dp.data_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_128x8_dp.data_out" output="memory.data_out">
+            <delay_constant max="40e-12" in_port="mem_128x8_dp.data_out" out_port="memory.data_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_chain_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,102 +86,106 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="regin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <output name="regout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="regin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="regout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin clb.regin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.regout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="regin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="regout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin clb.regin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.regout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -193,21 +199,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -219,92 +225,90 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -312,268 +316,268 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="regin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <output name="regout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <input name="regin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <output name="regout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="regin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <output name="regout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct3" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct4" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct5" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout frac_logic.out[0] fabric.regin" output="ff[0].D">        
-                        <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[0] fabric.regin" out_port="ff[0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout frac_logic.out[1] ff[0].Q" output="ff[1].D">        
-                        <delay_constant max="25e-12" in_port="adder[1].sumout frac_logic.out[1] ff[0].Q" out_port="ff[1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fle.regin" output="fabric.regin"/>      
-                  <direct name="direct4" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct5" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct6" input="fabric.regout" output="fle.regout"/>      
-                  <direct name="direct7" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="regin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct4" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct5" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct6" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct7" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct8" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout frac_logic.out[0] fabric.regin" output="ff[0].D">
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[0] fabric.regin" out_port="ff[0].D"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout frac_logic.out[1] ff[0].Q" output="ff[1].D">
+                <delay_constant max="25e-12" in_port="adder[1].sumout frac_logic.out[1] ff[0].Q" out_port="ff[1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fle.regin" output="fabric.regin"/>
+            <direct name="direct4" input="fabric.out" output="fle.out"/>
+            <direct name="direct5" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct6" input="fabric.regout" output="fle.regout"/>
+            <direct name="direct7" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -581,72 +585,72 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n1_lut6 end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="regin" num_pins="1"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>      
-                  <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>      
-                  <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define n1_lut6 end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="regin" num_pins="1"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>
+            <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>
+            <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -654,47 +658,46 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-               <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-            </direct>    
-            <direct name="shift_register_out" input="fle[9:9].regout" output="clb.regout">     
-               <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>     
-            </direct>    
-            <direct name="shift_register_link" input="fle[8:0].regout" output="fle[9:1].regin">     
-               <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>
+          <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>
+        </direct>
+        <direct name="shift_register_out" input="fle[9:9].regout" output="clb.regout">
+          <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>
+        </direct>
+        <direct name="shift_register_link" input="fle[8:0].regout" output="fle[9:1].regin">
+          <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,117 +86,121 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for fractruable LUT to be used in the physical mode of LUT -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="DI" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="regin" num_pins="1"/>    
-          <input name="scin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <output name="regout" num_pins="1"/>    
-          <output name="scout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="regin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="regout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="scin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="scout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin clb.regin clb.scin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.regout clb.scout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for fractruable LUT to be used in the physical mode of LUT -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="DI" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <input name="scin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <output name="scout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="regin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="regout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="scin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="scout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin clb.regin clb.scin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.regout clb.scout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -208,21 +214,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -234,93 +240,91 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <direct name="scan_chain" from_pin="clb.scout" to_pin="clb.scin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="shift_register" from_pin="clb.regout" to_pin="clb.regin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <direct name="scan_chain" from_pin="clb.scout" to_pin="clb.scin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -328,281 +332,281 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="regin" num_pins="1"/>   
-         <input name="scin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <output name="regout" num_pins="1"/>   
-         <output name="scout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <input name="regin" num_pins="1"/>
+      <input name="scin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <output name="regout" num_pins="1"/>
+      <output name="scout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="regin" num_pins="1"/>    
-            <input name="scin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <output name="regout" num_pins="1"/>    
-            <output name="scout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="scin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <output name="scout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->      
-                  <pb_type name="ff" blif_model=".subckt scff" num_pb="2">       
-                     <input name="D" num_pins="1"/>       
-                     <input name="DI" num_pins="1"/>       
-                     <output name="Q" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_setup value="66e-12" port="ff.DI" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct3" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct4" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct5" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <direct name="direct9" input="fabric.scin" output="ff[0].DI"/>       
-                     <direct name="direct10" input="ff[0].Q" output="ff[1].DI"/>       
-                     <direct name="direct11" input="ff[1].Q" output="fabric.scout"/>       
-                     <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout frac_logic.out[0] fabric.regin" output="ff[0].D">        
-                        <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[0] fabric.regin" out_port="ff[0].D"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout frac_logic.out[1] ff[0].Q" output="ff[1].D">        
-                        <delay_constant max="25e-12" in_port="adder[1].sumout frac_logic.out[1] ff[0].Q" out_port="ff[1].D"/>        
-                     </mux>       
-                     <mux name="mux3" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux4" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fle.regin" output="fabric.regin"/>      
-                  <direct name="direct4" input="fle.scin" output="fabric.scin"/>      
-                  <direct name="direct5" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct6" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct7" input="fabric.regout" output="fle.regout"/>      
-                  <direct name="direct8" input="fabric.scout" output="fle.scout"/>      
-                  <direct name="direct9" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <input name="scin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <output name="scout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="regin" num_pins="1"/>
+            <input name="scin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <output name="regout" num_pins="1"/>
+            <output name="scout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+            <pb_type name="ff" blif_model=".subckt scff" num_pb="2">
+              <input name="D" num_pins="1"/>
+              <input name="DI" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct4" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct5" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct6" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct7" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct8" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <direct name="direct9" input="fabric.scin" output="ff[0].DI"/>
+              <direct name="direct10" input="ff[0].Q" output="ff[1].DI"/>
+              <direct name="direct11" input="ff[1].Q" output="fabric.scout"/>
+              <complete name="complete1" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout frac_logic.out[0] fabric.regin" output="ff[0].D">
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[0] fabric.regin" out_port="ff[0].D"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout frac_logic.out[1] ff[0].Q" output="ff[1].D">
+                <delay_constant max="25e-12" in_port="adder[1].sumout frac_logic.out[1] ff[0].Q" out_port="ff[1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fle.regin" output="fabric.regin"/>
+            <direct name="direct4" input="fle.scin" output="fabric.scin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct7" input="fabric.regout" output="fle.regout"/>
+            <direct name="direct8" input="fabric.scout" output="fle.scout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -610,72 +614,72 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n1_lut6 end -->    
-            <!-- Define shift register begin -->    
-            <mode name="shift_register">     
-               <pb_type name="shift_reg" num_pb="1">      
-                  <input name="regin" num_pins="1"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>       
-                     <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>       
-                     <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>      
-                  <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>      
-                  <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define shift register end -->     
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define n1_lut6 end -->
+        <!-- Define shift register begin -->
+        <mode name="shift_register">
+          <pb_type name="shift_reg" num_pb="1">
+            <input name="regin" num_pins="1"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="shift_reg.regin" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D"/>
+              <direct name="direct3" input="ff[1].Q" output="shift_reg.regout"/>
+              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="shift_reg.regin"/>
+            <direct name="direct2" input="shift_reg.regout" output="fle.regout"/>
+            <direct name="direct3" input="fle.clk" output="shift_reg.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift register end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -683,56 +687,55 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-            <!-- Shift register chain links -->    
-            <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-               <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-            </direct>    
-            <direct name="shift_register_out" input="fle[9:9].regout" output="clb.regout">     
-               <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>     
-            </direct>    
-            <direct name="shift_register_link" input="fle[8:0].regout" output="fle[9:1].regin">     
-               <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="scan_chain_in" input="clb.scin" output="fle[0:0].scin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.scin" out_port="fle[0:0].scin"/>     
-            </direct>    
-            <direct name="scan_chain_out" input="fle[9:9].scout" output="clb.scout">
-        </direct>    
-            <direct name="scan_chain_link" input="fle[8:0].scout" output="fle[9:1].scin">
-        </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+        <!-- Shift register chain links -->
+        <direct name="shift_register_in" input="clb.regin" output="fle[0:0].regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>
+          <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>
+        </direct>
+        <direct name="shift_register_out" input="fle[9:9].regout" output="clb.regout">
+          <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>
+        </direct>
+        <direct name="shift_register_link" input="fle[8:0].regout" output="fle[9:1].regin">
+          <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="scan_chain_in" input="clb.scin" output="fle[0:0].scin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.scin" out_port="fle[0:0].scin"/>
+        </direct>
+        <direct name="scan_chain_out" input="fle[9:9].scout" output="clb.scout">
+        </direct>
+        <direct name="scan_chain_link" input="fle[8:0].scout" output="fle[9:1].scin">
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_40nm.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0" ?><!-- Homogeneous FPGA Architecture with Carry Chain for VPR8
+<?xml version="1.0"?>
+<!-- Homogeneous FPGA Architecture with Carry Chain for VPR8
 
   - The chip layout is organized with a 2x2 array of Configurable Logic Blocks (CLBs)
     surrounded by a ring of I/Os
   - [TODO] Delay numbers are extracted from a 12 nm technology
   Author: Xifan Tang, Aurelien Alacchi and Ganesh Gore
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -13,260 +15,262 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="shift">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="D_chain" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Each I/O tile includes a GPIO -->   
-      <!-- IOs go on the periphery of the FPGA, for consistency, 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="shift">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="D_chain" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Each I/O tile includes a GPIO -->
+    <!-- IOs go on the periphery of the FPGA, for consistency, 
          make it physically equivalent on all sides so that only one definition of I/Os is needed.
          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-      -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <!-- Each input of the tile can be driven by 15% of routing tracks
+      -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <!-- Each input of the tile can be driven by 15% of routing tracks
            Each output of the tile can drive 10% of routing tracks
-        -->    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Each CLB tile includes a Configurable Logic Block (CLB)
+        -->
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Each CLB tile includes a Configurable Logic Block (CLB)
          Each input of the tile can be driven by 15% of routing tracks
          Each output of the tile can drive 10% of routing tracks
-      -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="10" equivalent="full"/>    
-          <input name="I1" num_pins="10" equivalent="full"/>    
-          <input name="I2" num_pins="10" equivalent="full"/>    
-          <input name="I3" num_pins="10" equivalent="full"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="cin_trick" num_pins="1"/>    
-          <input name="regin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <output name="cout_copy" num_pins="1"/>    
-          <output name="regout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <!-- Each input of the tile can be driven by 15% of routing tracks
+      -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="10" equivalent="full"/>
+        <input name="I1" num_pins="10" equivalent="full"/>
+        <input name="I2" num_pins="10" equivalent="full"/>
+        <input name="I3" num_pins="10" equivalent="full"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="cin_trick" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <output name="cout_copy" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Each input of the tile can be driven by 15% of routing tracks
            Each output of the tile can drive 10% of routing tracks
            There are four pins (cin, cout, sc_in, sc_out) has not connection 
            to routing tracks. There are directed wired from/to adjacent CLBs
-        -->    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!-- Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
+        -->
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!-- Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
            We keep all the pins that touch routing architecture on the right and bottom sides of the tile
            Top side pins are mainly for direct connections
-        -->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">clb.sc_in clb.cin clb.cin_trick clb.regin clb.clk</loc>     
-             <loc side="right">clb.I0[9:0] clb.I1[9:0] clb.O[9:0]</loc>     
-             <loc side="bottom">clb.cout clb.cout_copy clb.sc_out clb.regout clb.I2[9:0] clb.I3[9:0] clb.O[19:10]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <!-- Apply tileable routing architecture.
+        -->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">clb.sc_in clb.cin clb.cin_trick clb.regin clb.clk</loc>
+          <loc side="right">clb.I0[9:0] clb.I1[9:0] clb.O[9:0]</loc>
+          <loc side="bottom">clb.cout clb.cout_copy clb.sc_out clb.regout clb.I2[9:0] clb.I3[9:0] clb.O[19:10]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <!-- Apply tileable routing architecture.
        This is strongly recommended if you want to PnR large FPGA fabric
-    --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <!-- Apply a fixed layout of 96x96 core array.
+    -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <!-- Apply a fixed layout of 96x96 core array.
          VPR8 considers the I/O ring in the array size
          Therefore the height and width are both 34
-      -->  
-      <fixed_layout name="96x96" width="98" height="98">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-      <!-- Apply a fixed layout of 48x48 core array.
+      -->
+    <fixed_layout name="96x96" width="98" height="98">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <!-- Apply a fixed layout of 48x48 core array.
          VPR8 considers the I/O ring in the array size
          Therefore the height and width are both 34
-      -->  
-      <fixed_layout name="48x48" width="50" height="50">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+      -->
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
          area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-      -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <!-- Use Wilton-style connecting pattern in switch block 
+      -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <!-- Use Wilton-style connecting pattern in switch block 
          Each routing track has access to only three other routing tracks
          (one per each side of the switch block except the side where the routing track locates)
-      -->  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <!-- Uni-directional routing architecture using only length-4 wires in routing channels -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <!-- Hard adder chain inside CLB is directly connected between adjacent CLBs -->  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <!-- Scan chain inside CLB is directly connected between adjacent CLBs -->  
-      <direct name="scff_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+      -->
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <!-- Uni-directional routing architecture using only length-4 wires in routing channels -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <!-- Hard adder chain inside CLB is directly connected between adjacent CLBs -->
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <!-- Scan chain inside CLB is directly connected between adjacent CLBs -->
+    <direct name="scff_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
        Delays below come from Ian Kuon. They are small, so they should be interpreted as
        the delays to and from registers in the I/O (and generally I/Os are registered 
        today and that is when you timing analyze them.
-       -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define multi-mode Configurable Logic Block (CLB) begin -->  
-      <!-- Technical highlight:
+       -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define multi-mode Configurable Logic Block (CLB) begin -->
+    <!-- Technical highlight:
          K6_frac_N10_I40_chain_shiftreg_depop50
          - K6_frac: Each Logic Element (LE) contains a fracturable 6 LUT,
                     which can operate as one 6-LUT or two 5-LUTs or four 4-LUTs 
@@ -280,416 +284,409 @@
          - shiftreg: Flip-flops inside CLB can be configured as shift registers.
                      The organization is similar the hard adder chain except it is programmable
          - depop50: every local routing multiplexer accesses to 50% of the CLB inputs
-      -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="10" equivalent="full"/>   
-         <input name="I1" num_pins="10" equivalent="full"/>   
-         <input name="I2" num_pins="10" equivalent="full"/>   
-         <input name="I3" num_pins="10" equivalent="full"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="cin_trick" num_pins="1"/>   
-         <input name="regin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <output name="cout_copy" num_pins="1"/>   
-         <output name="regout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-
-         <!-- Describe fracturable logic element -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="regin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="regout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-
-            <!-- Describe physical mode begins -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="frac_logic" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="regchain" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="lut5_out" num_pins="2"/>       
-                     <output name="lut6_out" num_pins="1"/>       
-                  </pb_type>      
-                  <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>       
-                     <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>       
-                     <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>       
-                     <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>       
-                     <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>       
-                     <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>       
-                     <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>       
-                     <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>       
-                     <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
-              </mux>       
-                     <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">      
-                  <input name="D" num_pins="1"/>      
-                  <input name="D_chain" num_pins="1"/>      
-                  <output name="Q" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>      
-                  <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>      
-               </pb_type>     
-               <interconnect>      
-                  <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>      
-                  <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>      
-                  <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>      
-                  <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>      
-                  <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>      
-                  <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>      
-                  <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>      
-                  <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>      
-                  <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>      
-                  <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>      
-                  <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>      
-                  <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>      
-                  <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
-            </mux>      
-                  <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
-            </mux>      
-               </interconnect>     
-            </mode>    
-            <!-- Define physical mode begins -->    
-            <!-- Define n2_lut5 mode begins -->    
-            <mode name="n2_lut5" disable_packing="false">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <mode name="blut5">        
-                        <pb_type name="flut5" num_pb="1">         
-                           <input name="in" num_pins="5"/>         
-                           <output name="out" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Regular LUT mode -->         
-                           <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">          
-                              <input name="in" num_pins="5" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+      -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="10" equivalent="full"/>
+      <input name="I1" num_pins="10" equivalent="full"/>
+      <input name="I2" num_pins="10" equivalent="full"/>
+      <input name="I3" num_pins="10" equivalent="full"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="cin_trick" num_pins="1"/>
+      <input name="regin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <output name="cout_copy" num_pins="1"/>
+      <output name="regout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Describe physical mode begins -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="frac_logic" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="regin" num_pins="1"/>
+            <input name="regchain" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="lut5_out" num_pins="2"/>
+              <output name="lut6_out" num_pins="1"/>
+            </pb_type>
+            <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>
+              <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>
+              <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>
+              <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>
+              <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>
+              <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>
+              <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>
+              <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>
+              <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
+              </mux>
+              <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
+            <input name="D" num_pins="1"/>
+            <input name="D_chain" num_pins="1"/>
+            <output name="Q" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>
+            <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>
+          </pb_type>
+          <interconnect>
+            <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>
+            <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>
+            <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>
+            <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>
+            <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>
+            <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>
+            <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>
+            <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>
+            <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>
+            <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>
+            <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>
+            <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>
+            <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
+            </mux>
+            <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
+            </mux>
+          </interconnect>
+        </mode>
+        <!-- Define physical mode begins -->
+        <!-- Define n2_lut5 mode begins -->
+        <mode name="n2_lut5" disable_packing="false">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <mode name="blut5">
+                <pb_type name="flut5" num_pb="1">
+                  <input name="in" num_pins="5"/>
+                  <output name="out" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Regular LUT mode -->
+                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                    <input name="in" num_pins="5" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                         202e-12
                         202e-12
                         202e-12
                         202e-12
                         202e-12
-                    </delay_matrix>          
-                           </pb_type>         
-
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="direct1" input="flut5.in" output="lut5.in"/>          
-                              <direct name="direct2" input="lut5.out" output="ff.D">           
-                                 <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="direct3" input="flut5.clk" output="ff.clk"/>          
-                              <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">           
-                                 <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in" output="flut5.in"/>         
-                           <direct name="direct2" input="ble5.clk" output="flut5.clk"/>         
-                           <direct name="direct3" input="flut5.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="arithmetic">        
-                        <pb_type name="arithmetic" num_pb="1">         
-                           <input name="in" num_pins="4"/>         
-                           <input name="cin" num_pins="1"/>         
-                           <output name="out" num_pins="1"/>         
-                           <output name="cout" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Special dual-LUT mode that drives adder only -->         
-                           <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">          
-                              <input name="in" num_pins="4" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="flut5.in" output="lut5.in"/>
+                    <direct name="direct2" input="lut5.out" output="ff.D">
+                      <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+                    </direct>
+                    <direct name="direct3" input="flut5.clk" output="ff.clk"/>
+                    <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">
+                      <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in" output="flut5.in"/>
+                  <direct name="direct2" input="ble5.clk" output="flut5.clk"/>
+                  <direct name="direct3" input="flut5.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+              <mode name="arithmetic">
+                <pb_type name="arithmetic" num_pb="1">
+                  <input name="in" num_pins="4"/>
+                  <input name="cin" num_pins="1"/>
+                  <output name="out" num_pins="1"/>
+                  <output name="cout" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Special dual-LUT mode that drives adder only -->
+                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+                    <input name="in" num_pins="4" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                         180e-12
                         180e-12
                         180e-12
                         180e-12
-                    </delay_matrix>          
-                           </pb_type>         
-                           <pb_type name="adder" blif_model=".subckt adder" num_pb="1">          
-                              <input name="a" num_pins="1"/>          
-                              <input name="b" num_pins="1"/>          
-                              <input name="cin" num_pins="1"/>          
-                              <output name="cout" num_pins="1"/>          
-                              <output name="sumout" num_pins="1"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>          
-                           </pb_type>         
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>          
-                              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>          
-                              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>          
-                              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                    </direct>          
-                              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                    </direct>          
-                              <direct name="add_to_ff" input="adder.sumout" output="ff.D">           
-                                 <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">           
-                                 <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>           
-                              </direct>          
-                              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">           
-                                 <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>           
-                              </direct>          
-                              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">           
-                                 <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>         
-                           <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">          
-                              <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->          
-                           </direct>         
-                           <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">          
-                              <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->          
-                           </direct>         
-                           <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>         
-                           <direct name="direct3" input="arithmetic.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">        
-                        <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->        
-                     </direct>       
-                     <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">        
-                        <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->        
-                     </direct>       
-                     <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">        
-                        <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->        
-                     </direct>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>      
-                  <direct name="carry_in" input="fle.cin" output="lut5inter.cin">       
-                     <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->       
-                  </direct>      
-                  <direct name="carry_out" input="lut5inter.cout" output="fle.cout">       
-                     <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n2_lut5 mode ends -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+                    <input name="a" num_pins="1"/>
+                    <input name="b" num_pins="1"/>
+                    <input name="cin" num_pins="1"/>
+                    <output name="cout" num_pins="1"/>
+                    <output name="sumout" num_pins="1"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+                    <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+                    <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+                    <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                    </direct>
+                    <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                    </direct>
+                    <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                      <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+                    </direct>
+                    <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                      <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+                    </direct>
+                    <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                      <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+                    </direct>
+                    <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                      <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>
+                  <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
+                    <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->
+                  </direct>
+                  <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
+                    <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->
+                  </direct>
+                  <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>
+                  <direct name="direct3" input="arithmetic.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
+                <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->
+              </direct>
+              <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
+                <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->
+              </direct>
+              <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
+                <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->
+              </direct>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+            <direct name="carry_in" input="fle.cin" output="lut5inter.cin">
+              <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->
+            </direct>
+            <direct name="carry_out" input="lut5inter.cout" output="fle.cout">
+              <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Define n2_lut5 mode ends -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n1_lut6 mode ends -->    
-            <!-- Define shift register mode begins -->    
-            <mode name="shift_register">     
-               <pb_type name="ble_shift" num_pb="1">      
-                  <input name="in" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D">        
-                        <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->        
-                     </direct>       
-                     <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>       
-                     <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>       
-                     <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>       
-                     <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="ble_shift.in"/>      
-                  <direct name="direct2" input="ble_shift.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>      
-                  <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>      
-               </interconnect>     
-            </mode>    
-           <!-- Define shift_register mode end -->    
-         </pb_type>   
-         <interconnect>    
-            <complete name="crossbar0" input="clb.I2 clb.I3 fle[9:0].out" output="fle[9:0].in[0]">     
-               <delay_constant max="190e-12" in_port="clb.I2 clb.I3" out_port="fle[9:0].in[0]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[0]"/>     
-            </complete>    
-            <complete name="crossbar1" input="clb.I1 clb.I2 fle[9:0].out" output="fle[9:0].in[1]">     
-               <delay_constant max="190e-12" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[1]"/>     
-            </complete>    
-            <complete name="crossbar2" input="clb.I0 clb.I1 fle[9:0].out" output="fle[9:0].in[2]">     
-               <delay_constant max="190e-12" in_port="clb.I0 clb.I1" out_port="fle[9:0].in[2]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[2]"/>     
-            </complete>    
-            <complete name="crossbar3" input="clb.I1 clb.I3 fle[9:0].out" output="fle[9:0].in[3]">     
-               <delay_constant max="190e-12" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[3]"/>     
-            </complete>    
-            <complete name="crossbar4" input="clb.I0 clb.I2 fle[9:0].out" output="fle[9:0].in[4]">     
-               <delay_constant max="190e-12" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[4]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[4]"/>     
-            </complete>    
-            <complete name="crossbar5" input="clb.I0 clb.I3 fle[9:0].out" output="fle[9:0].in[5]">
-        </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <complete name="carry_in" input="clb.cin clb.cin_trick fle[9:0].out" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->     
-            </complete>    
-
-            <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define n1_lut6 mode ends -->
+        <!-- Define shift register mode begins -->
+        <mode name="shift_register">
+          <pb_type name="ble_shift" num_pb="1">
+            <input name="in" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D">
+                <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->
+              </direct>
+              <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>
+              <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>
+              <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>
+              <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="ble_shift.in"/>
+            <direct name="direct2" input="ble_shift.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>
+            <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift_register mode end -->
+      </pb_type>
+      <interconnect>
+        <complete name="crossbar0" input="clb.I2 clb.I3 fle[9:0].out" output="fle[9:0].in[0]">
+          <delay_constant max="190e-12" in_port="clb.I2 clb.I3" out_port="fle[9:0].in[0]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[0]"/>
+        </complete>
+        <complete name="crossbar1" input="clb.I1 clb.I2 fle[9:0].out" output="fle[9:0].in[1]">
+          <delay_constant max="190e-12" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[1]"/>
+        </complete>
+        <complete name="crossbar2" input="clb.I0 clb.I1 fle[9:0].out" output="fle[9:0].in[2]">
+          <delay_constant max="190e-12" in_port="clb.I0 clb.I1" out_port="fle[9:0].in[2]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[2]"/>
+        </complete>
+        <complete name="crossbar3" input="clb.I1 clb.I3 fle[9:0].out" output="fle[9:0].in[3]">
+          <delay_constant max="190e-12" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[3]"/>
+        </complete>
+        <complete name="crossbar4" input="clb.I0 clb.I2 fle[9:0].out" output="fle[9:0].in[4]">
+          <delay_constant max="190e-12" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[4]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[4]"/>
+        </complete>
+        <complete name="crossbar5" input="clb.I0 clb.I3 fle[9:0].out" output="fle[9:0].in[5]">
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <complete name="carry_in" input="clb.cin clb.cin_trick fle[9:0].out" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->
           <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
-        </direct-->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <direct name="cout_copy" input="fle[9:9].cout" output="clb.cout_copy"/>    
-
-            <!-- Shift register links -->    
-            <direct name="regin" input="clb.regin" output="fle[0:0].regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.15e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-               <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-            </direct>    
-            <direct name="regout" input="fle[9:9].regout" output="clb.regout">     
-               <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>     
-            </direct>    
-            <direct name="reg_link" input="fle[8:0].regout" output="fle[9:1].regin">     
-               <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>     
-            </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="sc_in" input="clb.sc_in" output="fle[0:0].sc_in">
-        </direct>    
-            <direct name="sc_out" input="fle[9:9].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="sc_link" input="fle[8:0].sc_out" output="fle[9:1].sc_in">
-        </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->
+        </complete>
+        <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct-->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <direct name="cout_copy" input="fle[9:9].cout" output="clb.cout_copy"/>
+        <!-- Shift register links -->
+        <direct name="regin" input="clb.regin" output="fle[0:0].regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.15e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>
+          <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>
+        </direct>
+        <direct name="regout" input="fle[9:9].regout" output="clb.regout">
+          <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>
+        </direct>
+        <direct name="reg_link" input="fle[8:0].regout" output="fle[9:1].regin">
+          <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="sc_in" input="clb.sc_in" output="fle[0:0].sc_in">
+        </direct>
+        <direct name="sc_out" input="fle[9:9].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="sc_link" input="fle[8:0].sc_out" output="fle[9:1].sc_in">
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_spypad_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_spypad_40nm.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0" ?><!-- Homogeneous FPGA Architecture with Carry Chain for VPR8
+<?xml version="1.0"?>
+<!-- Homogeneous FPGA Architecture with Carry Chain for VPR8
 
   - The chip layout is organized with a 2x2 array of Configurable Logic Blocks (CLBs)
     surrounded by a ring of I/Os
   - [TODO] Delay numbers are extracted from a 12 nm technology
   Author: Xifan Tang, Aurelien Alacchi and Ganesh Gore
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -13,298 +15,302 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="shift">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="D_chain" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Each I/O tile includes a GPIO -->   
-      <!-- IOs go on the periphery of the FPGA, for consistency, 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="shift">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="D_chain" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Each I/O tile includes a GPIO -->
+    <!-- IOs go on the periphery of the FPGA, for consistency, 
          make it physically equivalent on all sides so that only one definition of I/Os is needed.
          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-      -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <!-- Each input of the tile can be driven by 15% of routing tracks
+      -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <!-- Each input of the tile can be driven by 15% of routing tracks
            Each output of the tile can drive 10% of routing tracks
-        -->    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Each CLB tile includes a Configurable Logic Block (CLB)
+        -->
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Each CLB tile includes a Configurable Logic Block (CLB)
          Each input of the tile can be driven by 15% of routing tracks
          Each output of the tile can drive 10% of routing tracks
-      -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="10" equivalent="full"/>    
-          <input name="I1" num_pins="10" equivalent="full"/>    
-          <input name="I2" num_pins="10" equivalent="full"/>    
-          <input name="I3" num_pins="10" equivalent="full"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="cin_trick" num_pins="1"/>    
-          <input name="regin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <output name="cout_copy" num_pins="1"/>    
-          <output name="regout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <!-- Each input of the tile can be driven by 15% of routing tracks
+      -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="10" equivalent="full"/>
+        <input name="I1" num_pins="10" equivalent="full"/>
+        <input name="I2" num_pins="10" equivalent="full"/>
+        <input name="I3" num_pins="10" equivalent="full"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="cin_trick" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <output name="cout_copy" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Each input of the tile can be driven by 15% of routing tracks
            Each output of the tile can drive 10% of routing tracks
            There are four pins (cin, cout, sc_in, sc_out) has not connection 
            to routing tracks. There are directed wired from/to adjacent CLBs
-        -->    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!-- Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
+        -->
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!-- Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
            We keep all the pins that touch routing architecture on the right and bottom sides of the tile
            Top side pins are mainly for direct connections
-        -->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">clb.sc_in clb.cin clb.cin_trick clb.regin clb.clk</loc>     
-             <loc side="right">clb.I0[9:0] clb.I1[9:0] clb.O[9:0]</loc>     
-             <loc side="bottom">clb.cout clb.cout_copy clb.sc_out clb.regout clb.I2[9:0] clb.I3[9:0] clb.O[19:10]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Each CLB tile with spypads includes a Configurable Logic Block (CLB) with spypads
+        -->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">clb.sc_in clb.cin clb.cin_trick clb.regin clb.clk</loc>
+          <loc side="right">clb.I0[9:0] clb.I1[9:0] clb.O[9:0]</loc>
+          <loc side="bottom">clb.cout clb.cout_copy clb.sc_out clb.regout clb.I2[9:0] clb.I3[9:0] clb.O[19:10]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Each CLB tile with spypads includes a Configurable Logic Block (CLB) with spypads
          Each input of the tile can be driven by 15% of routing tracks
          Each output of the tile can drive 10% of routing tracks
-      -->  
-      <tile name="clb_spypad" area="53894">   <sub_tile name="clb_spypad">    
-          <equivalent_sites>     
-             <site pb_type="clb_spypad"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="10" equivalent="full"/>    
-          <input name="I1" num_pins="10" equivalent="full"/>    
-          <input name="I2" num_pins="10" equivalent="full"/>    
-          <input name="I3" num_pins="10" equivalent="full"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="cin_trick" num_pins="1"/>    
-          <input name="regin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <output name="cout_copy" num_pins="1"/>    
-          <output name="regout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <!-- Each input of the tile can be driven by 15% of routing tracks
+      -->
+    <tile name="clb_spypad" area="53894">
+      <sub_tile name="clb_spypad">
+        <equivalent_sites>
+          <site pb_type="clb_spypad"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="10" equivalent="full"/>
+        <input name="I1" num_pins="10" equivalent="full"/>
+        <input name="I2" num_pins="10" equivalent="full"/>
+        <input name="I3" num_pins="10" equivalent="full"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="cin_trick" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <output name="cout_copy" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Each input of the tile can be driven by 15% of routing tracks
            Each output of the tile can drive 10% of routing tracks
            There are four pins (cin, cout, sc_in, sc_out) has not connection 
            to routing tracks. There are directed wired from/to adjacent CLBs
-        -->    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!-- Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
+        -->
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!-- Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
            We keep all the pins that touch routing architecture on the right and bottom sides of the tile
            Top side pins are mainly for direct connections
-        -->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">clb_spypad.sc_in clb_spypad.cin clb_spypad.cin_trick clb_spypad.regin clb_spypad.clk</loc>     
-             <loc side="right">clb_spypad.I0[9:0] clb_spypad.I1[9:0] clb_spypad.O[9:0]</loc>     
-             <loc side="bottom">clb_spypad.cout clb_spypad.cout_copy clb_spypad.sc_out clb_spypad.regout clb_spypad.I2[9:0] clb_spypad.I3[9:0] clb_spypad.O[19:10]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <!-- Apply tileable routing architecture.
+        -->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">clb_spypad.sc_in clb_spypad.cin clb_spypad.cin_trick clb_spypad.regin clb_spypad.clk</loc>
+          <loc side="right">clb_spypad.I0[9:0] clb_spypad.I1[9:0] clb_spypad.O[9:0]</loc>
+          <loc side="bottom">clb_spypad.cout clb_spypad.cout_copy clb_spypad.sc_out clb_spypad.regout clb_spypad.I2[9:0] clb_spypad.I3[9:0] clb_spypad.O[19:10]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <!-- Apply tileable routing architecture.
        This is strongly recommended if you want to PnR large FPGA fabric
-    --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!-- Use the clb with spypad at [1,1] by setting a higher priority -->   
-         <single type="clb_spypad" x="1" y="1" priority="11"/>   
-      </auto_layout>  
-      <!-- Apply a fixed layout of 2x2 core array.
+    -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!-- Use the clb with spypad at [1,1] by setting a higher priority -->
+      <single type="clb_spypad" x="1" y="1" priority="11"/>
+    </auto_layout>
+    <!-- Apply a fixed layout of 2x2 core array.
          VPR8 considers the I/O ring in the array size
          Therefore the height and width are both 4
-      -->  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!-- Use the clb with spypad at [1,1] by setting a higher priority -->   
-         <single type="clb_spypad" x="1" y="1" priority="11"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+      -->
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!-- Use the clb with spypad at [1,1] by setting a higher priority -->
+      <single type="clb_spypad" x="1" y="1" priority="11"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
          area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-      -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <!-- Use Wilton-style connecting pattern in switch block 
+      -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <!-- Use Wilton-style connecting pattern in switch block 
          Each routing track has access to only three other routing tracks
          (one per each side of the switch block except the side where the routing track locates)
-      -->  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <!-- Uni-directional routing architecture using only length-4 wires in routing channels -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <!-- Hard adder chain inside CLB is directly connected between adjacent CLBs -->  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <!-- Scan chain inside CLB is directly connected between adjacent CLBs -->  
-      <direct name="scff_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+      -->
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <!-- Uni-directional routing architecture using only length-4 wires in routing channels -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <!-- Hard adder chain inside CLB is directly connected between adjacent CLBs -->
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <!-- Scan chain inside CLB is directly connected between adjacent CLBs -->
+    <direct name="scff_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
        Delays below come from Ian Kuon. They are small, so they should be interpreted as
        the delays to and from registers in the I/O (and generally I/Os are registered 
        today and that is when you timing analyze them.
-       -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define multi-mode Configurable Logic Block (CLB) begin -->  
-      <!-- Technical highlight:
+       -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define multi-mode Configurable Logic Block (CLB) begin -->
+    <!-- Technical highlight:
          K6_frac_N10_I40_chain_shiftreg_depop50
          - K6_frac: Each Logic Element (LE) contains a fracturable 6 LUT,
                     which can operate as one 6-LUT or two 5-LUTs or four 4-LUTs 
@@ -318,419 +324,412 @@
          - shiftreg: Flip-flops inside CLB can be configured as shift registers.
                      The organization is similar the hard adder chain except it is programmable
          - depop50: every local routing multiplexer accesses to 50% of the CLB inputs
-      -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="10" equivalent="full"/>   
-         <input name="I1" num_pins="10" equivalent="full"/>   
-         <input name="I2" num_pins="10" equivalent="full"/>   
-         <input name="I3" num_pins="10" equivalent="full"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="cin_trick" num_pins="1"/>   
-         <input name="regin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <output name="cout_copy" num_pins="1"/>   
-         <output name="regout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-
-         <!-- Describe fracturable logic element -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="regin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="regout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-
-            <!-- Describe physical mode begins -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="frac_logic" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="regchain" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="lut5_out" num_pins="2"/>       
-                     <output name="lut6_out" num_pins="1"/>       
-                  </pb_type>      
-                  <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>       
-                     <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>       
-                     <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>       
-                     <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>       
-                     <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>       
-                     <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>       
-                     <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>       
-                     <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>       
-                     <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
-              </mux>       
-                     <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">      
-                  <input name="D" num_pins="1"/>      
-                  <input name="D_chain" num_pins="1"/>      
-                  <output name="Q" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>      
-                  <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>      
-               </pb_type>     
-               <interconnect>      
-                  <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>      
-                  <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>      
-                  <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>      
-                  <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>      
-                  <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>      
-                  <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>      
-                  <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>      
-                  <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>      
-                  <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>      
-                  <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>      
-                  <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>      
-                  <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>      
-                  <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
-            </mux>      
-                  <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
-            </mux>      
-               </interconnect>     
-            </mode>    
-            <!-- Define physical mode begins -->    
-            <!-- Define n2_lut5 mode begins -->    
-            <mode name="n2_lut5" disable_packing="false">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <mode name="blut5">        
-                        <pb_type name="flut5" num_pb="1">         
-                           <input name="in" num_pins="5"/>         
-                           <output name="out" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Regular LUT mode -->         
-                           <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">          
-                              <input name="in" num_pins="5" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+      -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="10" equivalent="full"/>
+      <input name="I1" num_pins="10" equivalent="full"/>
+      <input name="I2" num_pins="10" equivalent="full"/>
+      <input name="I3" num_pins="10" equivalent="full"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="cin_trick" num_pins="1"/>
+      <input name="regin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <output name="cout_copy" num_pins="1"/>
+      <output name="regout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Describe physical mode begins -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="frac_logic" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="regin" num_pins="1"/>
+            <input name="regchain" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="lut5_out" num_pins="2"/>
+              <output name="lut6_out" num_pins="1"/>
+            </pb_type>
+            <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>
+              <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>
+              <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>
+              <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>
+              <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>
+              <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>
+              <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>
+              <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>
+              <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
+              </mux>
+              <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
+            <input name="D" num_pins="1"/>
+            <input name="D_chain" num_pins="1"/>
+            <output name="Q" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>
+            <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>
+          </pb_type>
+          <interconnect>
+            <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>
+            <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>
+            <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>
+            <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>
+            <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>
+            <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>
+            <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>
+            <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>
+            <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>
+            <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>
+            <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>
+            <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>
+            <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
+            </mux>
+            <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
+            </mux>
+          </interconnect>
+        </mode>
+        <!-- Define physical mode begins -->
+        <!-- Define n2_lut5 mode begins -->
+        <mode name="n2_lut5" disable_packing="false">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <mode name="blut5">
+                <pb_type name="flut5" num_pb="1">
+                  <input name="in" num_pins="5"/>
+                  <output name="out" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Regular LUT mode -->
+                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                    <input name="in" num_pins="5" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                         202e-12
                         202e-12
                         202e-12
                         202e-12
                         202e-12
-                    </delay_matrix>          
-                           </pb_type>         
-
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="direct1" input="flut5.in" output="lut5.in"/>          
-                              <direct name="direct2" input="lut5.out" output="ff.D">           
-                                 <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="direct3" input="flut5.clk" output="ff.clk"/>          
-                              <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">           
-                                 <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in" output="flut5.in"/>         
-                           <direct name="direct2" input="ble5.clk" output="flut5.clk"/>         
-                           <direct name="direct3" input="flut5.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="arithmetic">        
-                        <pb_type name="arithmetic" num_pb="1">         
-                           <input name="in" num_pins="4"/>         
-                           <input name="cin" num_pins="1"/>         
-                           <output name="out" num_pins="1"/>         
-                           <output name="cout" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Special dual-LUT mode that drives adder only -->         
-                           <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">          
-                              <input name="in" num_pins="4" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="flut5.in" output="lut5.in"/>
+                    <direct name="direct2" input="lut5.out" output="ff.D">
+                      <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+                    </direct>
+                    <direct name="direct3" input="flut5.clk" output="ff.clk"/>
+                    <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">
+                      <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in" output="flut5.in"/>
+                  <direct name="direct2" input="ble5.clk" output="flut5.clk"/>
+                  <direct name="direct3" input="flut5.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+              <mode name="arithmetic">
+                <pb_type name="arithmetic" num_pb="1">
+                  <input name="in" num_pins="4"/>
+                  <input name="cin" num_pins="1"/>
+                  <output name="out" num_pins="1"/>
+                  <output name="cout" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Special dual-LUT mode that drives adder only -->
+                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+                    <input name="in" num_pins="4" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                         180e-12
                         180e-12
                         180e-12
                         180e-12
-                    </delay_matrix>          
-                           </pb_type>         
-                           <pb_type name="adder" blif_model=".subckt adder" num_pb="1">          
-                              <input name="a" num_pins="1"/>          
-                              <input name="b" num_pins="1"/>          
-                              <input name="cin" num_pins="1"/>          
-                              <output name="cout" num_pins="1"/>          
-                              <output name="sumout" num_pins="1"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>          
-                           </pb_type>         
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>          
-                              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>          
-                              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>          
-                              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                    </direct>          
-                              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                    </direct>          
-                              <direct name="add_to_ff" input="adder.sumout" output="ff.D">           
-                                 <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">           
-                                 <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>           
-                              </direct>          
-                              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">           
-                                 <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>           
-                              </direct>          
-                              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">           
-                                 <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>         
-                           <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">          
-                              <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->          
-                           </direct>         
-                           <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">          
-                              <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->          
-                           </direct>         
-                           <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>         
-                           <direct name="direct3" input="arithmetic.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">        
-                        <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->        
-                     </direct>       
-                     <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">        
-                        <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->        
-                     </direct>       
-                     <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">        
-                        <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->        
-                     </direct>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>      
-                  <direct name="carry_in" input="fle.cin" output="lut5inter.cin">       
-                     <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->       
-                  </direct>      
-                  <direct name="carry_out" input="lut5inter.cout" output="fle.cout">       
-                     <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n2_lut5 mode ends -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+                    <input name="a" num_pins="1"/>
+                    <input name="b" num_pins="1"/>
+                    <input name="cin" num_pins="1"/>
+                    <output name="cout" num_pins="1"/>
+                    <output name="sumout" num_pins="1"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+                    <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+                    <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+                    <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                    </direct>
+                    <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                    </direct>
+                    <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                      <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+                    </direct>
+                    <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                      <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+                    </direct>
+                    <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                      <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+                    </direct>
+                    <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                      <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>
+                  <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
+                    <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->
+                  </direct>
+                  <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
+                    <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->
+                  </direct>
+                  <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>
+                  <direct name="direct3" input="arithmetic.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
+                <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->
+              </direct>
+              <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
+                <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->
+              </direct>
+              <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
+                <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->
+              </direct>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+            <direct name="carry_in" input="fle.cin" output="lut5inter.cin">
+              <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->
+            </direct>
+            <direct name="carry_out" input="lut5inter.cout" output="fle.cout">
+              <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Define n2_lut5 mode ends -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n1_lut6 mode ends -->    
-            <!-- Define shift register mode begins -->    
-            <mode name="shift_register">     
-               <pb_type name="ble_shift" num_pb="1">      
-                  <input name="in" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D">        
-                        <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->        
-                     </direct>       
-                     <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>       
-                     <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>       
-                     <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>       
-                     <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="ble_shift.in"/>      
-                  <direct name="direct2" input="ble_shift.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>      
-                  <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>      
-               </interconnect>     
-            </mode>    
-           <!-- Define shift_register mode end -->    
-         </pb_type>   
-         <interconnect>    
-            <complete name="crossbar0" input="clb.I2 clb.I3 fle[9:0].out" output="fle[9:0].in[0]">     
-               <delay_constant max="190e-12" in_port="clb.I2 clb.I3" out_port="fle[9:0].in[0]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[0]"/>     
-            </complete>    
-            <complete name="crossbar1" input="clb.I1 clb.I2 fle[9:0].out" output="fle[9:0].in[1]">     
-               <delay_constant max="190e-12" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[1]"/>     
-            </complete>    
-            <complete name="crossbar2" input="clb.I0 clb.I1 fle[9:0].out" output="fle[9:0].in[2]">     
-               <delay_constant max="190e-12" in_port="clb.I0 clb.I1" out_port="fle[9:0].in[2]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[2]"/>     
-            </complete>    
-            <complete name="crossbar3" input="clb.I1 clb.I3 fle[9:0].out" output="fle[9:0].in[3]">     
-               <delay_constant max="190e-12" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[3]"/>     
-            </complete>    
-            <complete name="crossbar4" input="clb.I0 clb.I2 fle[9:0].out" output="fle[9:0].in[4]">     
-               <delay_constant max="190e-12" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[4]"/>     
-               <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[4]"/>     
-            </complete>    
-            <complete name="crossbar5" input="clb.I0 clb.I3 fle[9:0].out" output="fle[9:0].in[5]">
-        </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <complete name="carry_in" input="clb.cin clb.cin_trick fle[9:0].out" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->     
-            </complete>    
-
-            <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define n1_lut6 mode ends -->
+        <!-- Define shift register mode begins -->
+        <mode name="shift_register">
+          <pb_type name="ble_shift" num_pb="1">
+            <input name="in" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D">
+                <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->
+              </direct>
+              <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>
+              <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>
+              <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>
+              <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="ble_shift.in"/>
+            <direct name="direct2" input="ble_shift.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>
+            <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift_register mode end -->
+      </pb_type>
+      <interconnect>
+        <complete name="crossbar0" input="clb.I2 clb.I3 fle[9:0].out" output="fle[9:0].in[0]">
+          <delay_constant max="190e-12" in_port="clb.I2 clb.I3" out_port="fle[9:0].in[0]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[0]"/>
+        </complete>
+        <complete name="crossbar1" input="clb.I1 clb.I2 fle[9:0].out" output="fle[9:0].in[1]">
+          <delay_constant max="190e-12" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[1]"/>
+        </complete>
+        <complete name="crossbar2" input="clb.I0 clb.I1 fle[9:0].out" output="fle[9:0].in[2]">
+          <delay_constant max="190e-12" in_port="clb.I0 clb.I1" out_port="fle[9:0].in[2]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[2]"/>
+        </complete>
+        <complete name="crossbar3" input="clb.I1 clb.I3 fle[9:0].out" output="fle[9:0].in[3]">
+          <delay_constant max="190e-12" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[3]"/>
+        </complete>
+        <complete name="crossbar4" input="clb.I0 clb.I2 fle[9:0].out" output="fle[9:0].in[4]">
+          <delay_constant max="190e-12" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[4]"/>
+          <delay_constant max="190e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[4]"/>
+        </complete>
+        <complete name="crossbar5" input="clb.I0 clb.I3 fle[9:0].out" output="fle[9:0].in[5]">
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <complete name="carry_in" input="clb.cin clb.cin_trick fle[9:0].out" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->
           <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
-        </direct-->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <direct name="cout_copy" input="fle[9:9].cout" output="clb.cout_copy"/>    
-
-            <!-- Shift register links -->    
-            <direct name="regin" input="clb.regin" output="fle[0:0].regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.15e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-               <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-            </direct>    
-            <direct name="regout" input="fle[9:9].regout" output="clb.regout">     
-               <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>     
-            </direct>    
-            <direct name="reg_link" input="fle[8:0].regout" output="fle[9:1].regin">     
-               <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>     
-            </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="sc_in" input="clb.sc_in" output="fle[0:0].sc_in">
-        </direct>    
-            <direct name="sc_out" input="fle[9:9].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="sc_link" input="fle[8:0].sc_out" output="fle[9:1].sc_in">
-        </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define multi-mode Configurable Logic Block (CLB) with spypads begin -->  
-      <!-- Technical highlight:
+          <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->
+        </complete>
+        <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct-->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <direct name="cout_copy" input="fle[9:9].cout" output="clb.cout_copy"/>
+        <!-- Shift register links -->
+        <direct name="regin" input="clb.regin" output="fle[0:0].regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.15e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>
+          <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>
+        </direct>
+        <direct name="regout" input="fle[9:9].regout" output="clb.regout">
+          <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>
+        </direct>
+        <direct name="reg_link" input="fle[8:0].regout" output="fle[9:1].regin">
+          <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="sc_in" input="clb.sc_in" output="fle[0:0].sc_in">
+        </direct>
+        <direct name="sc_out" input="fle[9:9].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="sc_link" input="fle[8:0].sc_out" output="fle[9:1].sc_in">
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define multi-mode Configurable Logic Block (CLB) with spypads begin -->
+    <!-- Technical highlight:
          K6_frac_N10_I40_chain_shiftreg_depop50
          - K6_frac: Each Logic Element (LE) contains a fracturable 6 LUT,
                     which can operate as one 6-LUT or two 5-LUTs or four 4-LUTs 
@@ -745,804 +744,782 @@
                      The organization is similar the hard adder chain except it is programmable
          - depop50: every local routing multiplexer accesses to 50% of the CLB inputs
          - spypads: spypads are added to LUT outputs in the first fle (fle[0]) 
-      -->  
-      <pb_type name="clb_spypad">   
-         <input name="I0" num_pins="10" equivalent="full"/>   
-         <input name="I1" num_pins="10" equivalent="full"/>   
-         <input name="I2" num_pins="10" equivalent="full"/>   
-         <input name="I3" num_pins="10" equivalent="full"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="cin_trick" num_pins="1"/>   
-         <input name="regin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <output name="cout_copy" num_pins="1"/>   
-         <output name="regout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-
-         <!-- Describe fracturable logic element -->   
-         <pb_type name="fle" num_pb="9">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="regin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="regout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-
-            <!-- Describe physical mode begins -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="frac_logic" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="regchain" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="lut5_out" num_pins="2"/>       
-                     <output name="lut6_out" num_pins="1"/>       
-                  </pb_type>      
-                  <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>       
-                     <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>       
-                     <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>       
-                     <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>       
-                     <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>       
-                     <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>       
-                     <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>       
-                     <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>       
-                     <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
-              </mux>       
-                     <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">      
-                  <input name="D" num_pins="1"/>      
-                  <input name="D_chain" num_pins="1"/>      
-                  <output name="Q" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>      
-                  <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>      
-               </pb_type>     
-               <interconnect>      
-                  <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>      
-                  <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>      
-                  <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>      
-                  <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>      
-                  <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>      
-                  <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>      
-                  <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>      
-                  <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>      
-                  <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>      
-                  <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>      
-                  <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>      
-                  <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>      
-                  <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
-            </mux>      
-                  <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
-            </mux>      
-               </interconnect>     
-            </mode>    
-            <!-- Define physical mode begins -->    
-            <!-- Define n2_lut5 mode begins -->    
-            <mode name="n2_lut5" disable_packing="false">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <mode name="blut5">        
-                        <pb_type name="flut5" num_pb="1">         
-                           <input name="in" num_pins="5"/>         
-                           <output name="out" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Regular LUT mode -->         
-                           <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">          
-                              <input name="in" num_pins="5" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+      -->
+    <pb_type name="clb_spypad">
+      <input name="I0" num_pins="10" equivalent="full"/>
+      <input name="I1" num_pins="10" equivalent="full"/>
+      <input name="I2" num_pins="10" equivalent="full"/>
+      <input name="I3" num_pins="10" equivalent="full"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="cin_trick" num_pins="1"/>
+      <input name="regin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <output name="cout_copy" num_pins="1"/>
+      <output name="regout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element -->
+      <pb_type name="fle" num_pb="9">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Describe physical mode begins -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="frac_logic" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="regin" num_pins="1"/>
+            <input name="regchain" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="lut5_out" num_pins="2"/>
+              <output name="lut6_out" num_pins="1"/>
+            </pb_type>
+            <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>
+              <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>
+              <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>
+              <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>
+              <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>
+              <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>
+              <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>
+              <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>
+              <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
+              </mux>
+              <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
+            <input name="D" num_pins="1"/>
+            <input name="D_chain" num_pins="1"/>
+            <output name="Q" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>
+            <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>
+          </pb_type>
+          <interconnect>
+            <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>
+            <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>
+            <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>
+            <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>
+            <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>
+            <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>
+            <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>
+            <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>
+            <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>
+            <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>
+            <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>
+            <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>
+            <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
+            </mux>
+            <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
+            </mux>
+          </interconnect>
+        </mode>
+        <!-- Define physical mode begins -->
+        <!-- Define n2_lut5 mode begins -->
+        <mode name="n2_lut5" disable_packing="false">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <mode name="blut5">
+                <pb_type name="flut5" num_pb="1">
+                  <input name="in" num_pins="5"/>
+                  <output name="out" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Regular LUT mode -->
+                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                    <input name="in" num_pins="5" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                         202e-12
                         202e-12
                         202e-12
                         202e-12
                         202e-12
-                    </delay_matrix>          
-                           </pb_type>         
-
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="direct1" input="flut5.in" output="lut5.in"/>          
-                              <direct name="direct2" input="lut5.out" output="ff.D">           
-                                 <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="direct3" input="flut5.clk" output="ff.clk"/>          
-                              <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">           
-                                 <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in" output="flut5.in"/>         
-                           <direct name="direct2" input="ble5.clk" output="flut5.clk"/>         
-                           <direct name="direct3" input="flut5.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="arithmetic">        
-                        <pb_type name="arithmetic" num_pb="1">         
-                           <input name="in" num_pins="4"/>         
-                           <input name="cin" num_pins="1"/>         
-                           <output name="out" num_pins="1"/>         
-                           <output name="cout" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Special dual-LUT mode that drives adder only -->         
-                           <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">          
-                              <input name="in" num_pins="4" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="flut5.in" output="lut5.in"/>
+                    <direct name="direct2" input="lut5.out" output="ff.D">
+                      <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+                    </direct>
+                    <direct name="direct3" input="flut5.clk" output="ff.clk"/>
+                    <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">
+                      <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in" output="flut5.in"/>
+                  <direct name="direct2" input="ble5.clk" output="flut5.clk"/>
+                  <direct name="direct3" input="flut5.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+              <mode name="arithmetic">
+                <pb_type name="arithmetic" num_pb="1">
+                  <input name="in" num_pins="4"/>
+                  <input name="cin" num_pins="1"/>
+                  <output name="out" num_pins="1"/>
+                  <output name="cout" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Special dual-LUT mode that drives adder only -->
+                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+                    <input name="in" num_pins="4" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                         180e-12
                         180e-12
                         180e-12
                         180e-12
-                    </delay_matrix>          
-                           </pb_type>         
-                           <pb_type name="adder" blif_model=".subckt adder" num_pb="1">          
-                              <input name="a" num_pins="1"/>          
-                              <input name="b" num_pins="1"/>          
-                              <input name="cin" num_pins="1"/>          
-                              <output name="cout" num_pins="1"/>          
-                              <output name="sumout" num_pins="1"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>          
-                           </pb_type>         
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>          
-                              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>          
-                              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>          
-                              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                    </direct>          
-                              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                    </direct>          
-                              <direct name="add_to_ff" input="adder.sumout" output="ff.D">           
-                                 <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">           
-                                 <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>           
-                              </direct>          
-                              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">           
-                                 <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>           
-                              </direct>          
-                              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">           
-                                 <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>         
-                           <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">          
-                              <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->          
-                           </direct>         
-                           <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">          
-                              <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->          
-                           </direct>         
-                           <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>         
-                           <direct name="direct3" input="arithmetic.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">        
-                        <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->        
-                     </direct>       
-                     <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">        
-                        <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->        
-                     </direct>       
-                     <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">        
-                        <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->        
-                     </direct>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>      
-                  <direct name="carry_in" input="fle.cin" output="lut5inter.cin">       
-                     <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->       
-                  </direct>      
-                  <direct name="carry_out" input="lut5inter.cout" output="fle.cout">       
-                     <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n2_lut5 mode ends -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+                    <input name="a" num_pins="1"/>
+                    <input name="b" num_pins="1"/>
+                    <input name="cin" num_pins="1"/>
+                    <output name="cout" num_pins="1"/>
+                    <output name="sumout" num_pins="1"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+                    <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+                    <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+                    <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                    </direct>
+                    <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                    </direct>
+                    <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                      <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+                    </direct>
+                    <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                      <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+                    </direct>
+                    <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                      <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+                    </direct>
+                    <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                      <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>
+                  <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
+                    <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->
+                  </direct>
+                  <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
+                    <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->
+                  </direct>
+                  <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>
+                  <direct name="direct3" input="arithmetic.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
+                <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->
+              </direct>
+              <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
+                <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->
+              </direct>
+              <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
+                <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->
+              </direct>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+            <direct name="carry_in" input="fle.cin" output="lut5inter.cin">
+              <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->
+            </direct>
+            <direct name="carry_out" input="lut5inter.cout" output="fle.cout">
+              <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Define n2_lut5 mode ends -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n1_lut6 mode ends -->    
-            <!-- Define shift register mode begins -->    
-            <mode name="shift_register">     
-               <pb_type name="ble_shift" num_pb="1">      
-                  <input name="in" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D">        
-                        <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->        
-                     </direct>       
-                     <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>       
-                     <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>       
-                     <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>       
-                     <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="ble_shift.in"/>      
-                  <direct name="direct2" input="ble_shift.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>      
-                  <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>      
-               </interconnect>     
-            </mode>    
-           <!-- Define shift_register mode end -->    
-         </pb_type>   
-
-         <!-- Describe fracturable logic element with spy outputs -->   
-         <pb_type name="fle_spypad" num_pb="1">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="regin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="regout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-
-            <!-- Describe physical mode begins -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="frac_logic" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="regchain" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="lut5_out" num_pins="2"/>       
-                     <output name="lut6_out" num_pins="1"/>       
-                  </pb_type>      
-                  <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>       
-                     <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>       
-                     <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>       
-                     <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>       
-                     <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>       
-                     <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>       
-                     <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>       
-                     <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>       
-                     <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
-              </mux>       
-                     <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">      
-                  <input name="D" num_pins="1"/>      
-                  <input name="D_chain" num_pins="1"/>      
-                  <output name="Q" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>      
-                  <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>      
-               </pb_type>     
-               <interconnect>      
-                  <complete name="direct_clk" input="fle_spypad.clk" output="ff_phy[1:0].clk"/>      
-                  <direct name="direct_in" input="fle_spypad.in[5:0]" output="frac_logic.in[5:0]"/>      
-                  <direct name="direct_regin" input="fle_spypad.regin" output="frac_logic.regin"/>      
-                  <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>      
-                  <direct name="direct_regout" input="ff_phy[1].Q" output="fle_spypad.regout"/>      
-                  <direct name="direct_cin" input="fle_spypad.cin" output="frac_logic.cin"/>      
-                  <direct name="direct_cout" input="frac_logic.cout" output="fle_spypad.cout"/>      
-                  <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>      
-                  <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>      
-                  <direct name="direct_fle_scin" input="fle_spypad.sc_in" output="ff_phy[0].D_chain"/>      
-                  <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>      
-                  <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle_spypad.sc_out"/>      
-                  <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle_spypad.out[0]">
-            </mux>      
-                  <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle_spypad.out[1]">
-            </mux>      
-               </interconnect>     
-            </mode>    
-            <!-- Define physical mode begins -->    
-            <!-- Define n2_lut5 mode begins -->    
-            <mode name="n2_lut5" disable_packing="false">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <mode name="blut5">        
-                        <pb_type name="flut5" num_pb="1">         
-                           <input name="in" num_pins="5"/>         
-                           <output name="out" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Regular LUT mode -->         
-                           <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">          
-                              <input name="in" num_pins="5" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define n1_lut6 mode ends -->
+        <!-- Define shift register mode begins -->
+        <mode name="shift_register">
+          <pb_type name="ble_shift" num_pb="1">
+            <input name="in" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D">
+                <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->
+              </direct>
+              <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>
+              <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>
+              <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>
+              <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="ble_shift.in"/>
+            <direct name="direct2" input="ble_shift.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>
+            <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift_register mode end -->
+      </pb_type>
+      <!-- Describe fracturable logic element with spy outputs -->
+      <pb_type name="fle_spypad" num_pb="1">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Describe physical mode begins -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="frac_logic" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="regin" num_pins="1"/>
+            <input name="regchain" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="lut5_out" num_pins="2"/>
+              <output name="lut6_out" num_pins="1"/>
+            </pb_type>
+            <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>
+              <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>
+              <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>
+              <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>
+              <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>
+              <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>
+              <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>
+              <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>
+              <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
+              </mux>
+              <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
+            <input name="D" num_pins="1"/>
+            <input name="D_chain" num_pins="1"/>
+            <output name="Q" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>
+            <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>
+          </pb_type>
+          <interconnect>
+            <complete name="direct_clk" input="fle_spypad.clk" output="ff_phy[1:0].clk"/>
+            <direct name="direct_in" input="fle_spypad.in[5:0]" output="frac_logic.in[5:0]"/>
+            <direct name="direct_regin" input="fle_spypad.regin" output="frac_logic.regin"/>
+            <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>
+            <direct name="direct_regout" input="ff_phy[1].Q" output="fle_spypad.regout"/>
+            <direct name="direct_cin" input="fle_spypad.cin" output="frac_logic.cin"/>
+            <direct name="direct_cout" input="frac_logic.cout" output="fle_spypad.cout"/>
+            <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>
+            <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>
+            <direct name="direct_fle_scin" input="fle_spypad.sc_in" output="ff_phy[0].D_chain"/>
+            <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>
+            <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle_spypad.sc_out"/>
+            <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle_spypad.out[0]">
+            </mux>
+            <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle_spypad.out[1]">
+            </mux>
+          </interconnect>
+        </mode>
+        <!-- Define physical mode begins -->
+        <!-- Define n2_lut5 mode begins -->
+        <mode name="n2_lut5" disable_packing="false">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <mode name="blut5">
+                <pb_type name="flut5" num_pb="1">
+                  <input name="in" num_pins="5"/>
+                  <output name="out" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Regular LUT mode -->
+                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                    <input name="in" num_pins="5" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                         202e-12
                         202e-12
                         202e-12
                         202e-12
                         202e-12
-                    </delay_matrix>          
-                           </pb_type>         
-
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="direct1" input="flut5.in" output="lut5.in"/>          
-                              <direct name="direct2" input="lut5.out" output="ff.D">           
-                                 <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="direct3" input="flut5.clk" output="ff.clk"/>          
-                              <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">           
-                                 <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in" output="flut5.in"/>         
-                           <direct name="direct2" input="ble5.clk" output="flut5.clk"/>         
-                           <direct name="direct3" input="flut5.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="arithmetic">        
-                        <pb_type name="arithmetic" num_pb="1">         
-                           <input name="in" num_pins="4"/>         
-                           <input name="cin" num_pins="1"/>         
-                           <output name="out" num_pins="1"/>         
-                           <output name="cout" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Special dual-LUT mode that drives adder only -->         
-                           <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">          
-                              <input name="in" num_pins="4" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="flut5.in" output="lut5.in"/>
+                    <direct name="direct2" input="lut5.out" output="ff.D">
+                      <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+                    </direct>
+                    <direct name="direct3" input="flut5.clk" output="ff.clk"/>
+                    <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">
+                      <delay_constant max="25e-12" in_port="lut5.out" out_port="flut5.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="flut5.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in" output="flut5.in"/>
+                  <direct name="direct2" input="ble5.clk" output="flut5.clk"/>
+                  <direct name="direct3" input="flut5.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+              <mode name="arithmetic">
+                <pb_type name="arithmetic" num_pb="1">
+                  <input name="in" num_pins="4"/>
+                  <input name="cin" num_pins="1"/>
+                  <output name="out" num_pins="1"/>
+                  <output name="cout" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Special dual-LUT mode that drives adder only -->
+                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+                    <input name="in" num_pins="4" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                         180e-12
                         180e-12
                         180e-12
                         180e-12
-                    </delay_matrix>          
-                           </pb_type>         
-                           <pb_type name="adder" blif_model=".subckt adder" num_pb="1">          
-                              <input name="a" num_pins="1"/>          
-                              <input name="b" num_pins="1"/>          
-                              <input name="cin" num_pins="1"/>          
-                              <output name="cout" num_pins="1"/>          
-                              <output name="sumout" num_pins="1"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>          
-                              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>          
-                           </pb_type>         
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="66e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>          
-                              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>          
-                              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>          
-                              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                    </direct>          
-                              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                    </direct>          
-                              <direct name="add_to_ff" input="adder.sumout" output="ff.D">           
-                                 <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">           
-                                 <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>           
-                              </direct>          
-                              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">           
-                                 <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>           
-                              </direct>          
-                              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">           
-                                 <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>           
-                                 <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>         
-                           <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">          
-                              <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->          
-                           </direct>         
-                           <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">          
-                              <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->          
-                           </direct>         
-                           <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>         
-                           <direct name="direct3" input="arithmetic.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">        
-                        <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->        
-                     </direct>       
-                     <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">        
-                        <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->        
-                     </direct>       
-                     <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">        
-                        <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->        
-                     </direct>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle_spypad.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle_spypad.out"/>      
-                  <direct name="direct3" input="fle_spypad.clk" output="lut5inter.clk"/>      
-                  <direct name="carry_in" input="fle_spypad.cin" output="lut5inter.cin">       
-                     <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->       
-                  </direct>      
-                  <direct name="carry_out" input="lut5inter.cout" output="fle_spypad.cout">       
-                     <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->       
-                  </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n2_lut5 mode ends -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+                    <input name="a" num_pins="1"/>
+                    <input name="b" num_pins="1"/>
+                    <input name="cin" num_pins="1"/>
+                    <output name="cout" num_pins="1"/>
+                    <output name="sumout" num_pins="1"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.cout"/>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+                    <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+                    <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+                    <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                    </direct>
+                    <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                    </direct>
+                    <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                      <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+                    </direct>
+                    <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                      <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+                    </direct>
+                    <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                      <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+                    </direct>
+                    <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                      <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                      <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>
+                  <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
+                    <!--pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/-->
+                  </direct>
+                  <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
+                    <!--pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/-->
+                  </direct>
+                  <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>
+                  <direct name="direct3" input="arithmetic.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
+                <!--pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/-->
+              </direct>
+              <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
+                <!--pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/-->
+              </direct>
+              <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
+                <!--pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/-->
+              </direct>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle_spypad.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle_spypad.out"/>
+            <direct name="direct3" input="fle_spypad.clk" output="lut5inter.clk"/>
+            <direct name="carry_in" input="fle_spypad.cin" output="lut5inter.cin">
+              <!--pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/-->
+            </direct>
+            <direct name="carry_out" input="lut5inter.cout" output="fle_spypad.cout">
+              <!--pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/-->
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Define n2_lut5 mode ends -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
                   229e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle_spypad.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle_spypad.out[1:1]"/>      
-                  <direct name="direct3" input="fle_spypad.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n1_lut6 mode ends -->    
-            <!-- Define shift register mode begins -->    
-            <mode name="shift_register">     
-               <pb_type name="ble_shift" num_pb="1">      
-                  <input name="in" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D">        
-                        <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->        
-                     </direct>       
-                     <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>       
-                     <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>       
-                     <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>       
-                     <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle_spypad.regin" output="ble_shift.in"/>      
-                  <direct name="direct2" input="ble_shift.out" output="fle_spypad.out"/>      
-                  <direct name="direct3" input="fle_spypad.clk" output="ble_shift.clk"/>      
-                  <direct name="direct4" input="ble_shift.regout" output="fle_spypad.regout"/>      
-               </interconnect>     
-            </mode>    
-           <!-- Define shift_register mode end -->    
-         </pb_type>   
-
-         <interconnect>    
-            <complete name="crossbar0" input="clb_spypad.I2 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle[8:0].in[0]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I2 clb_spypad.I3" out_port="fle[8:0].in[0]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[0]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[0]"/>     
-            </complete>    
-            <complete name="crossbar0_spyfle" input="clb_spypad.I2 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle_spypad.in[0]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I2 clb_spypad.I3" out_port="fle_spypad.in[0]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[0]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[0]"/>     
-            </complete>    
-
-            <complete name="crossbar1" input="clb_spypad.I1 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle[8:0].in[1]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I2" out_port="fle[8:0].in[1]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[1]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[1]"/>     
-            </complete>    
-            <complete name="crossbar1_spyfle" input="clb_spypad.I1 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle_spypad.in[1]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I2" out_port="fle_spypad.in[1]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[1]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[1]"/>     
-            </complete>    
-
-            <complete name="crossbar2" input="clb_spypad.I0 clb_spypad.I1 fle[8:0].out fle_spypad.out" output="fle[8:0].in[2]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I1" out_port="fle[8:0].in[2]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[2]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[2]"/>     
-            </complete>    
-            <complete name="crossbar2_spyfle" input="clb_spypad.I0 clb_spypad.I1 fle[8:0].out fle_spypad.out" output="fle_spypad.in[2]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I1" out_port="fle_spypad.in[2]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[2]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[2]"/>     
-            </complete>    
-
-            <complete name="crossbar3" input="clb_spypad.I1 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle[8:0].in[3]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I3" out_port="fle[8:0].in[3]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[3]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[3]"/>     
-            </complete>    
-            <complete name="crossbar3_spyfle" input="clb_spypad.I1 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle_spypad.in[3]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I3" out_port="fle_spypad.in[3]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[3]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[3]"/>     
-            </complete>    
-
-            <complete name="crossbar4" input="clb_spypad.I0 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle[8:0].in[4]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I2" out_port="fle[8:0].in[4]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[4]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[4]"/>     
-            </complete>    
-            <complete name="crossbar4_spyfle" input="clb_spypad.I0 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle_spypad.in[4]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I2" out_port="fle_spypad.in[4]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[4]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[4]"/>     
-            </complete>    
-
-            <complete name="crossbar5" input="clb_spypad.I0 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle[8:0].in[5]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I3" out_port="fle[8:0].in[5]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[5]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[5]"/>     
-            </complete>    
-            <complete name="crossbar5_spyfle" input="clb_spypad.I0 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle_spypad.in[5]">     
-               <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I3" out_port="fle_spypad.in[5]"/>     
-               <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[5]"/>     
-               <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[5]"/>     
-            </complete>    
-
-            <complete name="clks" input="clb_spypad.clk" output="fle[8:0].clk">
-        </complete>    
-            <complete name="clks_spyfle" input="clb_spypad.clk" output="fle_spypad.clk">
-        </complete>    
-            <complete name="carry_in" input="clb_spypad.cin clb_spypad.cin_trick fle[8:0].out fle_spypad.out" output="fle_spypad.cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->     
-               <pack_pattern name="chain" in_port="clb_spypad.cin" out_port="fle_spypad.cin"/>     
-               <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->     
-            </complete>    
-
-            <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle_spypad.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle_spypad.out[1:1]"/>
+            <direct name="direct3" input="fle_spypad.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define n1_lut6 mode ends -->
+        <!-- Define shift register mode begins -->
+        <mode name="shift_register">
+          <pb_type name="ble_shift" num_pb="1">
+            <input name="in" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D">
+                <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->
+              </direct>
+              <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>
+              <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>
+              <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>
+              <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle_spypad.regin" output="ble_shift.in"/>
+            <direct name="direct2" input="ble_shift.out" output="fle_spypad.out"/>
+            <direct name="direct3" input="fle_spypad.clk" output="ble_shift.clk"/>
+            <direct name="direct4" input="ble_shift.regout" output="fle_spypad.regout"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift_register mode end -->
+      </pb_type>
+      <interconnect>
+        <complete name="crossbar0" input="clb_spypad.I2 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle[8:0].in[0]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I2 clb_spypad.I3" out_port="fle[8:0].in[0]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[0]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[0]"/>
+        </complete>
+        <complete name="crossbar0_spyfle" input="clb_spypad.I2 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle_spypad.in[0]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I2 clb_spypad.I3" out_port="fle_spypad.in[0]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[0]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[0]"/>
+        </complete>
+        <complete name="crossbar1" input="clb_spypad.I1 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle[8:0].in[1]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I2" out_port="fle[8:0].in[1]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[1]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[1]"/>
+        </complete>
+        <complete name="crossbar1_spyfle" input="clb_spypad.I1 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle_spypad.in[1]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I2" out_port="fle_spypad.in[1]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[1]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[1]"/>
+        </complete>
+        <complete name="crossbar2" input="clb_spypad.I0 clb_spypad.I1 fle[8:0].out fle_spypad.out" output="fle[8:0].in[2]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I1" out_port="fle[8:0].in[2]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[2]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[2]"/>
+        </complete>
+        <complete name="crossbar2_spyfle" input="clb_spypad.I0 clb_spypad.I1 fle[8:0].out fle_spypad.out" output="fle_spypad.in[2]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I1" out_port="fle_spypad.in[2]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[2]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[2]"/>
+        </complete>
+        <complete name="crossbar3" input="clb_spypad.I1 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle[8:0].in[3]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I3" out_port="fle[8:0].in[3]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[3]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[3]"/>
+        </complete>
+        <complete name="crossbar3_spyfle" input="clb_spypad.I1 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle_spypad.in[3]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I1 clb_spypad.I3" out_port="fle_spypad.in[3]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[3]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[3]"/>
+        </complete>
+        <complete name="crossbar4" input="clb_spypad.I0 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle[8:0].in[4]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I2" out_port="fle[8:0].in[4]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[4]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[4]"/>
+        </complete>
+        <complete name="crossbar4_spyfle" input="clb_spypad.I0 clb_spypad.I2 fle[8:0].out fle_spypad.out" output="fle_spypad.in[4]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I2" out_port="fle_spypad.in[4]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[4]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[4]"/>
+        </complete>
+        <complete name="crossbar5" input="clb_spypad.I0 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle[8:0].in[5]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I3" out_port="fle[8:0].in[5]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle[8:0].in[5]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle[8:0].in[5]"/>
+        </complete>
+        <complete name="crossbar5_spyfle" input="clb_spypad.I0 clb_spypad.I3 fle[8:0].out fle_spypad.out" output="fle_spypad.in[5]">
+          <delay_constant max="190e-12" in_port="clb_spypad.I0 clb_spypad.I3" out_port="fle_spypad.in[5]"/>
+          <delay_constant max="190e-12" in_port="fle[8:0].out" out_port="fle_spypad.in[5]"/>
+          <delay_constant max="190e-12" in_port="fle_spypad.out" out_port="fle_spypad.in[5]"/>
+        </complete>
+        <complete name="clks" input="clb_spypad.clk" output="fle[8:0].clk">
+        </complete>
+        <complete name="clks_spyfle" input="clb_spypad.clk" output="fle_spypad.clk">
+        </complete>
+        <complete name="carry_in" input="clb_spypad.cin clb_spypad.cin_trick fle[8:0].out fle_spypad.out" output="fle_spypad.cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->
+          <pack_pattern name="chain" in_port="clb_spypad.cin" out_port="fle_spypad.cin"/>
+          <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->
+        </complete>
+        <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
           <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
-        </direct-->    
-            <direct name="clbouts1_spyfle" input="fle_spypad.out[0:0]" output="clb_spypad.O[0:0]"/>    
-            <direct name="clbouts2_spyfle" input="fle_spypad.out[1:1]" output="clb_spypad.O[10:10]"/>    
-            <direct name="clbouts1" input="fle[8:0].out[0:0]" output="clb_spypad.O[9:1]"/>    
-            <direct name="clbouts2" input="fle[8:0].out[1:1]" output="clb_spypad.O[19:11]"/>    
-            <direct name="cout_copy" input="fle[8:8].cout" output="clb_spypad.cout_copy"/>    
-
-            <!-- Shift register links -->    
-            <direct name="regin" input="clb_spypad.regin" output="fle_spypad.regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.15e-9" in_port="clb_spypad.regin" out_port="fle_spypad.regin"/>     
-               <pack_pattern name="chain" in_port="clb_spypad.regin" out_port="fle_spypad.regin"/>     
-            </direct>    
-            <direct name="regout" input="fle[8:8].regout" output="clb_spypad.regout">     
-               <pack_pattern name="chain" in_port="fle[8:8].regout" out_port="clb_spypad.regout"/>     
-            </direct>    
-            <direct name="reg_link_spyfle" input="fle_spypad.regout" output="fle[0:0].regin">     
-               <pack_pattern name="chain" in_port="fle_spypad.regout" out_port="fle[0:0].regin"/>     
-            </direct>    
-            <direct name="reg_link" input="fle[7:0].regout" output="fle[8:1].regin">     
-               <pack_pattern name="chain" in_port="fle[7:0].regout" out_port="fle[8:1].regin"/>     
-            </direct>    
-
-            <!-- Carry chain links -->    
-            <direct name="carry_out" input="fle[8:8].cout" output="clb_spypad.cout">     
-               <pack_pattern name="chain" in_port="fle[8:8].cout" out_port="clb_spypad.cout"/>     
-            </direct>    
-            <direct name="carry_link_spyfle" input="fle_spypad.cout" output="fle[0:0].cin">     
-               <pack_pattern name="chain" in_port="fle_spypad.cout" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[7:0].cout" output="fle[8:1].cin">     
-               <pack_pattern name="chain" in_port="fle[7:0].cout" out_port="fle[8:1].cin"/>     
-            </direct>    
-
-            <!-- Scan chain links: Do NOT use pack patterns here.
-                               They are testing elements and are NOT dealed by packers -->    
-            <direct name="sc_in" input="clb_spypad.sc_in" output="fle_spypad.sc_in">
-        </direct>    
-            <direct name="sc_out" input="fle[8:8].sc_out" output="clb_spypad.sc_out">
-        </direct>    
-            <direct name="sc_link_spyfle" input="fle_spypad.sc_out" output="fle[0:0].sc_in">
-        </direct>    
-            <direct name="sc_link" input="fle[7:0].sc_out" output="fle[8:1].sc_in">
-        </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-
-   </complexblocklist> 
+        </direct-->
+        <direct name="clbouts1_spyfle" input="fle_spypad.out[0:0]" output="clb_spypad.O[0:0]"/>
+        <direct name="clbouts2_spyfle" input="fle_spypad.out[1:1]" output="clb_spypad.O[10:10]"/>
+        <direct name="clbouts1" input="fle[8:0].out[0:0]" output="clb_spypad.O[9:1]"/>
+        <direct name="clbouts2" input="fle[8:0].out[1:1]" output="clb_spypad.O[19:11]"/>
+        <direct name="cout_copy" input="fle[8:8].cout" output="clb_spypad.cout_copy"/>
+        <!-- Shift register links -->
+        <direct name="regin" input="clb_spypad.regin" output="fle_spypad.regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.15e-9" in_port="clb_spypad.regin" out_port="fle_spypad.regin"/>
+          <pack_pattern name="chain" in_port="clb_spypad.regin" out_port="fle_spypad.regin"/>
+        </direct>
+        <direct name="regout" input="fle[8:8].regout" output="clb_spypad.regout">
+          <pack_pattern name="chain" in_port="fle[8:8].regout" out_port="clb_spypad.regout"/>
+        </direct>
+        <direct name="reg_link_spyfle" input="fle_spypad.regout" output="fle[0:0].regin">
+          <pack_pattern name="chain" in_port="fle_spypad.regout" out_port="fle[0:0].regin"/>
+        </direct>
+        <direct name="reg_link" input="fle[7:0].regout" output="fle[8:1].regin">
+          <pack_pattern name="chain" in_port="fle[7:0].regout" out_port="fle[8:1].regin"/>
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_out" input="fle[8:8].cout" output="clb_spypad.cout">
+          <pack_pattern name="chain" in_port="fle[8:8].cout" out_port="clb_spypad.cout"/>
+        </direct>
+        <direct name="carry_link_spyfle" input="fle_spypad.cout" output="fle[0:0].cin">
+          <pack_pattern name="chain" in_port="fle_spypad.cout" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_link" input="fle[7:0].cout" output="fle[8:1].cin">
+          <pack_pattern name="chain" in_port="fle[7:0].cout" out_port="fle[8:1].cin"/>
+        </direct>
+        <!-- Scan chain links: Do NOT use pack patterns here.
+                               They are testing elements and are NOT dealed by packers -->
+        <direct name="sc_in" input="clb_spypad.sc_in" output="fle_spypad.sc_in">
+        </direct>
+        <direct name="sc_out" input="fle[8:8].sc_out" output="clb_spypad.sc_out">
+        </direct>
+        <direct name="sc_link_spyfle" input="fle_spypad.sc_out" output="fle[0:0].sc_in">
+        </direct>
+        <direct name="sc_link" input="fle[7:0].sc_out" output="fle[8:1].sc_in">
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_mem16K_depop50_12nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_mem16K_depop50_12nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- Heterogeneous FPGA Architecture with Carry Chain for VPR8
+<?xml version="1.0"?>
+<!-- Heterogeneous FPGA Architecture with Carry Chain for VPR8
 
   - The chip layout is organized with a 32x32 array of Configurable Logic Blocks (CLBs)
     surrounded by a ring of I/Os
@@ -7,8 +8,9 @@
     Process corner: TT 0.8V
   
   Author: Xifan Tang, Aurelien Alacchi and Ganesh Gore
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -16,303 +18,307 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="shift">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <model name="scff">   
-         <input_ports>    
-            <port name="D" clock="clk"/>    
-            <port name="D_chain" clock="clk"/>    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="Q" clock="clk"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Each I/O tile includes a GPIO -->   
-      <!-- IOs go on the periphery of the FPGA, for consistency, 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="shift">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="scff">
+      <input_ports>
+        <port name="D" clock="clk"/>
+        <port name="D_chain" clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Each I/O tile includes a GPIO -->
+    <!-- IOs go on the periphery of the FPGA, for consistency, 
          make it physically equivalent on all sides so that only one definition of I/Os is needed.
          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-      -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="1">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <!-- Each input of the tile can be driven by 15% of routing tracks
+      -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="1">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <!-- Each input of the tile can be driven by 15% of routing tracks
            Each output of the tile can drive 10% of routing tracks
-        -->    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <!-- Each CLB tile includes a Configurable Logic Block (CLB)
+        -->
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <!-- Each CLB tile includes a Configurable Logic Block (CLB)
          Each input of the tile can be driven by 15% of routing tracks
          Each output of the tile can drive 10% of routing tracks
-      -->  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I0" num_pins="10" equivalent="full"/>    
-          <input name="I1" num_pins="10" equivalent="full"/>    
-          <input name="I2" num_pins="10" equivalent="full"/>    
-          <input name="I3" num_pins="10" equivalent="full"/>    
-          <input name="sc_in" num_pins="1"/>    
-          <input name="cin" num_pins="1"/>    
-          <input name="cin_trick" num_pins="1"/>    
-          <input name="regin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="sc_out" num_pins="1"/>    
-          <output name="cout" num_pins="1"/>    
-          <output name="cout_copy" num_pins="1"/>    
-          <output name="regout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <!-- Each input of the tile can be driven by 15% of routing tracks
+      -->
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I0" num_pins="10" equivalent="full"/>
+        <input name="I1" num_pins="10" equivalent="full"/>
+        <input name="I2" num_pins="10" equivalent="full"/>
+        <input name="I3" num_pins="10" equivalent="full"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="cin" num_pins="1"/>
+        <input name="cin_trick" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="cout" num_pins="1"/>
+        <output name="cout_copy" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Each input of the tile can be driven by 15% of routing tracks
            Each output of the tile can drive 10% of routing tracks
            There are four pins (cin, cout, sc_in, sc_out) has not connection 
            to routing tracks. There are directed wired from/to adjacent CLBs
-        -->    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!-- Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
+        -->
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!-- Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- To ensure best tileable routing architecture (minimize the number of unique SBs
            We keep all the pins that touch routing architecture on the right and bottom sides of the tile
            Top side pins are mainly for direct connections
-        -->    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">clb.sc_in clb.cin clb.cin_trick clb.regin clb.clk</loc>     
-             <loc side="right">clb.I0[9:0] clb.I1[9:0] clb.O[9:0]</loc>     
-             <loc side="bottom">clb.cout clb.cout_copy clb.sc_out clb.regout clb.I2[9:0] clb.I3[9:0] clb.O[19:10]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="d_in" num_pins="32"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="32"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left"/>     
-             <loc side="top">memory.clk</loc>     
-             <loc side="right">memory.waddr memory.d_in[15:0] memory.wen memory.d_out[15:0]</loc>     
-             <loc side="bottom">memory.raddr memory.d_in[31:16] memory.ren memory.d_out[31:16]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <!-- Apply tileable routing architecture.
+        -->
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">clb.sc_in clb.cin clb.cin_trick clb.regin clb.clk</loc>
+          <loc side="right">clb.I0[9:0] clb.I1[9:0] clb.O[9:0]</loc>
+          <loc side="bottom">clb.cout clb.cout_copy clb.sc_out clb.regout clb.I2[9:0] clb.I3[9:0] clb.O[19:10]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="d_in" num_pins="32"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="32"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left"/>
+          <loc side="top">memory.clk</loc>
+          <loc side="right">memory.waddr memory.d_in[15:0] memory.wen memory.d_out[15:0]</loc>
+          <loc side="bottom">memory.raddr memory.d_in[31:16] memory.ren memory.d_out[31:16]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <!-- Apply tileable routing architecture.
        This is strongly recommended if you want to PnR large FPGA fabric
-    --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="16" starty="1" repeatx="16" priority="20"/>   
-         <col type="EMPTY" startx="16" repeatx="16" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="6x6" width="8" height="8">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="EMPTY" startx="16" repeatx="16" starty="1" priority="19"/>   
-      </fixed_layout>  
-      <!-- Apply a fixed layout of 2x2 core array.
+    -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="16" starty="1" repeatx="16" priority="20"/>
+      <col type="EMPTY" startx="16" repeatx="16" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="6x6" width="8" height="8">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="EMPTY" startx="16" repeatx="16" starty="1" priority="19"/>
+    </fixed_layout>
+    <!-- Apply a fixed layout of 2x2 core array.
          VPR8 considers the I/O ring in the array size
          Therefore the height and width are both 4
-      -->  
-      <fixed_layout name="32x32" width="34" height="34">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="16" starty="1" repeatx="16" priority="20"/>   
-         <col type="EMPTY" startx="16" repeatx="16" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+      -->
+    <fixed_layout name="32x32" width="34" height="34">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="16" starty="1" repeatx="16" priority="20"/>
+      <col type="EMPTY" startx="16" repeatx="16" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
          area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-      -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <!-- Use Wilton-style connecting pattern in switch block 
+      -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <!-- Use Wilton-style connecting pattern in switch block 
          Each routing track has access to only three other routing tracks
          (one per each side of the switch block except the side where the routing track locates)
-      -->  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <switch type="mux" name="0" R="0" Cin="0" Cout="0" Tdel="200e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <switch type="mux" name="ipin_cblock" R="0." Cout="0." Cin="0" Tdel="210e-12" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <!-- Uni-directional routing architecture using only length-4 wires in routing channels -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="0" Cmetal="0">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <!-- Hard adder chain inside CLB is directly connected between adjacent CLBs -->  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-      <!-- Scan chain inside CLB is directly connected between adjacent CLBs -->  
-      <direct name="scff_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+      -->
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <switch type="mux" name="0" R="0" Cin="0" Cout="0" Tdel="200e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="ipin_cblock" R="0." Cout="0." Cin="0" Tdel="210e-12" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <!-- Uni-directional routing architecture using only length-4 wires in routing channels -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="0" Cmetal="0">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <!-- Hard adder chain inside CLB is directly connected between adjacent CLBs -->
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+    <!-- Scan chain inside CLB is directly connected between adjacent CLBs -->
+    <direct name="scff_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="0" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="0" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="0" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="0" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
        Delays below come from Ian Kuon. They are small, so they should be interpreted as
        the delays to and from registers in the I/O (and generally I/Os are registered 
        today and that is when you timing analyze them.
-       -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="0" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="0" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define multi-mode Configurable Logic Block (CLB) begin -->  
-      <!-- Technical highlight:
+       -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="0" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="0" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define multi-mode Configurable Logic Block (CLB) begin -->
+    <!-- Technical highlight:
          K6_frac_N10_I40_chain_shiftreg_depop50
          - K6_frac: Each Logic Element (LE) contains a fracturable 6 LUT,
                     which can operate as one 6-LUT or two 5-LUTs or four 4-LUTs 
@@ -326,493 +332,485 @@
          - shiftreg: Flip-flops inside CLB can be configured as shift registers.
                      The organization is similar the hard adder chain except it is programmable
          - depop50: every local routing multiplexer accesses to 50% of the CLB inputs
-      -->  
-      <pb_type name="clb">   
-         <input name="I0" num_pins="10" equivalent="full"/>   
-         <input name="I1" num_pins="10" equivalent="full"/>   
-         <input name="I2" num_pins="10" equivalent="full"/>   
-         <input name="I3" num_pins="10" equivalent="full"/>   
-         <input name="sc_in" num_pins="1"/>   
-         <input name="cin" num_pins="1"/>   
-         <input name="cin_trick" num_pins="1"/>   
-         <input name="regin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="sc_out" num_pins="1"/>   
-         <output name="cout" num_pins="1"/>   
-         <output name="cout_copy" num_pins="1"/>   
-         <output name="regout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-
-         <!-- Describe fracturable logic element -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <input name="sc_in" num_pins="1"/>    
-            <input name="regin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <output name="sc_out" num_pins="1"/>    
-            <output name="regout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-
-            <!-- Describe physical mode begins -->    
-            <!-- Timing annotation is not require for unpackable mode
+      -->
+    <pb_type name="clb">
+      <input name="I0" num_pins="10" equivalent="full"/>
+      <input name="I1" num_pins="10" equivalent="full"/>
+      <input name="I2" num_pins="10" equivalent="full"/>
+      <input name="I3" num_pins="10" equivalent="full"/>
+      <input name="sc_in" num_pins="1"/>
+      <input name="cin" num_pins="1"/>
+      <input name="cin_trick" num_pins="1"/>
+      <input name="regin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="sc_out" num_pins="1"/>
+      <output name="cout" num_pins="1"/>
+      <output name="cout_copy" num_pins="1"/>
+      <output name="regout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="sc_in" num_pins="1"/>
+        <input name="regin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <output name="sc_out" num_pins="1"/>
+        <output name="regout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Describe physical mode begins -->
+        <!-- Timing annotation is not require for unpackable mode
              It will not be used by timing analyzer
-          -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="frac_logic" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <input name="regin" num_pins="1"/>      
-                  <input name="regchain" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="lut5_out" num_pins="2"/>       
-                     <output name="lut6_out" num_pins="1"/>       
-                  </pb_type>      
-                  <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>       
-                     <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>       
-                     <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>       
-                     <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>       
-                     <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>       
-                     <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>       
-                     <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>       
-                     <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>       
-                     <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
-              </mux>       
-                     <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
-              </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">      
-                  <input name="D" num_pins="1"/>      
-                  <input name="D_chain" num_pins="1"/>      
-                  <output name="Q" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>      
-                  <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>      
-                  <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>      
-               </pb_type>     
-               <interconnect>      
-                  <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>      
-                  <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>      
-                  <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>      
-                  <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>      
-                  <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>      
-                  <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>      
-                  <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>      
-                  <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>      
-                  <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>      
-                  <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>      
-                  <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>      
-                  <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>      
-                  <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
-            </mux>      
-                  <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
-            </mux>      
-               </interconnect>     
-            </mode>    
-            <!-- Define physical mode begins -->    
-            <!-- Define n2_lut5 mode begins -->    
-            <mode name="n2_lut5" disable_packing="false">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="out" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <mode name="blut5">        
-                        <pb_type name="flut5" num_pb="1">         
-                           <input name="in" num_pins="5"/>         
-                           <output name="out" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Regular LUT mode -->         
-                           <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">          
-                              <input name="in" num_pins="5" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+          -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="frac_logic" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="regin" num_pins="1"/>
+            <input name="regchain" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="lut5_out" num_pins="2"/>
+              <output name="lut6_out" num_pins="1"/>
+            </pb_type>
+            <pb_type name="adder_phy" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.a" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.b" out_port="adder_phy.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder_phy.cin" out_port="adder_phy.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct_fraclut_in" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>
+              <direct name="direct_cin" input="frac_logic.cin" output="adder_phy[0].cin"/>
+              <direct name="direct_carry" input="adder_phy[0].cout" output="adder_phy[1].cin"/>
+              <direct name="direct_cout" input="adder_phy[1].cout" output="frac_logic.cout"/>
+              <direct name="direct_lut4carry0" input="frac_lut6.lut4_out[0]" output="adder_phy[0].a"/>
+              <direct name="direct_lut4carry1" input="frac_lut6.lut4_out[1]" output="adder_phy[0].b"/>
+              <direct name="direct_lut4carry2" input="frac_lut6.lut4_out[2]" output="adder_phy[1].a"/>
+              <direct name="direct_lut4carry3" input="frac_lut6.lut4_out[3]" output="adder_phy[1].b"/>
+              <mux name="mux1" input="adder_phy[0].sumout frac_lut6.lut5_out[0] frac_logic.regin" output="frac_logic.out[0]">
+              </mux>
+              <mux name="mux2" input="adder_phy[1].sumout frac_lut6.lut5_out[1] frac_lut6.lut6_out[0] frac_logic.regchain[0]" output="frac_logic.out[1]">
+              </mux>
+            </interconnect>
+          </pb_type>
+          <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
+            <input name="D" num_pins="1"/>
+            <input name="D_chain" num_pins="1"/>
+            <output name="Q" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <T_setup value="66e-12" port="ff_phy.D" clock="clk"/>
+            <T_setup value="66e-12" port="ff_phy.D_chain" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff_phy.Q" clock="clk"/>
+          </pb_type>
+          <interconnect>
+            <complete name="direct_clk" input="fle.clk" output="ff_phy[1:0].clk"/>
+            <direct name="direct_in" input="fle.in[5:0]" output="frac_logic.in[5:0]"/>
+            <direct name="direct_regin" input="fle.regin" output="frac_logic.regin"/>
+            <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>
+            <direct name="direct_regout" input="ff_phy[1].Q" output="fle.regout"/>
+            <direct name="direct_cin" input="fle.cin" output="frac_logic.cin"/>
+            <direct name="direct_cout" input="frac_logic.cout" output="fle.cout"/>
+            <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>
+            <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>
+            <direct name="direct_fle_scin" input="fle.sc_in" output="ff_phy[0].D_chain"/>
+            <direct name="direct_fle_sc_chain" input="ff_phy[0].Q" output="ff_phy[1].D_chain"/>
+            <direct name="direct_fle_scout" input="ff_phy[1].Q" output="fle.sc_out"/>
+            <mux name="mux1" input="ff_phy[0].Q frac_logic.out[0]" output="fle.out[0]">
+            </mux>
+            <mux name="mux2" input="ff_phy[1].Q frac_logic.out[1]" output="fle.out[1]">
+            </mux>
+          </interconnect>
+        </mode>
+        <!-- Define physical mode begins -->
+        <!-- Define n2_lut5 mode begins -->
+        <mode name="n2_lut5" disable_packing="false">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <mode name="blut5">
+                <pb_type name="flut5" num_pb="1">
+                  <input name="in" num_pins="5"/>
+                  <output name="out" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Regular LUT mode -->
+                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                    <input name="in" num_pins="5" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                         193e-12
                         193e-12
                         193e-12
                         193e-12
                         193e-12
-                    </delay_matrix>          
-                           </pb_type>         
-
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="26e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="direct1" input="flut5.in" output="lut5.in"/>          
-                              <direct name="direct2" input="lut5.out" output="ff.D">           
-                                 <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="direct3" input="flut5.clk" output="ff.clk"/>          
-                              <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">           
-                                 <delay_constant max="112e-12" in_port="lut5.out" out_port="flut5.out"/>           
-                                 <delay_constant max="48e-12" in_port="ff.Q" out_port="flut5.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in" output="flut5.in"/>         
-                           <direct name="direct2" input="ble5.clk" output="flut5.clk"/>         
-                           <direct name="direct3" input="flut5.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                     <mode name="arithmetic">        
-                        <pb_type name="arithmetic" num_pb="1">         
-                           <input name="in" num_pins="4"/>         
-                           <input name="cin" num_pins="1"/>         
-                           <output name="out" num_pins="1"/>         
-                           <output name="cout" num_pins="1"/>         
-                           <clock name="clk" num_pins="1"/>         
-                           <!-- Special dual-LUT mode that drives adder only -->         
-                           <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">          
-                              <input name="in" num_pins="4" port_class="lut_in"/>          
-                              <output name="out" num_pins="1" port_class="lut_out"/>          
-                              <!-- LUT timing using delay matrix -->          
-                              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                    </delay_matrix>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="26e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="flut5.in" output="lut5.in"/>
+                    <direct name="direct2" input="lut5.out" output="ff.D">
+                      <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+                    </direct>
+                    <direct name="direct3" input="flut5.clk" output="ff.clk"/>
+                    <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">
+                      <delay_constant max="112e-12" in_port="lut5.out" out_port="flut5.out"/>
+                      <delay_constant max="48e-12" in_port="ff.Q" out_port="flut5.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in" output="flut5.in"/>
+                  <direct name="direct2" input="ble5.clk" output="flut5.clk"/>
+                  <direct name="direct3" input="flut5.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+              <mode name="arithmetic">
+                <pb_type name="arithmetic" num_pb="1">
+                  <input name="in" num_pins="4"/>
+                  <input name="cin" num_pins="1"/>
+                  <output name="out" num_pins="1"/>
+                  <output name="cout" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Special dual-LUT mode that drives adder only -->
+                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+                    <input name="in" num_pins="4" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                         161e-12
                         161e-12
                         161e-12
                         161e-12
-                    </delay_matrix>          
-                           </pb_type>         
-                           <!-- Delay extracted from standard cell lib file
+                    </delay_matrix>
+                  </pb_type>
+                  <!-- Delay extracted from standard cell lib file
                        Consider the minimum slew and minimum load
-                   -->         
-                           <pb_type name="adder" blif_model=".subckt adder" num_pb="1">          
-                              <input name="a" num_pins="1"/>          
-                              <input name="b" num_pins="1"/>          
-                              <input name="cin" num_pins="1"/>          
-                              <output name="cout" num_pins="1"/>          
-                              <output name="sumout" num_pins="1"/>          
-                              <delay_constant max="26e-12" in_port="adder.a" out_port="adder.sumout"/>          
-                              <delay_constant max="26e-12" in_port="adder.b" out_port="adder.sumout"/>          
-                              <delay_constant max="26e-12" in_port="adder.cin" out_port="adder.sumout"/>          
-                              <delay_constant max="26e-12" in_port="adder.a" out_port="adder.cout"/>          
-                              <delay_constant max="26e-12" in_port="adder.b" out_port="adder.cout"/>          
-                              <delay_constant max="26e-12" in_port="adder.cin" out_port="adder.cout"/>          
-                           </pb_type>         
-                           <!-- Delay extracted from standard cell lib file
+                   -->
+                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+                    <input name="a" num_pins="1"/>
+                    <input name="b" num_pins="1"/>
+                    <input name="cin" num_pins="1"/>
+                    <output name="cout" num_pins="1"/>
+                    <output name="sumout" num_pins="1"/>
+                    <delay_constant max="26e-12" in_port="adder.a" out_port="adder.sumout"/>
+                    <delay_constant max="26e-12" in_port="adder.b" out_port="adder.sumout"/>
+                    <delay_constant max="26e-12" in_port="adder.cin" out_port="adder.sumout"/>
+                    <delay_constant max="26e-12" in_port="adder.a" out_port="adder.cout"/>
+                    <delay_constant max="26e-12" in_port="adder.b" out_port="adder.cout"/>
+                    <delay_constant max="26e-12" in_port="adder.cin" out_port="adder.cout"/>
+                  </pb_type>
+                  <!-- Delay extracted from standard cell lib file
                        Consider the minimum slew and minimum load
-                   -->         
-                           <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">          
-                              <input name="D" num_pins="1" port_class="D"/>          
-                              <output name="Q" num_pins="1" port_class="Q"/>          
-                              <clock name="clk" num_pins="1" port_class="clock"/>          
-                              <T_setup value="26e-12" port="ff.D" clock="clk"/>          
-                              <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>          
-                           </pb_type>         
-                           <interconnect>          
-                              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>          
-                              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>          
-                              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>          
-                              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                    </direct>          
-                              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                    </direct>          
-                              <direct name="add_to_ff" input="adder.sumout" output="ff.D">           
-                                 <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>           
-                              </direct>          
-                              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">           
-                                 <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>           
-                              </direct>          
-                              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">           
-                                 <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>           
-                              </direct>          
-                              <!-- Timing is extracted from the physical implementation 
+                   -->
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="26e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+                    <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+                    <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+                    <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                    </direct>
+                    <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                    </direct>
+                    <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                      <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+                    </direct>
+                    <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                      <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+                    </direct>
+                    <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                      <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+                    </direct>
+                    <!-- Timing is extracted from the physical implementation 
                          The path from ff.Q to arithmetic.out consists of a routing multiplexer
                          The path from adder.sumout to arithmetic.out consists of two routing multiplexers
                          One multiplexer connects from adder to ff.D 
                          Another connects from the ff.D to arithmetic.out
-                      -->          
-                              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">           
-                                 <delay_constant max="112e-12" in_port="adder.sumout" out_port="arithmetic.out"/>           
-                                 <delay_constant max="48e-12" in_port="ff.Q" out_port="arithmetic.out"/>           
-                              </mux>          
-                           </interconnect>         
-                        </pb_type>        
-
-                        <interconnect>         
-                           <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>         
-                           <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
-                  </direct>         
-                           <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
-                  </direct>         
-                           <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>         
-                           <direct name="direct3" input="arithmetic.out" output="ble5.out"/>         
-                        </interconnect>        
-                     </mode>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
-              </direct>       
-                     <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
-              </direct>       
-                     <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
-              </direct>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>      
-                  <direct name="carry_in" input="fle.cin" output="lut5inter.cin">
-            </direct>      
-                  <direct name="carry_out" input="lut5inter.cout" output="fle.cout">
-            </direct>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n2_lut5 mode ends -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                      -->
+                    <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                      <delay_constant max="112e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                      <delay_constant max="48e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>
+                  <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
+                  </direct>
+                  <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
+                  </direct>
+                  <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>
+                  <direct name="direct3" input="arithmetic.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
+              </direct>
+              <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
+              </direct>
+              <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
+              </direct>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+            <direct name="carry_in" input="fle.cin" output="lut5inter.cin">
+            </direct>
+            <direct name="carry_out" input="lut5inter.cout" output="fle.cout">
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- Define n2_lut5 mode ends -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   230e-12
                   230e-12
                   230e-12
                   230e-12
                   230e-12
                   230e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Delay extracted from standard cell lib file
+              </delay_matrix>
+            </pb_type>
+            <!-- Delay extracted from standard cell lib file
                  Consider the minimum slew and minimum load
-             -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="26e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="112e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="48e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Define n1_lut6 mode ends -->    
-            <!-- Define shift register mode begins -->    
-            <mode name="shift_register">     
-               <pb_type name="ble_shift" num_pb="1">      
-                  <input name="in" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="regout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="26e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>       
-                     <direct name="direct2" input="ff[0].Q" output="ff[1].D">        
-                        <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->        
-                     </direct>       
-                     <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>       
-                     <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>       
-                     <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>       
-                     <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.regin" output="ble_shift.in"/>      
-                  <direct name="direct2" input="ble_shift.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>      
-                  <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>      
-               </interconnect>     
-            </mode>    
-           <!-- Define shift_register mode end -->    
-         </pb_type>   
-         <interconnect>    
-            <complete name="crossbar0" input="clb.I2 clb.I3 fle[9:0].out" output="fle[9:0].in[0]">     
-               <delay_constant max="230e-12" in_port="clb.I2 clb.I3" out_port="fle[9:0].in[0]"/>     
-               <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[0]"/>     
-            </complete>    
-            <complete name="crossbar1" input="clb.I1 clb.I2 fle[9:0].out" output="fle[9:0].in[1]">     
-               <delay_constant max="230e-12" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]"/>     
-               <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[1]"/>     
-            </complete>    
-            <complete name="crossbar2" input="clb.I0 clb.I1 fle[9:0].out" output="fle[9:0].in[2]">     
-               <delay_constant max="230e-12" in_port="clb.I0 clb.I1" out_port="fle[9:0].in[2]"/>     
-               <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[2]"/>     
-            </complete>    
-            <complete name="crossbar3" input="clb.I1 clb.I3 fle[9:0].out" output="fle[9:0].in[3]">     
-               <delay_constant max="230e-12" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]"/>     
-               <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[3]"/>     
-            </complete>    
-            <complete name="crossbar4" input="clb.I0 clb.I2 fle[9:0].out" output="fle[9:0].in[4]">     
-               <delay_constant max="230e-12" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[4]"/>     
-               <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[4]"/>     
-            </complete>    
-            <complete name="crossbar5" input="clb.I0 clb.I3 fle[9:0].out" output="fle[9:0].in[5]">     
-               <delay_constant max="230e-12" in_port="clb.I0 clb.I3" out_port="fle[9:0].in[5]"/>     
-               <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[5]"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <complete name="carry_in" input="clb.cin clb.cin_trick fle[9:0].out" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->     
-            </complete>    
-
-            <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+             -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="26e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="112e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="48e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[1:1]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Define n1_lut6 mode ends -->
+        <!-- Define shift register mode begins -->
+        <mode name="shift_register">
+          <pb_type name="ble_shift" num_pb="1">
+            <input name="in" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="regout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ff" blif_model=".subckt shift" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="26e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="46e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble_shift.in" output="ff[0].D"/>
+              <direct name="direct2" input="ff[0].Q" output="ff[1].D">
+                <!--pack_pattern name="ble_shift" in_port="ff[0].Q" out_port="ff[1].D"/-->
+              </direct>
+              <direct name="out1" input="ff[0].Q" output="ble_shift.out[0]"/>
+              <direct name="out2" input="ff[1].Q" output="ble_shift.out[1]"/>
+              <direct name="direct_regout" input="ff[1].Q" output="ble_shift.regout"/>
+              <complete name="direct3" input="ble_shift.clk" output="ff[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.regin" output="ble_shift.in"/>
+            <direct name="direct2" input="ble_shift.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="ble_shift.clk"/>
+            <direct name="direct4" input="ble_shift.regout" output="fle.regout"/>
+          </interconnect>
+        </mode>
+        <!-- Define shift_register mode end -->
+      </pb_type>
+      <interconnect>
+        <complete name="crossbar0" input="clb.I2 clb.I3 fle[9:0].out" output="fle[9:0].in[0]">
+          <delay_constant max="230e-12" in_port="clb.I2 clb.I3" out_port="fle[9:0].in[0]"/>
+          <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[0]"/>
+        </complete>
+        <complete name="crossbar1" input="clb.I1 clb.I2 fle[9:0].out" output="fle[9:0].in[1]">
+          <delay_constant max="230e-12" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]"/>
+          <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[1]"/>
+        </complete>
+        <complete name="crossbar2" input="clb.I0 clb.I1 fle[9:0].out" output="fle[9:0].in[2]">
+          <delay_constant max="230e-12" in_port="clb.I0 clb.I1" out_port="fle[9:0].in[2]"/>
+          <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[2]"/>
+        </complete>
+        <complete name="crossbar3" input="clb.I1 clb.I3 fle[9:0].out" output="fle[9:0].in[3]">
+          <delay_constant max="230e-12" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]"/>
+          <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[3]"/>
+        </complete>
+        <complete name="crossbar4" input="clb.I0 clb.I2 fle[9:0].out" output="fle[9:0].in[4]">
+          <delay_constant max="230e-12" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[4]"/>
+          <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[4]"/>
+        </complete>
+        <complete name="crossbar5" input="clb.I0 clb.I3 fle[9:0].out" output="fle[9:0].in[5]">
+          <delay_constant max="230e-12" in_port="clb.I0 clb.I3" out_port="fle[9:0].in[5]"/>
+          <delay_constant max="230e-12" in_port="fle[9:0].out" out_port="fle[9:0].in[5]"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <complete name="carry_in" input="clb.cin clb.cin_trick fle[9:0].out" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <!--delay_constant max="0.15e-9" in_port="clb.cin clb.cin_trick" out_port="fle[0:0].cin"/-->
           <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
-        </direct-->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]">     
-               <delay_constant max="172e-12" in_port="fle[9:0].out[0:0]" out_port="clb.O[9:0]"/>     
-            </direct>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]">     
-               <delay_constant max="172e-12" in_port="fle[9:0].out[1:1]" out_port="clb.O[19:10]"/>     
-            </direct>    
-            <direct name="cout_copy" input="fle[9:9].cout" output="clb.cout_copy"/>    
-
-            <!-- Shift register links -->    
-            <direct name="regin" input="clb.regin" output="fle[0:0].regin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-               <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>     
-            </direct>    
-            <direct name="regout" input="fle[9:9].regout" output="clb.regout">     
-               <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>     
-            </direct>    
-            <direct name="reg_link" input="fle[8:0].regout" output="fle[9:1].regin">     
-               <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>     
-            </direct>    
-            <!-- Carry chain links -->    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-            <!-- Scan chain links -->    
-            <direct name="sc_in" input="clb.sc_in" output="fle[0:0].sc_in">
-        </direct>    
-            <direct name="sc_out" input="fle[9:9].sc_out" output="clb.sc_out">
-        </direct>    
-            <direct name="sc_link" input="fle[8:0].sc_out" output="fle[9:1].sc_in">
-        </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="d_in" num_pins="32"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="32"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 512x32=16Kbit memory block
+          <!--pack_pattern name="chain" in_port="clb.cin_trick" out_port="fle[0:0].cin"/-->
+        </complete>
+        <!--direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct-->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]">
+          <delay_constant max="172e-12" in_port="fle[9:0].out[0:0]" out_port="clb.O[9:0]"/>
+        </direct>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]">
+          <delay_constant max="172e-12" in_port="fle[9:0].out[1:1]" out_port="clb.O[19:10]"/>
+        </direct>
+        <direct name="cout_copy" input="fle[9:9].cout" output="clb.cout_copy"/>
+        <!-- Shift register links -->
+        <direct name="regin" input="clb.regin" output="fle[0:0].regin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0e-9" in_port="clb.regin" out_port="fle[0:0].regin"/>
+          <pack_pattern name="chain" in_port="clb.regin" out_port="fle[0:0].regin"/>
+        </direct>
+        <direct name="regout" input="fle[9:9].regout" output="clb.regout">
+          <pack_pattern name="chain" in_port="fle[9:9].regout" out_port="clb.regout"/>
+        </direct>
+        <direct name="reg_link" input="fle[8:0].regout" output="fle[9:1].regin">
+          <pack_pattern name="chain" in_port="fle[8:0].regout" out_port="fle[9:1].regin"/>
+        </direct>
+        <!-- Carry chain links -->
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+        <!-- Scan chain links -->
+        <direct name="sc_in" input="clb.sc_in" output="fle[0:0].sc_in">
+        </direct>
+        <direct name="sc_out" input="fle[9:9].sc_out" output="clb.sc_out">
+        </direct>
+        <direct name="sc_link" input="fle[8:0].sc_out" output="fle[9:1].sc_in">
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="d_in" num_pins="32"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="32"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 512x32=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_512x32_dp">    
-            <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address"/>     
-               <input name="raddr" num_pins="10" port_class="address"/>     
-               <input name="d_in" num_pins="32" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <!-- TODO the setup time and clk2Q delay should be extracted from BRAM LIB -->     
-               <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-
-   </complexblocklist> 
+        -->
+      <mode name="mem_512x32_dp">
+        <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address"/>
+          <input name="raddr" num_pins="10" port_class="address"/>
+          <input name="d_in" num_pins="32" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <!-- TODO the setup time and clk2Q delay should be extracted from BRAM LIB -->
+          <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_mem16K_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,145 +86,151 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="d_in" num_pins="32"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="32"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="perimeter"/>    
-          <!--pinlocations pattern="custom">
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="d_in" num_pins="32"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="32"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="perimeter"/>
+        <!--pinlocations pattern="custom">
         <loc side="left"></loc>
         <loc side="top">memory.clk</loc>
         <loc side="right" yoffset="0">memory.waddr[0:4] memory.d_in[0:15] memory.wen</loc>
         <loc side="right" yoffset="1">memory.raddr[0:4] memory.d_out[0:15]</loc>
         <loc side="bottom">memory.waddr[5:9] memory.raddr[5:9] memory.d_in[16:31] memory.ren memory.d_out[16:31]</loc>
-      </pinlocations-->    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="4x4" width="5" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+      </pinlocations-->
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="4x4" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -236,21 +244,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -262,91 +270,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -354,255 +360,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -610,45 +616,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -656,93 +662,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="d_in" num_pins="32"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="32"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 512x32=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="d_in" num_pins="32"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="32"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 512x32=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_512x32_dp">    
-            <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address"/>     
-               <input name="raddr" num_pins="10" port_class="address"/>     
-               <input name="d_in" num_pins="32" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_512x32_dp">
+        <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address"/>
+          <input name="raddr" num_pins="10" port_class="address"/>
+          <input name="d_in" num_pins="32" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_wide_mem16K_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_thru_channel_adder_chain_wide_mem16K_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
 
   - 40 nm technology
@@ -75,8 +76,9 @@
 
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -84,138 +86,144 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <model name="adder">   
-         <input_ports>    
-            <port name="a" combinational_sink_ports="sumout cout"/>    
-            <port name="b" combinational_sink_ports="sumout cout"/>    
-            <port name="cin" combinational_sink_ports="sumout cout"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="cout"/>    
-            <port name="sumout"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut4_out"/>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-      <model name="dual_port_ram">   
-         <input_ports>    
-            <!-- write address lines -->    
-            <port name="waddr" clock="clk"/>    
-            <!-- read address lines -->    
-            <port name="raddr" clock="clk"/>    
-            <!-- data lines can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_in" clock="clk"/>    
-            <!-- write enable -->    
-            <port name="wen" clock="clk"/>    
-            <!-- read enable -->    
-            <port name="ren" clock="clk"/>    
-            <!-- memories are often clocked -->    
-            <port name="clk" is_clock="1"/>    
-         </input_ports>   
-         <output_ports>    
-            <!-- output can be broken down into smaller bit widths minimum size 1 -->    
-            <port name="d_out" clock="clk"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="40" equivalent="full"/>    
-          <input name="cin" num_pins="1"/>    
-          <output name="O" num_pins="20" equivalent="none"/>    
-          <output name="cout" num_pins="1"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">     
-             <fc_override port_name="cin" fc_type="frac" fc_val="0"/>     
-             <fc_override port_name="cout" fc_type="frac" fc_val="0"/>     
-          </fc>    
-          <!--  Highly recommand to customize pin location when direct connection is used!!! -->    
-          <!--pinlocations pattern="spread"/-->    
-          <pinlocations pattern="custom">     
-             <loc side="left">clb.clk</loc>     
-             <loc side="top">clb.cin</loc>     
-             <loc side="right">clb.O[9:0] clb.I[19:0]</loc>     
-             <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="memory" width="2" height="2" area="548000">   <sub_tile name="memory">    
-          <equivalent_sites>     
-             <site pb_type="memory"/>     
-          </equivalent_sites>    
-          <input name="waddr" num_pins="10"/>    
-          <input name="raddr" num_pins="10"/>    
-          <input name="d_in" num_pins="32"/>    
-          <input name="wen" num_pins="1"/>    
-          <input name="ren" num_pins="1"/>    
-          <output name="d_out" num_pins="32"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="perimeter"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true" through_channel="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </auto_layout>  
-      <fixed_layout name="4x4" width="6" height="6">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-         <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->   
-         <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>   
-         <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" width="2" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="d_in" num_pins="32"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="32"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="perimeter"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -229,21 +237,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	    -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
            book area formula. This means the mux transistors are about 5x minimum drive strength.
            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -255,91 +263,89 @@
            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
            2.5x when looking up in Jeff's tables.
            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
              With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <directlist>  
-      <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>  
-   </directlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -347,255 +353,255 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="40" equivalent="full"/>   
-         <input name="cin" num_pins="1"/>   
-         <output name="O" num_pins="20" equivalent="none"/>   
-         <output name="cout" num_pins="1"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="10">    
-            <input name="in" num_pins="6"/>    
-            <input name="cin" num_pins="1"/>    
-            <output name="out" num_pins="2"/>    
-            <output name="cout" num_pins="1"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="2"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="lut4_out" num_pins="4"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut4_out" num_pins="4"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>        
-                        <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>               
-                  <!-- Define adders -->      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="2">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>       
-                     <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>       
-                     <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>       
-                     <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>       
-                     <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>       
-                     <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>       
-                     <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>       
-                     <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fle.cin" output="fabric.cin"/>      
-                  <direct name="direct3" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct4" input="fabric.cout" output="fle.cout"/>      
-                  <direct name="direct5" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- BEGIN fle mode of dual lut5 -->    
-            <mode name="n2_lut5">     
-               <pb_type name="ble5" num_pb="2">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Regular LUT mode -->      
-                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="5" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                   we instead take the average of these numbers to get more stable results
                 82e-12
                 173e-12
                 261e-12
                 263e-12
                 398e-12
-                -->       
-                     <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                 235e-12
                 235e-12
                 235e-12
                 235e-12
                 235e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble5.in" output="lut5.in"/>       
-                     <direct name="direct2" input="lut5.out" output="ff.D">        
-                        <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble5.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">        
-                        <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>      
-                  <complete name="direct3" input="fle.clk" output="ble5.clk"/>      
-                  <direct name="direct4" input="ble5.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- END fle mode of dual lut5 -->    
-            <!-- BEGIN arithmetic mode of dual lut4 + adders -->    
-            <mode name="arithmetic">     
-               <pb_type name="arithmetic" num_pb="2">      
-                  <input name="in" num_pins="4"/>      
-                  <input name="cin" num_pins="1"/>      
-                  <output name="out" num_pins="1"/>      
-                  <output name="cout" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Special dual-LUT mode that drives adder only -->      
-                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">       
-                     <input name="in" num_pins="4" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+              </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
                   261e-12
                   263e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                   195e-12
                   195e-12
                   195e-12
                   195e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">       
-                     <input name="a" num_pins="1"/>       
-                     <input name="b" num_pins="1"/>       
-                     <input name="cin" num_pins="1"/>       
-                     <output name="cout" num_pins="1"/>       
-                     <output name="sumout" num_pins="1"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>       
-                     <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>       
-                     <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="clock" input="arithmetic.clk" output="ff.clk"/>       
-                     <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>       
-                     <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>       
-                     <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
-                </direct>       
-                     <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
-                </direct>       
-                     <direct name="add_to_ff" input="adder.sumout" output="ff.D">        
-                        <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="carry_in" input="arithmetic.cin" output="adder.cin">        
-                        <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>        
-                     </direct>       
-                     <direct name="carry_out" input="adder.cout" output="arithmetic.cout">        
-                        <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>        
-                     </direct>       
-                     <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">        
-                        <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>      
-                  <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>      
-                  <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">       
-                     <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>       
-                  </direct>      
-                  <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">       
-                     <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>       
-                  </direct>      
-                  <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">       
-                     <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>       
-                  </direct>      
-                  <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>      
-                  <direct name="direct4" input="arithmetic.out" output="fle.out"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n2_lut5 -->    
-            <mode name="n1_lut6">     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -603,45 +609,45 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
                   261e-12
-                </delay_matrix>       
-                  </pb_type>      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- n1_lut6 -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
            The delays below come from Stratix IV. the delay through a connection block
            input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
            delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -649,93 +655,92 @@
            The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
            Since all our outputs LUT outputs go to a BLE output, and have a delay of 
            25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-           to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>     
-            </complete>    
-
-            <complete name="clks" input="clb.clk" output="fle[9:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                  By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                  then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                  naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>    
-            <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>    
-            <!-- Carry chain links -->    
-            <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">     
-               <!-- Put all inter-block carry chain delay on this one edge -->     
-               <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-               <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>     
-            </direct>    
-            <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">     
-               <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>     
-            </direct>    
-            <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">     
-               <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>     
-            </direct>    
-         </interconnect>   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-      <!-- Define single-mode dual-port memory begin -->  
-      <pb_type name="memory">   
-         <input name="waddr" num_pins="10"/>   
-         <input name="raddr" num_pins="10"/>   
-         <input name="d_in" num_pins="32"/>   
-         <input name="wen" num_pins="1"/>   
-         <input name="ren" num_pins="1"/>   
-         <output name="d_out" num_pins="32"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Specify the 512x32=16Kbit memory block
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="d_in" num_pins="32"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="32"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 512x32=16Kbit memory block
            Note: the delay numbers are extracted from VPR flagship XML without modification
                  Should align to the process technology we using to create the 16K dual-port RAM
-        -->   
-         <mode name="mem_512x32_dp">    
-            <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">     
-               <input name="waddr" num_pins="10" port_class="address"/>     
-               <input name="raddr" num_pins="10" port_class="address"/>     
-               <input name="d_in" num_pins="32" port_class="data_in"/>     
-               <input name="wen" num_pins="1" port_class="write_en"/>     
-               <input name="ren" num_pins="1" port_class="write_en"/>     
-               <output name="d_out" num_pins="32" port_class="data_out"/>     
-               <clock name="clk" num_pins="1" port_class="clock"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>     
-               <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>     
-               <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>     
-               <power method="pin-toggle">      
-                  <port name="clk" energy_per_toggle="17.9e-12"/>      
-                  <static_power power_per_instance="0.0"/>      
-               </power>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">      
-                  <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>      
-               </direct>     
-               <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">      
-                  <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>      
-               </direct>     
-               <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">      
-                  <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>      
-               </direct>     
-               <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">      
-                  <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>      
-               </direct>     
-               <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">      
-                  <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>      
-               </direct>     
-               <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">      
-                  <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>      
-               </direct>     
-               <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
-          </direct>     
-            </interconnect>    
-         </mode>   
-      </pb_type>  
-      <!-- Define single-mode dual-port memory end -->  
-   </complexblocklist> 
+        -->
+      <mode name="mem_512x32_dp">
+        <pb_type name="mem_512x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address"/>
+          <input name="raddr" num_pins="10" port_class="address"/>
+          <input name="d_in" num_pins="32" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x32_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_512x32_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_512x32_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_512x32_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_512x32_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_512x32_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_512x32_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_512x32_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_512x32_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_512x32_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_512x32_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_512x32_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_512x32_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_512x32_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
 </architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N8_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N8_tileable_40nm.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" ?><!-- 
+<?xml version="1.0"?>
+<!-- 
   Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
 
   - 40 nm technology
@@ -12,8 +13,9 @@
   Based on flagship k6_frac_N10_mem32K_40nm.xml architecture.
 
   Authors: Jason Luu, Jeff Goeders, Vaughn Betz
---><architecture> 
-   <!-- 
+-->
+<architecture>
+  <!-- 
        ODIN II specific config begins 
        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
        ".model [type_of_block]") that this architecture supports.
@@ -21,78 +23,82 @@
        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
        already special structures in blif (.names, .input, .output, and .latch) 
        that describe them.
-  --> 
-   <models>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="io">   
-         <input_ports>    
-            <port name="outpad"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="inpad"/>    
-         </output_ports>   
-      </model>  
-      <!-- A virtual model for I/O to be used in the physical mode of io block -->  
-      <model name="frac_lut6">   
-         <input_ports>    
-            <port name="in"/>    
-         </input_ports>   
-         <output_ports>    
-            <port name="lut5_out"/>    
-            <port name="lut6_out"/>    
-         </output_ports>   
-      </model>  
-   </models> 
-   <tiles>  
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
          If you need to register the I/O, define clocks in the circuit models
          These clocks can be handled in back-end
-     -->  
-      <tile name="io" area="0">   <sub_tile name="io" capacity="8">    
-          <equivalent_sites>     
-             <site pb_type="io"/>     
-          </equivalent_sites>    
-          <input name="outpad" num_pins="1"/>    
-          <output name="inpad" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="custom">     
-             <loc side="left">io.outpad io.inpad</loc>     
-             <loc side="top">io.outpad io.inpad</loc>     
-             <loc side="right">io.outpad io.inpad</loc>     
-             <loc side="bottom">io.outpad io.inpad</loc>     
-          </pinlocations>    
-       </sub_tile>  </tile>  
-      <tile name="clb" area="53894">   <sub_tile name="clb">    
-          <equivalent_sites>     
-             <site pb_type="clb"/>     
-          </equivalent_sites>    
-          <input name="I" num_pins="32" equivalent="full"/>    
-          <output name="O" num_pins="16" equivalent="none"/>    
-          <clock name="clk" num_pins="1"/>    
-          <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>    
-          <pinlocations pattern="spread"/>    
-       </sub_tile>  </tile>  
-   </tiles> 
-   <!-- ODIN II specific config ends --> 
-   <!-- Physical descriptions begin --> 
-   <layout tileable="true">  
-      <auto_layout aspect_ratio="1.0">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </auto_layout>  
-      <fixed_layout name="2x2" width="4" height="4">   
-         <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->   
-         <perimeter type="io" priority="100"/>   
-         <corners type="EMPTY" priority="101"/>   
-         <!--Fill with 'clb'-->   
-         <fill type="clb" priority="10"/>   
-      </fixed_layout>  
-   </layout> 
-   <device>  
-      <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="32" equivalent="full"/>
+        <output name="O" num_pins="16" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
 			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
 			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
 			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
@@ -106,21 +112,21 @@
 			     The delay values are lined up with Stratix IV, which has an architecture similar to this
 			     proposed FPGA, and which is also 40 nm 
 			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->  
-      <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>  
-      <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
      	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->  
-      <area grid_logic_tile_area="0"/>  
-      <chan_width_distr>   
-         <x distr="uniform" peak="1.000000"/>   
-         <y distr="uniform" peak="1.000000"/>   
-      </chan_width_distr>  
-      <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>  
-      <connection_block input_switch_name="ipin_cblock"/>  
-   </device> 
-   <switchlist>  
-      <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
 	       book area formula. This means the mux transistors are about 5x minimum drive strength.
 	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
 	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
@@ -132,87 +138,86 @@
 	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
 	       2.5x when looking up in Jeff's tables.
 	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->  
-      <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>  
-      <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->  
-      <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>  
-   </switchlist> 
-   <segmentlist>  
-      <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
 			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->  
-      <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->  
-      <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">   
-         <mux name="0"/>   
-         <sb type="pattern">1 1 1 1 1</sb>   
-         <cb type="pattern">1 1 1 1</cb>   
-      </segment>  
-   </segmentlist> 
-   <complexblocklist>  
-      <!-- Define I/O pads begin -->  
-      <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->  
-      <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->  
-      <pb_type name="io">   
-         <input name="outpad" num_pins="1"/>   
-         <output name="inpad" num_pins="1"/>   
-         <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
            If you need to register the I/O, define clocks in the circuit models
            These clocks can be handled in back-end
-       -->   
-         <!-- A mode denotes the physical implementation of an I/O 
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
            This mode will be not packable but is mainly used for fabric verilog generation   
-        -->   
-         <mode name="physical" disable_packing="true">    
-            <pb_type name="iopad" blif_model=".subckt io" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="iopad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>      
-               </direct>     
-               <direct name="inpad" input="iopad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-
-         <!-- IOs can operate as either inputs or outputs.
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
 	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
 	     the delays to and from registers in the I/O (and generally I/Os are registered 
 	     today and that is when you timing analyze them.
-	     -->   
-         <mode name="inpad">    
-            <pb_type name="inpad" blif_model=".input" num_pb="1">     
-               <output name="inpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="inpad" input="inpad.inpad" output="io.inpad">      
-                  <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <mode name="outpad">    
-            <pb_type name="outpad" blif_model=".output" num_pb="1">     
-               <input name="outpad" num_pins="1"/>     
-            </pb_type>    
-            <interconnect>     
-               <direct name="outpad" input="io.outpad" output="outpad.outpad">      
-                  <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>      
-               </direct>     
-            </interconnect>    
-         </mode>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- IOs go on the periphery of the FPGA, for consistency, 
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
           make it physically equivalent on all sides so that only one definition of I/Os is needed.
           If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
-        -->   
-         <!-- Place I/Os on the sides of the FPGA -->   
-         <power method="ignore"/>   
-      </pb_type>  
-      <!-- Define I/O pads ends -->  
-      <!-- Define general purpose logic block (CLB) begin -->  
-      <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
 	   area is 60 L^2 yields a tile area of 84375 MWTAs.
 	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
 	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
@@ -220,152 +225,152 @@
 	   area in this analysis. That is a lower proportion of of routing area than most academics
 	   assume, but note that the total routing area really includes the crossbar, which would push
 	   routing area up significantly, we estimate into the ~70% range. 
-	   -->  
-      <pb_type name="clb">   
-         <input name="I" num_pins="32" equivalent="full"/>   
-         <output name="O" num_pins="16" equivalent="none"/>   
-         <clock name="clk" num_pins="1"/>   
-         <!-- Describe fracturable logic element.  
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="32" equivalent="full"/>
+      <output name="O" num_pins="16" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
              Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
              The outputs of the fracturable logic element can be optionally registered
-        -->   
-         <pb_type name="fle" num_pb="8">    
-            <input name="in" num_pins="6"/>    
-            <output name="out" num_pins="2"/>    
-            <clock name="clk" num_pins="1"/>    
-            <!-- Physical mode definition begin (physical implementation of the fle) -->    
-            <mode name="physical" disable_packing="true">     
-               <pb_type name="fabric" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="frac_logic" num_pb="1">       
-                     <input name="in" num_pins="6"/>       
-                     <output name="out" num_pins="2"/>       
-                     <!-- Define LUT -->       
-                     <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">        
-                        <input name="in" num_pins="6"/>        
-                        <output name="lut5_out" num_pins="2"/>        
-                        <output name="lut6_out" num_pins="1"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>        
-                        <direct name="direct2" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>        
-                        <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->        
-                        <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>        
-                     </interconnect>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="fabric.in" output="frac_logic.in"/>       
-                     <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>       
-                     <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>       
-                     <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>        
-                        <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>        
-                     </mux>       
-                     <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>        
-                        <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="fabric.in"/>      
-                  <direct name="direct2" input="fabric.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="fabric.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Physical mode definition end (physical implementation of the fle) -->    
-            <!-- Dual 5-LUT mode definition begin -->    
-            <mode name="n2_lut5">     
-               <pb_type name="lut5inter" num_pb="1">      
-                  <input name="in" num_pins="5"/>      
-                  <output name="out" num_pins="2"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <pb_type name="ble5" num_pb="2">       
-                     <input name="in" num_pins="5"/>       
-                     <output name="out" num_pins="1"/>       
-                     <clock name="clk" num_pins="1"/>       
-                     <!-- Define the LUT -->       
-                     <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">        
-                        <input name="in" num_pins="5" port_class="lut_in"/>        
-                        <output name="out" num_pins="1" port_class="lut_out"/>        
-                        <!-- LUT timing using delay matrix -->        
-                        <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+        -->
+      <pb_type name="fle" num_pb="8">
+        <input name="in" num_pins="6"/>
+        <output name="out" num_pins="2"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <complete name="direct3" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fabric.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 5-LUT mode definition begin -->
+        <mode name="n2_lut5">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="5" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                            we instead take the average of these numbers to get more stable results
                       82e-12
                       173e-12
                       261e-12
                       263e-12
                       398e-12
-                      -->        
-                        <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                      -->
+                <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
                   235e-12
                   235e-12
                   235e-12
                   235e-12
                   235e-12
-                </delay_matrix>        
-                     </pb_type>       
-                     <!-- Define the flip-flop -->       
-                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">        
-                        <input name="D" num_pins="1" port_class="D"/>        
-                        <output name="Q" num_pins="1" port_class="Q"/>        
-                        <clock name="clk" num_pins="1" port_class="clock"/>        
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>        
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>        
-                     </pb_type>       
-                     <interconnect>        
-                        <direct name="direct1" input="ble5.in[4:0]" output="lut5[0:0].in[4:0]"/>        
-                        <direct name="direct2" input="lut5[0:0].out" output="ff[0:0].D">         
-                           <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->         
-                           <pack_pattern name="ble5" in_port="lut5[0:0].out" out_port="ff[0:0].D"/>         
-                        </direct>        
-                        <direct name="direct3" input="ble5.clk" output="ff[0:0].clk"/>        
-                        <mux name="mux1" input="ff[0:0].Q lut5.out[0:0]" output="ble5.out[0:0]">         
-                           <!-- LUT to output is faster than FF to output on a Stratix IV -->         
-                           <delay_constant max="25e-12" in_port="lut5.out[0:0]" out_port="ble5.out[0:0]"/>         
-                           <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>         
-                        </mux>        
-                     </interconnect>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>       
-                     <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>       
-                     <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>       
-                     <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>      
-                  <direct name="direct2" input="lut5inter.out" output="fle.out"/>      
-                  <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- Dual 5-LUT mode definition end -->    
-            <!-- 6-LUT mode definition begin -->    
-            <mode name="n1_lut6">     
-               <!-- Define 6-LUT mode -->     
-               <pb_type name="ble6" num_pb="1">      
-                  <input name="in" num_pins="6"/>      
-                  <output name="out" num_pins="1"/>      
-                  <clock name="clk" num_pins="1"/>      
-                  <!-- Define LUT -->      
-                  <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">       
-                     <input name="in" num_pins="6" port_class="lut_in"/>       
-                     <output name="out" num_pins="1" port_class="lut_out"/>       
-                     <!-- LUT timing using delay matrix -->       
-                     <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble5.in[4:0]" output="lut5[0:0].in[4:0]"/>
+                <direct name="direct2" input="lut5[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble5" in_port="lut5[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble5.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut5.out[0:0]" output="ble5.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut5.out[0:0]" out_port="ble5.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble5.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 5-LUT mode definition end -->
+        <!-- 6-LUT mode definition begin -->
+        <mode name="n1_lut6">
+          <!-- Define 6-LUT mode -->
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
                        we instead take the average of these numbers to get more stable results
                   82e-12
                   173e-12
@@ -373,48 +378,48 @@
                   263e-12
                   398e-12
                   397e-12
-                  -->       
-                     <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
                 261e-12
-              </delay_matrix>       
-                  </pb_type>      
-                  <!-- Define flip-flop -->      
-                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">       
-                     <input name="D" num_pins="1" port_class="D"/>       
-                     <output name="Q" num_pins="1" port_class="Q"/>       
-                     <clock name="clk" num_pins="1" port_class="clock"/>       
-                     <T_setup value="66e-12" port="ff.D" clock="clk"/>       
-                     <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>       
-                  </pb_type>      
-                  <interconnect>       
-                     <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>       
-                     <direct name="direct2" input="lut6.out" output="ff.D">        
-                        <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->        
-                        <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>        
-                     </direct>       
-                     <direct name="direct3" input="ble6.clk" output="ff.clk"/>       
-                     <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">        
-                        <!-- LUT to output is faster than FF to output on a Stratix IV -->        
-                        <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>        
-                        <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>        
-                     </mux>       
-                  </interconnect>      
-               </pb_type>     
-               <interconnect>      
-                  <direct name="direct1" input="fle.in" output="ble6.in"/>      
-                  <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>      
-                  <direct name="direct3" input="fle.clk" output="ble6.clk"/>      
-               </interconnect>     
-            </mode>    
-            <!-- 6-LUT mode definition end -->    
-         </pb_type>   
-         <interconnect>    
-            <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
 		     The delays below come from Stratix IV. the delay through a connection block
 		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
 		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
@@ -422,24 +427,24 @@
 		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
 		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
 		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
-		     to get the part that should be marked on the crossbar.	 -->    
-            <complete name="crossbar" input="clb.I fle[7:0].out" output="fle[7:0].in">     
-               <delay_constant max="95e-12" in_port="clb.I" out_port="fle[7:0].in"/>     
-               <delay_constant max="75e-12" in_port="fle[7:0].out" out_port="fle[7:0].in"/>     
-            </complete>    
-            <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>    
-            <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[7:0].out" output="fle[7:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[7:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[7:0].out" out_port="fle[7:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
                By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
                then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
                naive specification).
-          -->    
-            <direct name="clbouts1" input="fle[7:0].out[0:0]" output="clb.O[7:0]"/>    
-            <direct name="clbouts2" input="fle[7:0].out[1:1]" output="clb.O[15:8]"/>    
-         </interconnect>   
-         <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->   
-         <!-- Place this general purpose logic block in any unspecified column -->   
-      </pb_type>  
-      <!-- Define general purpose logic block (CLB) ends -->  
-   </complexblocklist> 
+          -->
+        <direct name="clbouts1" input="fle[7:0].out[0:0]" output="clb.O[7:0]"/>
+        <direct name="clbouts2" input="fle[7:0].out[1:1]" output="clb.O[15:8]"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
 </architecture>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #832 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- architecture XML files do not follow a standard format, which may have lint errors or cause mistakenly formatted by users when viewing through tools, e.g., VScode.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] XML code format can be applied by ``make format-xml``. **Only** format ``openfpga_flow/vpr_arch`` and ``openfpga_flow/openfpga_arch``
- [x] Updated architecture XML using [xmllint](https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html)
- [x] Force XML code format check on CI 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
