### PR TITLE
Pcf hotfix - Avoid key collision when validating pcf data 

### DIFF
--- a/libs/libpcf/src/base/pcf_data.cpp
+++ b/libs/libpcf/src/base/pcf_data.cpp
@@ -60,7 +60,8 @@ bool PcfData::validate() const {
     net2pin[curr_net] = curr_pin;
   }
   /* We should not have duplicated pins in assignment: 1 pin -> 2 nets */
-  /* Caution: must use constant pointer here, otherwise you may see duplicated key on BasicPort with different content! */
+  /* Caution: must use constant pointer here, otherwise you may see duplicated
+   * key on BasicPort with different content! */
   std::map<const BasicPort*, std::string> pin2net;
   for (const PcfIoConstraintId& io_id : io_constraints()) {
     std::string curr_net = io_constraint_nets_[io_id];

--- a/libs/libpcf/src/base/pcf_data.cpp
+++ b/libs/libpcf/src/base/pcf_data.cpp
@@ -70,6 +70,7 @@ bool PcfData::validate() const {
       VTR_LOG_ERROR("Pin '%s[%lu]' is assigned to two nets '%s' and '%s'!\n",
                     curr_pin.get_name().c_str(), curr_pin.get_lsb(),
                     result->second.c_str(), curr_net.c_str());
+      num_err++;
     }
     pin2net[curr_pin] = curr_net;
   }

--- a/libs/libpcf/src/base/pcf_data.cpp
+++ b/libs/libpcf/src/base/pcf_data.cpp
@@ -60,11 +60,12 @@ bool PcfData::validate() const {
     net2pin[curr_net] = curr_pin;
   }
   /* We should not have duplicated pins in assignment: 1 pin -> 2 nets */
-  std::map<BasicPort, std::string> pin2net;
+  /* Caution: must use constant pointer here, otherwise you may see duplicated key on BasicPort with different content! */
+  std::map<const BasicPort*, std::string> pin2net;
   for (const PcfIoConstraintId& io_id : io_constraints()) {
     std::string curr_net = io_constraint_nets_[io_id];
-    BasicPort curr_pin = io_constraint_pins_[io_id];
-    auto result = pin2net.find(curr_pin);
+    const BasicPort& curr_pin = io_constraint_pins_[io_id];
+    auto result = pin2net.find(&curr_pin);
     if (result != pin2net.end()) {
       /* Found one pin assigned to two nets, this is definitely an error  */
       VTR_LOG_ERROR("Pin '%s[%lu]' is assigned to two nets '%s' and '%s'!\n",
@@ -72,7 +73,7 @@ bool PcfData::validate() const {
                     result->second.c_str(), curr_net.c_str());
       num_err++;
     }
-    pin2net[curr_pin] = curr_net;
+    pin2net[&curr_pin] = curr_net;
   }
   if (num_err) {
     return false;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [x] Fixed a bug where validation failed but return no error numbers
- [x] Use constant pointer so that we can avoid key collision when validating pcf data

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
