### PR TITLE
Now Yosys binary is installed to build directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,8 @@ jobs:
             build/openfpga/libopenfpga.a
             build/openfpga/openfpga_shell.so
             build/openfpga/openfpga
-            yosys/install/share
-            yosys/install/bin
+            build/yosys/share
+            build/yosys/bin
             openfpga_flow
             openfpga.sh
 
@@ -446,11 +446,11 @@ jobs:
           chmod +x build/vtr-verilog-to-routing/ace2/ace
           chmod +x build/vtr-verilog-to-routing/vpr/vpr
           chmod +x build/openfpga/openfpga
-          chmod +x yosys/install/bin/yosys
-          chmod +x yosys/install/bin/yosys-abc
-          chmod +x yosys/install/bin/yosys-config
-          chmod +x yosys/install/bin/yosys-filterlib
-          chmod +x yosys/install/bin/yosys-smtbmc
+          chmod +x build/yosys/bin/yosys
+          chmod +x build/yosys/bin/yosys-abc
+          chmod +x build/yosys/bin/yosys-config
+          chmod +x build/yosys/bin/yosys-filterlib
+          chmod +x build/yosys/bin/yosys-smtbmc
       - name: ${{matrix.config.name}}_GCC-8_(Ubuntu 20.04)
         shell: bash
         run: source openfpga.sh && source openfpga_flow/regression_test_scripts/${{matrix.config.name}}.sh --debug --show_thread_logs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,14 +312,14 @@ endif()
 
 # we will check if yosys already exist. if not then build it
 if (OPENFPGA_WITH_YOSYS)
-    if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/yosys)
+    if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys)
         message(STATUS "Yosys pre-build exist so skipping it")
     else ()
         # run makefile provided, we pass-on the options to the local make file 
         add_custom_target(
             yosys ALL 
             COMMAND $(MAKE) config-gcc
-            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys
+            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys
             COMMENT "Compile Yosys with given Makefile"
         )
@@ -331,7 +331,7 @@ if (OPENFPGA_WITH_YOSYS)
                 yosys-plugins ALL
                 COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_BINARY_DIR}/yosys EXTRA_FLAGS="-DPASS_NAME=synth_ql"
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
-                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys
+                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
                 COMMENT "Compile Yosys-plugins with given Makefile"
             )
             add_dependencies(yosys-plugins yosys)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,15 +312,15 @@ endif()
 
 # we will check if yosys already exist. if not then build it
 if (OPENFPGA_WITH_YOSYS)
-    if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/yosys/install/bin/yosys)
+    if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/yosys)
         message(STATUS "Yosys pre-build exist so skipping it")
     else ()
         # run makefile provided, we pass-on the options to the local make file 
         add_custom_target(
             yosys ALL 
             COMMAND $(MAKE) config-gcc
-            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/install
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/yosys
+            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys
             COMMENT "Compile Yosys with given Makefile"
         )
         # yosys compilation ends
@@ -329,9 +329,9 @@ if (OPENFPGA_WITH_YOSYS)
         if (OPENFPGA_WITH_YOSYS_PLUGIN)
             add_custom_target(
                 yosys-plugins ALL
-                COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_BINARY_DIR}/yosys/install EXTRA_FLAGS="-DPASS_NAME=synth_ql"
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/yosys-plugins
-                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/install/bin/yosys
+                COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_BINARY_DIR}/yosys EXTRA_FLAGS="-DPASS_NAME=synth_ql"
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
+                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys
                 COMMENT "Compile Yosys-plugins with given Makefile"
             )
             add_dependencies(yosys-plugins yosys)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,15 +312,15 @@ endif()
 
 # we will check if yosys already exist. if not then build it
 if (OPENFPGA_WITH_YOSYS)
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/yosys/install/bin/yosys)
+    if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/yosys/install/bin/yosys)
         message(STATUS "Yosys pre-build exist so skipping it")
     else ()
         # run makefile provided, we pass-on the options to the local make file 
         add_custom_target(
             yosys ALL 
             COMMAND $(MAKE) config-gcc
-            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_SOURCE_DIR}/yosys/install
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys
+            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/install
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/yosys
             COMMENT "Compile Yosys with given Makefile"
         )
         # yosys compilation ends
@@ -329,9 +329,9 @@ if (OPENFPGA_WITH_YOSYS)
         if (OPENFPGA_WITH_YOSYS_PLUGIN)
             add_custom_target(
                 yosys-plugins ALL
-                COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_SOURCE_DIR}/yosys/install EXTRA_FLAGS="-DPASS_NAME=synth_ql"
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
-                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/yosys/install/bin/yosys
+                COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_BINARY_DIR}/yosys/install EXTRA_FLAGS="-DPASS_NAME=synth_ql"
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/yosys-plugins
+                DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/install/bin/yosys
                 COMMENT "Compile Yosys-plugins with given Makefile"
             )
             add_dependencies(yosys-plugins yosys)

--- a/docker/Dockerfile.master
+++ b/docker/Dockerfile.master
@@ -3,8 +3,8 @@ RUN mkdir -p /opt/openfpga
 WORKDIR /opt/openfpga
 COPY . /opt/openfpga
 RUN chmod +x build/vtr-verilog-to-routing/abc/abc build/vtr-verilog-to-routing/ace2/ace build/openfpga/openfpga build/vtr-verilog-to-routing/vpr/vpr
-RUN chmod +x yosys/install/bin/yosys yosys/install/bin/yosys-abc yosys/install/bin/yosys-config yosys/install/bin/yosys-filterlib yosys/install/bin/yosys-smtbmc
-ENV PATH="/opt/openfpga/build/openfpga:/opt/openfpga/yosys/install/bin:${PATH}"
+RUN chmod +x build/yosys/bin/yosys build/yosys/bin/yosys-abc build/yosys/bin/yosys-config build/yosys/bin/yosys-filterlib build/yosys/bin/yosys-smtbmc
+ENV PATH="/opt/openfpga/build/openfpga:/opt/openfpga/build/yosys/bin:${PATH}"
 ENV PATH="/opt/openfpga/build/vtr-verilog-to-routing/ace2:/opt/openfpga/build/vtr-verilog-to-routing/abc:/opt/openfpga/build/vtr-verilog-to-routing/vpr:${PATH}"
 ENV OPENFPGA_PATH="/opt/openfpga"
 

--- a/openfpga_flow/misc/fpgaflow_default_tool_path.conf
+++ b/openfpga_flow/misc/fpgaflow_default_tool_path.conf
@@ -1,13 +1,13 @@
 # Standard Configuration Example
 [CAD_TOOLS_PATH]
 openfpga_shell_path = ${PATH:OPENFPGA_PATH}/build/openfpga/openfpga
-yosys_path = ${PATH:OPENFPGA_PATH}/yosys/install/bin/yosys
+yosys_path = ${PATH:OPENFPGA_PATH}/build/yosys/install/bin/yosys
 misc_dir = ${PATH:OPENFPGA_PATH}/openfpga_flow/misc
 odin2_path = ${PATH:OPENFPGA_PATH}/openfpga_flow/not_used_atm/odin2.exe
-abc_path = ${PATH:OPENFPGA_PATH}/yosys/install/bin/yosys-abc
+abc_path = ${PATH:OPENFPGA_PATH}/build/yosys/install/bin/yosys-abc
 abc_mccl_path = ${PATH:OPENFPGA_PATH}/build/vtr-verilog-to-routing/abc/abc
-abc_with_bb_support_path = ${PATH:OPENFPGA_PATH}/vtr-verilog-to-routing/abc/abc
-vpr_path = ${PATH:OPENFPGA_PATH}/vtr-verilog-to-routing/vpr/vpr
+abc_with_bb_support_path = ${PATH:OPENFPGA_PATH}/build/vtr-verilog-to-routing/abc/abc
+vpr_path = ${PATH:OPENFPGA_PATH}/build/vtr-verilog-to-routing/vpr/vpr
 ace_path = ${PATH:OPENFPGA_PATH}/build/vtr-verilog-to-routing/ace2/ace
 pro_blif_path = ${PATH:OPENFPGA_PATH}/openfpga_flow/scripts/pro_blif.pl
 iverilog_path = iverilog

--- a/openfpga_flow/misc/fpgaflow_default_tool_path.conf
+++ b/openfpga_flow/misc/fpgaflow_default_tool_path.conf
@@ -1,10 +1,10 @@
 # Standard Configuration Example
 [CAD_TOOLS_PATH]
 openfpga_shell_path = ${PATH:OPENFPGA_PATH}/build/openfpga/openfpga
-yosys_path = ${PATH:OPENFPGA_PATH}/build/yosys/install/bin/yosys
+yosys_path = ${PATH:OPENFPGA_PATH}/build/yosys/bin/yosys
 misc_dir = ${PATH:OPENFPGA_PATH}/openfpga_flow/misc
 odin2_path = ${PATH:OPENFPGA_PATH}/openfpga_flow/not_used_atm/odin2.exe
-abc_path = ${PATH:OPENFPGA_PATH}/build/yosys/install/bin/yosys-abc
+abc_path = ${PATH:OPENFPGA_PATH}/build/yosys/bin/yosys-abc
 abc_mccl_path = ${PATH:OPENFPGA_PATH}/build/vtr-verilog-to-routing/abc/abc
 abc_with_bb_support_path = ${PATH:OPENFPGA_PATH}/build/vtr-verilog-to-routing/abc/abc
 vpr_path = ${PATH:OPENFPGA_PATH}/build/vtr-verilog-to-routing/vpr/vpr


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Yosys binary was installed to source directory of yosys submodule. This is not a standard way. It causes trouble when creating  binary release for OpenFPGA.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Move yosys binary to build directory (``build/yosys`` by default)
- [x] Adapted fpga flow default paths accrodingly. 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
