### PR TITLE
Fixed a bug in repack when only invisible routing sinks are … 

### DIFF
--- a/openfpga/src/repack/repack.cpp
+++ b/openfpga/src/repack/repack.cpp
@@ -766,7 +766,9 @@ static void add_lb_router_nets(
         VTR_LOGV(verbose, "Bypass routing due to no routing traces found\n");
         continue;
       } else {
-        VTR_LOGV(verbose, "No regular routing traces found but only invisible routing traces will be considered\n");
+        VTR_LOGV(verbose,
+                 "No regular routing traces found but only invisible routing "
+                 "traces will be considered\n");
       }
     } else if (1 == pb_route_indices.size()) {
       pb_route_index = pb_route_indices[0];

--- a/openfpga/src/repack/repack.cpp
+++ b/openfpga/src/repack/repack.cpp
@@ -762,8 +762,12 @@ static void add_lb_router_nets(
      * */
     int pb_route_index;
     if (0 == pb_route_indices.size()) {
-      VTR_LOGV(verbose, "Bypass routing due to no routing traces found\n");
-      continue;
+      if (ignored_global_net_sinks[atom_net_id_to_route].empty()) {
+        VTR_LOGV(verbose, "Bypass routing due to no routing traces found\n");
+        continue;
+      } else {
+        VTR_LOGV(verbose, "No regular routing traces found but only invisible routing traces will be considered\n");
+      }
     } else if (1 == pb_route_indices.size()) {
       pb_route_index = pb_route_indices[0];
     } else {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Repacker skip some nets to be routed, when there are no regular routing traces found but there are invisible routing traces existing.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- Repacker will route the net when there are only invisible routing traces existing

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
