### PR TITLE
Update dpram16k, dpram2048x8 and dpram1k

### DIFF
--- a/openfpga_flow/openfpga_cell_library/verilog/dpram16k.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dpram16k.v
@@ -14,7 +14,7 @@ module dpram_512x32 (
 	input[0:31] d_in,
 	output[0:31] d_out );
 
-		dual_port_sram memory_0 (
+		dpram_512x32_core memory_0 (
 			.wclk		(clk),
 			.wen		(wen),
 			.waddr		(waddr),
@@ -26,7 +26,7 @@ module dpram_512x32 (
 
 endmodule
 
-module dual_port_sram (
+module dpram_512x32_core (
 	input wclk,
 	input wen,
 	input[0:9] waddr,

--- a/openfpga_flow/openfpga_cell_library/verilog/dpram1k.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dpram1k.v
@@ -14,7 +14,7 @@ module dpram_128x8 (
 	input[0:7] d_in,
 	output[0:7] d_out );
 
-		dual_port_sram memory_0 (
+		dpram_128x8_core memory_0 (
 			.wclk		(clk),
 			.wen		(wen),
 			.waddr		(waddr),
@@ -26,7 +26,7 @@ module dpram_128x8 (
 
 endmodule
 
-module dual_port_sram (
+module dpram_128x8_core (
 	input wclk,
 	input wen,
 	input[0:6] waddr,

--- a/openfpga_flow/openfpga_cell_library/verilog/dpram_2048x8.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dpram_2048x8.v
@@ -14,7 +14,7 @@ module dpram_2048x8 (
   input[0:7] data_in,
   output[0:7] data_out );
 
-    dual_port_sram memory_0 (
+    dpram_2048x8_core memory_0 (
       .wclk    (clk),
       .wen    (wen),
       .waddr    (waddr),
@@ -32,7 +32,7 @@ endmodule
 // Function    : Core module of dual port RAM 2048 addresses x 8 bit
 // Coder       : Xifan tang
 //-----------------------------------------------------
-module dual_port_sram (
+module dpram_2048x8_core (
   input wclk,
   input wen,
   input[0:10] waddr,


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> The dual port RAM modules have the same named `dual_port_sram` submodules that can confuse Design Compiler NXT while compiling them one-by-one in the same working space. So, their names have changed. Also, `dpram.v`  and `dpram_512x
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->
> The `dual_port_sram` names are rewritten according to their sizes.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [X] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
