### PR TITLE
Now hidden commands are not allowed to be called through interactive mode and script model in OpenFPGA shell

### DIFF
--- a/libs/libopenfpgashell/src/shell.h
+++ b/libs/libopenfpgashell/src/shell.h
@@ -206,8 +206,9 @@ class Shell {
   void exit(const int& init_err = 0) const;
   /* Execute a command, the command line is the user's input to launch a command
    * The common_context is the data structure to exchange data between commands
+   * Optionally, hidden commands may be forbidden to call. User can allow them to be called under different situations
    */
-  int execute_command(const char* cmd_line, T& common_context);
+  int execute_command(const char* cmd_line, T& common_context, const bool& allow_hidden_command = true);
 
  private: /* Internal data */
   /* Name of the shell, this will appear in the interactive mode */

--- a/libs/libopenfpgashell/src/shell.h
+++ b/libs/libopenfpgashell/src/shell.h
@@ -206,9 +206,11 @@ class Shell {
   void exit(const int& init_err = 0) const;
   /* Execute a command, the command line is the user's input to launch a command
    * The common_context is the data structure to exchange data between commands
-   * Optionally, hidden commands may be forbidden to call. User can allow them to be called under different situations
+   * Optionally, hidden commands may be forbidden to call. User can allow them
+   * to be called under different situations
    */
-  int execute_command(const char* cmd_line, T& common_context, const bool& allow_hidden_command = true);
+  int execute_command(const char* cmd_line, T& common_context,
+                      const bool& allow_hidden_command = true);
 
  private: /* Internal data */
   /* Name of the shell, this will appear in the interactive mode */

--- a/libs/libopenfpgashell/src/shell.tpp
+++ b/libs/libopenfpgashell/src/shell.tpp
@@ -286,7 +286,8 @@ void Shell<T>::run_interactive_mode(T& context, const bool& quiet_mode) {
      * Add to history 
      */
     if (strlen(cmd_line) > 0) {
-      execute_command((const char*)cmd_line, context);
+      /* Do not allow any hidden command to be directly called by users */
+      execute_command((const char*)cmd_line, context, false);
       add_history(cmd_line);
     }
 
@@ -378,7 +379,8 @@ void Shell<T>::run_script_mode(const char* script_file_name,
     /* Process the command only when the full command line in ended */
     if (!cmd_line.empty()) {
       VTR_LOG("\nCommand line to execute: %s\n", cmd_line.c_str());
-      int status = execute_command(cmd_line.c_str(), context);
+      /* Do not allow any hidden command to be directly called by users */
+      int status = execute_command(cmd_line.c_str(), context, false);
       /* Empty the line ready to start a new line */
       cmd_line.clear();
 
@@ -507,7 +509,7 @@ void Shell<T>::exit(const int& init_err) const {
  ***********************************************************************/
 template <class T>
 int Shell<T>::execute_command(const char* cmd_line,
-                               T& common_context) {
+                               T& common_context, const bool& allow_hidden_command) {
   openfpga::StringToken tokenizer(cmd_line);  
   tokenizer.add_delim(' ');
   /* Do not split the string in each quote "", as they should be a piece */
@@ -536,6 +538,14 @@ int Shell<T>::execute_command(const char* cmd_line,
     VTR_LOG("Try to call a command '%s' which is not defined!\n",
             tokens[0].c_str());
     return CMD_EXEC_FATAL_ERROR;
+  }
+  /* Do not allow hidden commands if specified */
+  if (!allow_hidden_command) {
+    if (command_hidden_[cmd_id]) {
+      VTR_LOG("Try to call a command '%s' which is not defined!\n",
+              tokens[0].c_str());
+      return CMD_EXEC_FATAL_ERROR;
+    }
   }
 
   /* Check the dependency graph to see if all the prequistics have been met */

--- a/libs/libopenfpgashell/src/shell.tpp
+++ b/libs/libopenfpgashell/src/shell.tpp
@@ -420,13 +420,13 @@ void Shell<T>::print_commands(const bool& show_hidden) const {
     }
     
     /* Print the class name */
-    if (show_hidden && hidden_class) {
+    if (!show_hidden && hidden_class) {
       continue;
     }
     VTR_LOG("%s:\n", command_class_names_[cmd_class].c_str());
 
     for (const ShellCommandId& cmd : commands_by_classes_[cmd_class]) {
-      if (show_hidden && command_hidden_[cmd]) {
+      if (!show_hidden && command_hidden_[cmd]) {
         continue;
       }
       VTR_LOG("\t%s\n", commands_[cmd].name().c_str());


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Hidden commands are already not shown in help desk but they can still be called in both interactive mode and script mode in OpenFPGA shell, as long as the users know their existence. This will hurt and confuse many users, especially for commercial vendors who want to keep their scerets.

> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- As titled. 
- Developers can freely specify if their hidden command can or cannot be called in these modes, depending their actual needs.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
