### PR TITLE
Now OpenFPGA Shell can show customized name in ending messages

### DIFF
--- a/libs/libopenfpgashell/src/shell.tpp
+++ b/libs/libopenfpgashell/src/shell.tpp
@@ -369,7 +369,7 @@ void Shell<T>::run_script_mode(const char* script_file_name,
       if (CMD_EXEC_FATAL_ERROR == status) {
         VTR_LOG("Fatal error occurred!\n");
         /* If in the batch mode, we will exit with errors */ 
-        VTR_LOGV(batch_mode, "OpenFPGA Abort\n");
+        VTR_LOGV(batch_mode, "%s Abort\n", name_.c_str());
         if (batch_mode) {
           exit(CMD_EXEC_FATAL_ERROR);
         }
@@ -461,7 +461,8 @@ void Shell<T>::exit(const int& init_err) const {
   VTR_LOG("\nFinish execution with %d errors\n",
             num_err);
 
-  VTR_LOG("\nThe entire OpenFPGA flow took %g seconds\n",
+  VTR_LOG("\nThe entire %s flow took %g seconds\n",
+          name_.c_str(),
           (double)(std::clock() - time_start_) / (double)CLOCKS_PER_SEC);
 
   VTR_LOG("\nThank you for using %s!\n",


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Shell name is hardcoded in openfpga shell's ending messages. This will limit the use of openfpgashell in extension
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Remove hardcoded name and replace with a shell name which can be customized when initialize the shell.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
