### PR TITLE
[doc] hotfix on sphinxcontrib-youtube package which causes readthedoc…

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,5 +24,3 @@ python:
   system_packages: true
   install:
     - requirements: docs/requirements.txt
-    - method: pip
-      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,9 @@ version: 2
 
 # Specify docker image for building the doc
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -19,7 +21,8 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   system_packages: true
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@
 sphinxcontrib-bibtex<2.0.0
 
 # Package required to embed youtube video
-sphinxcontrib-yt
+sphinxcontrib-youtube
 
 # Package required to convert SVG for latex building
 sphinxcontrib-svg2pdfconverter

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@
 #recommonmark
 
 #Handle references in bibtex format
-sphinxcontrib-bibtex<2.0.0
+sphinxcontrib-bibtex
 
 # Package required to embed youtube video
 sphinxcontrib-youtube

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ import sphinx_rtd_theme
 # For bibtex support
 import sphinxcontrib.bibtex
 # For embedded youtube
-import sphinxcontrib.yt
+import sphinxcontrib.youtube
 # For converting SVG to PNG using rsvg
 import sphinxcontrib.rsvgconverter
 
@@ -57,7 +57,7 @@ extensions = [
     'sphinx.ext.graphviz',
     'sphinxcontrib.bibtex',
     'sphinx.ext.autosectionlabel',
-    'sphinxcontrib.yt',
+    'sphinxcontrib.youtube',
     'sphinxcontrib.rsvgconverter',
 ]
 


### PR DESCRIPTION
…s to fail

> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- See the readthedocs build failures in recent PRs #755 #1149

The error logs from readthedocs is pointing to the python package ``sphinxcontrib-yt``, which is 3 year old. 

```
[rtd-command-info] start-time: 2023-05-04T01:57:15.259507Z, end-time: 2023-05-04T01:57:16.259264Z, duration: 0, exit-code: 1
python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
Collecting sphinxcontrib-bibtex<2.0.0 (from -r docs/requirements.txt (line 9))
  Downloading sphinxcontrib_bibtex-1.0.0-py3-none-any.whl (14 kB)
Collecting sphinxcontrib-yt (from -r docs/requirements.txt (line 12))
  Downloading sphinxcontrib.yt-0.2.2.tar.gz (2.3 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      ERROR: Can not execute `setup.py` since setuptools is not available in the build environment.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```


>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Replace the ``sphinxcontrib-yt`` package with ``sphinxcontrib-youtube`` 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
