### PR TITLE
fix mux syntax in circuit_model_examples

### DIFF
--- a/docs/source/manual/arch_lang/circuit_model_examples.rst
+++ b/docs/source/manual/arch_lang/circuit_model_examples.rst
@@ -523,9 +523,9 @@ Template
 
 .. option:: <design_technology type="<string>" structure="<string>" num_level="<int>" add_const_input="<bool>" const_input_val="<int>" local_encoder="<bool>"/>
 
-  - ``structure="tree|multi-level|one-level"`` Specify the multiplexer structure for a multiplexer. The structure option is only valid for SRAM-based multiplexers. For RRAM-based multiplexers, currently we only support the one-level structure
+  - ``structure="tree|multi_level|one_level"`` Specify the multiplexer structure for a multiplexer. The structure option is only valid for SRAM-based multiplexers. For RRAM-based multiplexers, currently we only support the one_level structure
 
-  - ``num_level="<int>"`` Specify the number of levels when ``multi-level`` structure is selected.
+  - ``num_level="<int>"`` Specify the number of levels when ``multi_level`` structure is selected.
     
   - ``add_const_input="true|false"`` Specify if an extra input should be added to the multiplexer circuits. For example, an 4-input multiplexer will be turned to a 5-input multiplexer. The extra input will be wired to a constant value, which can be specified through the XML syntax ``const_input_val``.
 
@@ -563,7 +563,7 @@ The code describing this Multiplexer is:
 .. code-block:: xml
 
   <circuit_model type="mux" name="mux_1level" prefix="mux_1level">
-    <design_technology type="cmos" structure="one-level"/>
+    <design_technology type="cmos" structure="one_level"/>
     <input_buffer exist="on" circuit_model_name="inv1x"/> 
     <output_buffer exist="on" circuit_model_name="tapbuf4"/> 
     <pass_gate_logic circuit_model_name="tgate"/>


### PR DESCRIPTION
the documentation is inconsistent about using underscores or dashes when describing a mux. It used one-level, but multi_level. Only underscores are valid in openfpga

> ### Motivate of the pull request
> - [x ] To address an existing issue. If so, please provide a link to the issue: <issue id>
I didn't make an issue yet, I just noticed it and changed it. It's possible there are other occurrences I didn't see. 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
it changes one piece of documentation to fix some typos or leftover old syntax
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
N/A
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
