### PR TITLE
Cleanup: Move command string parsing to OpenFPGA Tokenizer

### DIFF
--- a/libs/libopenfpgautil/src/openfpga_tokenizer.cpp
+++ b/libs/libopenfpgautil/src/openfpga_tokenizer.cpp
@@ -89,6 +89,40 @@ std::vector<std::string> StringToken::split() {
   return split(delims);
 }
 
+std::vector<size_t> StringToken::find_positions(const char& delim) const {
+  std::vector<size_t> anchors;
+  size_t found = data_.find(delim);
+  while (std::string::npos != found) {
+    anchors.push_back(found);
+    found = data_.find(delim, found + 1);
+  }
+  return anchors;
+}
+
+std::vector<std::string> StringToken::split_by_chunks(const char& chunk_delim, const bool& split_odd_chunk) const {
+  size_t chunk_idx_mod = 0;
+  if (split_odd_chunk) {
+    chunk_idx_mod = 1;
+  }
+  std::vector<std::string> tokens; 
+  /* There are pairs of quotes, identify the chunk which should be split*/
+  std::vector<std::string> token_chunks = split(chunk_delim);
+  for (size_t ichunk = 0; ichunk < token_chunks.size(); ichunk++) {
+    /* Chunk with even index (including the first) is always out of two quote -> Split!
+     * Chunk with odd index is always between two quotes -> Do not split!
+     */
+    if (ichunk % 2 == chunk_idx_mod) {
+      StringToken chunk_tokenizer(token_chunks[ichunk]);  
+      for (std::string curr_token : chunk_tokenizer.split()) {
+        tokens.push_back(curr_token);
+      }
+    } else {
+      tokens.push_back(token_chunks[ichunk]);
+    }
+  }
+  return tokens;
+}
+
 /************************************************************************
  * Public Mutators
  ***********************************************************************/

--- a/libs/libopenfpgautil/src/openfpga_tokenizer.cpp
+++ b/libs/libopenfpgautil/src/openfpga_tokenizer.cpp
@@ -99,20 +99,21 @@ std::vector<size_t> StringToken::find_positions(const char& delim) const {
   return anchors;
 }
 
-std::vector<std::string> StringToken::split_by_chunks(const char& chunk_delim, const bool& split_odd_chunk) const {
+std::vector<std::string> StringToken::split_by_chunks(
+  const char& chunk_delim, const bool& split_odd_chunk) const {
   size_t chunk_idx_mod = 0;
   if (split_odd_chunk) {
     chunk_idx_mod = 1;
   }
-  std::vector<std::string> tokens; 
+  std::vector<std::string> tokens;
   /* There are pairs of quotes, identify the chunk which should be split*/
   std::vector<std::string> token_chunks = split(chunk_delim);
   for (size_t ichunk = 0; ichunk < token_chunks.size(); ichunk++) {
-    /* Chunk with even index (including the first) is always out of two quote -> Split!
-     * Chunk with odd index is always between two quotes -> Do not split!
+    /* Chunk with even index (including the first) is always out of two quote ->
+     * Split! Chunk with odd index is always between two quotes -> Do not split!
      */
     if (ichunk % 2 == chunk_idx_mod) {
-      StringToken chunk_tokenizer(token_chunks[ichunk]);  
+      StringToken chunk_tokenizer(token_chunks[ichunk]);
       for (std::string curr_token : chunk_tokenizer.split()) {
         tokens.push_back(curr_token);
       }

--- a/libs/libopenfpgautil/src/openfpga_tokenizer.h
+++ b/libs/libopenfpgautil/src/openfpga_tokenizer.h
@@ -27,28 +27,28 @@ class StringToken {
   std::vector<std::string> split(const char* delim) const;
   std::vector<std::string> split(const std::vector<char>& delim) const;
   std::vector<std::string> split();
-  /** @brief Find the position (i-th charactor) in a string for a given delimiter, it will return a list of positions
-   * For example, to find the position of all quotes (") in a string:
-   *   "we" are good
-   * The following code is suggested:
-   *   StringToken tokenizer("\"we\" are good");
-   *   std::vector<size_t> anchors = tokenizer.find_positions('\"')
-   * The following vector will be returned:
-   *  [0, 3] */
+  /** @brief Find the position (i-th charactor) in a string for a given
+   * delimiter, it will return a list of positions For example, to find the
+   * position of all quotes (") in a string: "we" are good The following code is
+   * suggested: StringToken tokenizer("\"we\" are good"); std::vector<size_t>
+   * anchors = tokenizer.find_positions('\"') The following vector will be
+   * returned: [0, 3] */
   std::vector<size_t> find_positions(const char& delim) const;
-  /** @brief split the string for each chunk. This is useful where there are chunks of substring should not be splitted by the given delimiter
-   * For example, to split the string with quotes (") in a string:
-   *   source "cmdA --opt1 val1;cmdB --opt2 val2" --verbose
-   * where the string between the two quotes should not be splitted
-   * The following code is suggested:
-   *   StringToken tokenizer("source \"cmdA --opt1 val1;cmdB --opt2 val2\" --verbose");
+  /** @brief split the string for each chunk. This is useful where there are
+   * chunks of substring should not be splitted by the given delimiter For
+   * example, to split the string with quotes (") in a string: source "cmdA
+   * --opt1 val1;cmdB --opt2 val2" --verbose where the string between the two
+   * quotes should not be splitted The following code is suggested: StringToken
+   * tokenizer("source \"cmdA --opt1 val1;cmdB --opt2 val2\" --verbose");
    *   std::vector<std::string> tokenizer.split_by_chunks('\"', true);
-   * The following vector will be returned:  
+   * The following vector will be returned:
    *   ["source" "cmdA --opt1 val1;cmdB --opt2 val2" "--verbose"]
-   * 
-   * .. note:: The option ``split_odd_chunk`` is useful when the chunk delimiter appears at the beginning of the string. 
+   *
+   * .. note:: The option ``split_odd_chunk`` is useful when the chunk delimiter
+   * appears at the beginning of the string.
    */
-  std::vector<std::string> split_by_chunks(const char& chunk_delim, const bool& split_odd_chunk = false) const;
+  std::vector<std::string> split_by_chunks(
+    const char& chunk_delim, const bool& split_odd_chunk = false) const;
 
  public: /* Public Mutators */
   void set_data(const std::string& data);

--- a/libs/libopenfpgautil/src/openfpga_tokenizer.h
+++ b/libs/libopenfpgautil/src/openfpga_tokenizer.h
@@ -27,6 +27,28 @@ class StringToken {
   std::vector<std::string> split(const char* delim) const;
   std::vector<std::string> split(const std::vector<char>& delim) const;
   std::vector<std::string> split();
+  /** @brief Find the position (i-th charactor) in a string for a given delimiter, it will return a list of positions
+   * For example, to find the position of all quotes (") in a string:
+   *   "we" are good
+   * The following code is suggested:
+   *   StringToken tokenizer("\"we\" are good");
+   *   std::vector<size_t> anchors = tokenizer.find_positions('\"')
+   * The following vector will be returned:
+   *  [0, 3] */
+  std::vector<size_t> find_positions(const char& delim) const;
+  /** @brief split the string for each chunk. This is useful where there are chunks of substring should not be splitted by the given delimiter
+   * For example, to split the string with quotes (") in a string:
+   *   source "cmdA --opt1 val1;cmdB --opt2 val2" --verbose
+   * where the string between the two quotes should not be splitted
+   * The following code is suggested:
+   *   StringToken tokenizer("source \"cmdA --opt1 val1;cmdB --opt2 val2\" --verbose");
+   *   std::vector<std::string> tokenizer.split_by_chunks('\"', true);
+   * The following vector will be returned:  
+   *   ["source" "cmdA --opt1 val1;cmdB --opt2 val2" "--verbose"]
+   * 
+   * .. note:: The option ``split_odd_chunk`` is useful when the chunk delimiter appears at the beginning of the string. 
+   */
+  std::vector<std::string> split_by_chunks(const char& chunk_delim, const bool& split_odd_chunk = false) const;
 
  public: /* Public Mutators */
   void set_data(const std::string& data);


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Currently the command line parsing for supporting quotes are in OpenFPGA shell (shell.tpp), which should be part of the generic tokenizer in openfpga utility library
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- As titled

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
