### PR TITLE
Support ``fpga_core`` wrapper insertion

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/setup_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/setup_commands.rst
@@ -281,6 +281,29 @@ build_fabric
 
   .. note:: This is a must-run command before launching FPGA-Verilog, FPGA-Bitstream, FPGA-SDC and FPGA-SPICE
 
+.. _cmd_add_fpga_core_to_fabric:
+  
+add_fpga_core_to_fabric
+~~~~~~~~~~~~~~~~~~~~~~~
+
+  Add a wrapper module ``fpga_core`` as an intermediate layer to FPGA fabric. After this command, the existing module ``fpga_top`` will remain the top-level module while there is a new module ``fpga_core`` under it. Under fpga_core, there will be the detailed building blocks.
+
+  .. option:: --instance_name <string>
+
+    This is optional. Specify the instance name to be used when instanciate the ``fpga_core`` module under the top-level module ``fpga_top``. If not defined, by default it is ``fpga_core_inst``.
+
+
+  .. option:: --frame_view
+
+    Create only frame views of the module graph. When enabled, top-level module will not include any nets. This option is made for save runtime and memory.
+
+    .. warning:: Recommend to turn the option on when bitstream generation is the only purpose of the flow. Do not use it when you need generate netlists!
+
+  .. option:: --verbose
+
+    Show verbose log
+
+
 write_fabric_hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/libs/libopenfpgautil/src/openfpga_reserved_words.h
+++ b/libs/libopenfpgautil/src/openfpga_reserved_words.h
@@ -12,6 +12,8 @@ namespace openfpga {
 
 /* Top-level module name */
 constexpr const char* FPGA_TOP_MODULE_NAME = "fpga_top";
+constexpr const char* FPGA_CORE_MODULE_NAME = "fpga_core";
+constexpr const char* FPGA_CORE_INSTANCE_NAME = "fpga_instance";
 
 /* Configuration chain naming constant strings */
 constexpr const char* CONFIGURABLE_MEMORY_CHAIN_IN_NAME = "ccff_head";

--- a/openfpga/src/base/openfpga_build_fabric_template.h
+++ b/openfpga/src/base/openfpga_build_fabric_template.h
@@ -231,6 +231,18 @@ int write_fabric_io_info_template(const T& openfpga_ctx, const Command& cmd,
     cmd_context.option_enable(cmd, opt_verbose));
 }
 
+/********************************************************************
+ * Add fpga_core module to the module graph
+ *******************************************************************/
+template <class T>
+int add_fpga_core_to_fabric_template(T& openfpga_ctx, const Command& cmd,
+                                     const CommandContext& cmd_context) {
+  CommandOptionId opt_verbose = cmd.option("verbose");
+  bool verbose_output = cmd_context.option_enable(cmd, opt_verbose);
+
+  return add_fpga_core_to_device_module_graph(openfpga_ctx.mutable_module_graph(), verbose_output);
+}
+
 } /* end namespace openfpga */
 
 #endif

--- a/openfpga/src/base/openfpga_build_fabric_template.h
+++ b/openfpga/src/base/openfpga_build_fabric_template.h
@@ -14,6 +14,7 @@
 #include "fabric_hierarchy_writer.h"
 #include "fabric_key_writer.h"
 #include "globals.h"
+#include "openfpga_naming.h"
 #include "read_xml_fabric_key.h"
 #include "vtr_log.h"
 #include "vtr_time.h"
@@ -237,10 +238,20 @@ int write_fabric_io_info_template(const T& openfpga_ctx, const Command& cmd,
 template <class T>
 int add_fpga_core_to_fabric_template(T& openfpga_ctx, const Command& cmd,
                                      const CommandContext& cmd_context) {
+  CommandOptionId opt_frame_view = cmd.option("frame_view");
+  bool frame_view = cmd_context.option_enable(cmd, opt_frame_view);
   CommandOptionId opt_verbose = cmd.option("verbose");
   bool verbose_output = cmd_context.option_enable(cmd, opt_verbose);
 
-  return add_fpga_core_to_device_module_graph(openfpga_ctx.mutable_module_graph(), verbose_output);
+  CommandOptionId opt_inst_name = cmd.option("instance_name");
+  std::string core_inst_name = generate_fpga_core_instance_name();
+  if (true == cmd_context.option_enable(cmd, opt_inst_name)) {
+    core_inst_name = cmd_context.option_value(cmd, opt_inst_name);
+  }
+
+  return add_fpga_core_to_device_module_graph(
+    openfpga_ctx.mutable_module_graph(), core_inst_name, frame_view,
+    verbose_output);
 }
 
 } /* end namespace openfpga */

--- a/openfpga/src/base/openfpga_naming.cpp
+++ b/openfpga/src/base/openfpga_naming.cpp
@@ -1400,6 +1400,22 @@ std::string generate_fpga_top_module_name() {
 }
 
 /*********************************************************************
+ * Generate the module name for the fpga core module
+ * We give a fixed name here, because it is independent from benchmark file
+ ********************************************************************/
+std::string generate_fpga_core_module_name() {
+  return std::string(FPGA_CORE_MODULE_NAME);
+}
+
+/*********************************************************************
+ * Generate the module name for the fpga core module
+ * We give a fixed name here, because it is independent from benchmark file
+ ********************************************************************/
+std::string generate_fpga_core_instance_name() {
+  return std::string(FPGA_CORE_INSTANCE_NAME);
+}
+
+/*********************************************************************
  * Generate the netlist name for the top-level module
  * The top-level module is actually the FPGA fabric
  * We give a fixed name here, because it is independent from benchmark file

--- a/openfpga/src/base/openfpga_naming.cpp
+++ b/openfpga/src/base/openfpga_naming.cpp
@@ -1425,6 +1425,15 @@ std::string generate_fpga_top_netlist_name(const std::string& postfix) {
 }
 
 /*********************************************************************
+ * Generate the netlist name for the top-level module
+ * The top-level module is actually the FPGA fabric
+ * We give a fixed name here, because it is independent from benchmark file
+ ********************************************************************/
+std::string generate_fpga_core_netlist_name(const std::string& postfix) {
+  return std::string(FPGA_CORE_MODULE_NAME + postfix);
+}
+
+/*********************************************************************
  * Generate the module name for a constant generator
  * either VDD or GND, depending on the input argument
  ********************************************************************/

--- a/openfpga/src/base/openfpga_naming.h
+++ b/openfpga/src/base/openfpga_naming.h
@@ -258,6 +258,10 @@ std::string generate_fpga_global_io_port_name(
 
 std::string generate_fpga_top_module_name();
 
+std::string generate_fpga_core_module_name();
+
+std::string generate_fpga_core_instance_name();
+
 std::string generate_fpga_top_netlist_name(const std::string& postfix);
 
 std::string generate_const_value_module_name(const size_t& const_val);

--- a/openfpga/src/base/openfpga_naming.h
+++ b/openfpga/src/base/openfpga_naming.h
@@ -264,6 +264,8 @@ std::string generate_fpga_core_instance_name();
 
 std::string generate_fpga_top_netlist_name(const std::string& postfix);
 
+std::string generate_fpga_core_netlist_name(const std::string& postfix);
+
 std::string generate_const_value_module_name(const size_t& const_val);
 
 std::string generate_const_value_module_output_port_name(

--- a/openfpga/src/base/openfpga_setup_command_template.h
+++ b/openfpga/src/base/openfpga_setup_command_template.h
@@ -692,6 +692,35 @@ ShellCommandId add_route_clock_rr_graph_command_template(
   return shell_cmd_id;
 }
 
+/********************************************************************
+ * - Add a command to Shell environment: add_fpga_core_to_fabric
+ * - Add associated options
+ * - Add command dependency
+ *******************************************************************/
+template <class T>
+ShellCommandId add_add_fpga_core_to_fabric_command_template(
+  openfpga::Shell<T>& shell, const ShellCommandClassId& cmd_class_id,
+  const std::vector<ShellCommandId>& dependent_cmds, const bool& hidden) {
+  Command shell_cmd("add_fpga_core_to_fabric");
+
+  /* Add an option '--verbose' */
+  shell_cmd.add_option("verbose", false, "Show verbose outputs");
+
+  /* Add command 'pb_pin_fixup' to the Shell */
+  ShellCommandId shell_cmd_id = shell.add_command(
+    shell_cmd,
+    "Add fpga_core as an intermediate layer to FPGA fabric. After this command, the fpga_top will remain the top-level module while there is a new module fpga_core under it. Under fpga_core, there will be the detailed building blocks",
+    hidden);
+  shell.set_command_class(shell_cmd_id, cmd_class_id);
+  shell.set_command_execute_function(shell_cmd_id,
+                                     add_fpga_core_to_fabric_template<T>);
+
+  /* Add command dependency to the Shell */
+  shell.set_command_dependency(shell_cmd_id, dependent_cmds);
+
+  return shell_cmd_id;
+}
+
 template <class T>
 void add_setup_command_templates(openfpga::Shell<T>& shell,
                                  const bool& hidden = false) {
@@ -859,6 +888,7 @@ void add_setup_command_templates(openfpga::Shell<T>& shell,
   lut_tt_fixup_dependent_cmds.push_back(vpr_cmd_id);
   add_lut_truth_table_fixup_command_template<T>(
     shell, openfpga_setup_cmd_class, lut_tt_fixup_dependent_cmds, hidden);
+
   /********************************
    * Command 'build_fabric'
    */
@@ -868,6 +898,16 @@ void add_setup_command_templates(openfpga::Shell<T>& shell,
   build_fabric_dependent_cmds.push_back(link_arch_cmd_id);
   ShellCommandId build_fabric_cmd_id = add_build_fabric_command_template<T>(
     shell, openfpga_setup_cmd_class, build_fabric_dependent_cmds, hidden);
+
+  /********************************
+   * Command 'add_fpga_core_to_fabric'
+   */
+  /* The command should NOT be executed before
+   * 'build_fabric' */
+  std::vector<ShellCommandId> add_fpga_core_to_fabric_dependent_cmds;
+  add_fpga_core_to_fabric_dependent_cmds.push_back(build_fabric_cmd_id);
+  ShellCommandId add_fpga_core_to_fabric_cmd_id = add_add_fpga_core_to_fabric_command_template<T>(
+    shell, openfpga_setup_cmd_class, add_fpga_core_to_fabric_dependent_cmds, hidden);
 
   /********************************
    * Command 'write_fabric_hierarchy'

--- a/openfpga/src/base/openfpga_setup_command_template.h
+++ b/openfpga/src/base/openfpga_setup_command_template.h
@@ -703,13 +703,25 @@ ShellCommandId add_add_fpga_core_to_fabric_command_template(
   const std::vector<ShellCommandId>& dependent_cmds, const bool& hidden) {
   Command shell_cmd("add_fpga_core_to_fabric");
 
+  /* Add an option '--instance_name'*/
+  CommandOptionId opt_inst_name = shell_cmd.add_option(
+    "instance_name", false, "specify the instance of fpga_core under fpga_top");
+  shell_cmd.set_option_require_value(opt_inst_name, openfpga::OPT_STRING);
+
+  /* Add an option '--verbose' */
+  shell_cmd.add_option(
+    "frame_view", false,
+    "Build only frame view of the fabric (nets are skipped)");
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Show verbose outputs");
 
   /* Add command 'pb_pin_fixup' to the Shell */
   ShellCommandId shell_cmd_id = shell.add_command(
     shell_cmd,
-    "Add fpga_core as an intermediate layer to FPGA fabric. After this command, the fpga_top will remain the top-level module while there is a new module fpga_core under it. Under fpga_core, there will be the detailed building blocks",
+    "Add fpga_core as an intermediate layer to FPGA fabric. After this "
+    "command, the fpga_top will remain the top-level module while there is a "
+    "new module fpga_core under it. Under fpga_core, there will be the "
+    "detailed building blocks",
     hidden);
   shell.set_command_class(shell_cmd_id, cmd_class_id);
   shell.set_command_execute_function(shell_cmd_id,
@@ -906,8 +918,10 @@ void add_setup_command_templates(openfpga::Shell<T>& shell,
    * 'build_fabric' */
   std::vector<ShellCommandId> add_fpga_core_to_fabric_dependent_cmds;
   add_fpga_core_to_fabric_dependent_cmds.push_back(build_fabric_cmd_id);
-  ShellCommandId add_fpga_core_to_fabric_cmd_id = add_add_fpga_core_to_fabric_command_template<T>(
-    shell, openfpga_setup_cmd_class, add_fpga_core_to_fabric_dependent_cmds, hidden);
+  ShellCommandId add_fpga_core_to_fabric_cmd_id =
+    add_add_fpga_core_to_fabric_command_template<T>(
+      shell, openfpga_setup_cmd_class, add_fpga_core_to_fabric_dependent_cmds,
+      hidden);
 
   /********************************
    * Command 'write_fabric_hierarchy'

--- a/openfpga/src/base/openfpga_setup_command_template.h
+++ b/openfpga/src/base/openfpga_setup_command_template.h
@@ -918,10 +918,9 @@ void add_setup_command_templates(openfpga::Shell<T>& shell,
    * 'build_fabric' */
   std::vector<ShellCommandId> add_fpga_core_to_fabric_dependent_cmds;
   add_fpga_core_to_fabric_dependent_cmds.push_back(build_fabric_cmd_id);
-  ShellCommandId add_fpga_core_to_fabric_cmd_id =
-    add_add_fpga_core_to_fabric_command_template<T>(
-      shell, openfpga_setup_cmd_class, add_fpga_core_to_fabric_dependent_cmds,
-      hidden);
+  add_add_fpga_core_to_fabric_command_template<T>(
+    shell, openfpga_setup_cmd_class, add_fpga_core_to_fabric_dependent_cmds,
+    hidden);
 
   /********************************
    * Command 'write_fabric_hierarchy'

--- a/openfpga/src/fabric/build_device_module.cpp
+++ b/openfpga/src/fabric/build_device_module.cpp
@@ -154,7 +154,7 @@ int add_fpga_core_to_device_module_graph(ModuleManager& module_manager,
 
   /* Create a wrapper module under the existing fpga_top */
   ModuleId new_top_module = module_manager.create_wrapper_module(
-    top_module, top_module_name, core_inst_name, frame_view);
+    top_module, top_module_name, core_inst_name, !frame_view);
   if (!module_manager.valid_module_id(new_top_module)) {
     VTR_LOGV_ERROR(verbose,
                    "Failed to create a wrapper module '%s' on top of '%s'!\n",

--- a/openfpga/src/fabric/build_device_module.cpp
+++ b/openfpga/src/fabric/build_device_module.cpp
@@ -126,4 +126,31 @@ int build_device_module_graph(
   return status;
 }
 
+/********************************************************************
+ * The main function to be called for adding the fpga_core wrapper to a FPGA fabric
+ * - Rename existing fpga_top to fpga_core
+ * - Create a wrapper module 'fpga_top' on the fpga_core
+ *******************************************************************/
+int add_fpga_core_to_device_module_graph(ModuleManager& module_manager, const bool& verbose) {
+  int status = CMD_EXEC_SUCCESS;
+
+  /* Execute the module graph api */
+  std::string top_module_name = generate_fpga_top_module_name();
+  ModuleId top_module = module_manager.find_module(top_module_name);
+  if (!module_manager.valid_module_id(top_module)) {
+    return CMD_EXEC_FATAL_ERROR;
+  }
+  /* TODO: Use a constant for the top_module name */  
+
+  /* Rename existing top module to fpga_core */
+  module_manager.set_module_name(top_module, "fpga_core");
+  /* Create a wrapper module under the existing fpga_top */
+  ModuleId new_top_module = module_manager.create_wrapper(top_module, top_module_name),
+  if (!module_manager.valid_module_id(new_top_module)) {
+    return CMD_EXEC_FATAL_ERROR;
+  }
+
+  return status;
+}
+
 } /* end namespace openfpga */

--- a/openfpga/src/fabric/build_device_module.cpp
+++ b/openfpga/src/fabric/build_device_module.cpp
@@ -164,6 +164,12 @@ int add_fpga_core_to_device_module_graph(ModuleManager& module_manager,
   VTR_LOGV(verbose, "Created a wrapper module '%s' on top of '%s'\n",
            top_module_name.c_str(), core_module_name.c_str());
 
+  /* Now fpga_core should be the only configurable child under the top-level
+   * module */
+  module_manager.add_configurable_child(new_top_module, top_module, 0);
+
+  /* TODO: Update the fabric global ports */
+
   return status;
 }
 

--- a/openfpga/src/fabric/build_device_module.h
+++ b/openfpga/src/fabric/build_device_module.h
@@ -23,7 +23,10 @@ int build_device_module_graph(
   const bool& duplicate_grid_pin, const FabricKey& fabric_key,
   const bool& generate_random_fabric_key, const bool& verbose);
 
-int add_fpga_core_to_device_module_graph(ModuleManager& module_manager, const bool& verbose);
+int add_fpga_core_to_device_module_graph(ModuleManager& module_manager,
+                                         const std::string& core_inst_name,
+                                         const bool& frame_view,
+                                         const bool& verbose);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/fabric/build_device_module.h
+++ b/openfpga/src/fabric/build_device_module.h
@@ -23,6 +23,8 @@ int build_device_module_graph(
   const bool& duplicate_grid_pin, const FabricKey& fabric_key,
   const bool& generate_random_fabric_key, const bool& verbose);
 
+int add_fpga_core_to_device_module_graph(ModuleManager& module_manager, const bool& verbose);
+
 } /* end namespace openfpga */
 
 #endif

--- a/openfpga/src/fabric/module_manager.cpp
+++ b/openfpga/src/fabric/module_manager.cpp
@@ -1257,9 +1257,6 @@ ModuleId ModuleManager::create_wrapper_module(
   reserve_module_nets(wrapper_module, num_nets_to_reserve);
   for (ModulePortId new_port : module_ports(wrapper_module)) {
     BasicPort new_port_info = module_port(wrapper_module, new_port);
-    /* Create new net */
-    ModuleNetId new_net = create_module_net(wrapper_module);
-    VTR_ASSERT(valid_module_net_id(wrapper_module, new_net));
     /* For each input pin, create a new source */
     ModuleManager::e_module_port_type new_port_type =
       port_type(wrapper_module, new_port);
@@ -1267,26 +1264,28 @@ ModuleId ModuleManager::create_wrapper_module(
     ModulePortId existing_port = port_map[new_port];
     BasicPort existing_port_info = module_port(existing_module, existing_port);
     VTR_ASSERT(existing_port_info == new_port_info);
-    reserve_module_net_sources(wrapper_module, new_net,
-                               new_port_info.pins().size());
-    reserve_module_net_sinks(wrapper_module, new_net,
-                             new_port_info.pins().size());
     if (new_port_type !=
         ModuleManager::e_module_port_type::MODULE_OUTPUT_PORT) {
-      for (auto pin : new_port_info.pins()) {
+      for (size_t ipin = 0; ipin < new_port_info.pins().size(); ++ipin) {
+        /* Create new net */
+        ModuleNetId new_net = create_module_net(wrapper_module);
+        VTR_ASSERT(valid_module_net_id(wrapper_module, new_net));
         add_module_net_source(wrapper_module, new_net, wrapper_module, 0,
-                              new_port, pin);
+                              new_port, new_port_info.pins()[ipin]);
         add_module_net_sink(wrapper_module, new_net, existing_module, 0,
-                            existing_port, pin);
+                            existing_port, existing_port_info.pins()[ipin]);
       }
     } else {
       VTR_ASSERT_SAFE(new_port_type ==
                       ModuleManager::e_module_port_type::MODULE_OUTPUT_PORT);
-      for (auto pin : new_port_info.pins()) {
+      for (size_t ipin = 0; ipin < new_port_info.pins().size(); ++ipin) {
+        /* Create new net */
+        ModuleNetId new_net = create_module_net(wrapper_module);
+        VTR_ASSERT(valid_module_net_id(wrapper_module, new_net));
         add_module_net_source(wrapper_module, new_net, existing_module, 0,
-                              existing_port, pin);
+                              existing_port, new_port_info.pins()[ipin]);
         add_module_net_sink(wrapper_module, new_net, wrapper_module, 0,
-                            new_port, pin);
+                            new_port, existing_port_info.pins()[ipin]);
       }
     }
   }

--- a/openfpga/src/fabric/module_manager.cpp
+++ b/openfpga/src/fabric/module_manager.cpp
@@ -747,7 +747,13 @@ void ModuleManager::set_module_name(const ModuleId& module,
                                     const std::string& name) {
   /* Validate the id of module */
   VTR_ASSERT(valid_module_id(module));
+  std::string old_name = names_[module];
   names_[module] = name;
+
+  /* Unregister the old name */
+  name_id_map_.erase(old_name);
+  /* Register the new name */
+  name_id_map_[name] = module;
 }
 
 void ModuleManager::set_module_usage(const ModuleId& module,

--- a/openfpga/src/fabric/module_manager.h
+++ b/openfpga/src/fabric/module_manager.h
@@ -317,6 +317,8 @@ class ModuleManager {
   /* Set a port to be a wire */
   void set_port_is_wire(const ModuleId& module, const std::string& port_name,
                         const bool& is_wire);
+  void set_port_is_wire(const ModuleId& module, const ModulePortId& port_id,
+                        const bool& is_wire);
   /* Set a port to be mappable to an I/O from users' implemenations */
   void set_port_is_mappable_io(const ModuleId& module,
                                const ModulePortId& port_id,
@@ -324,6 +326,8 @@ class ModuleManager {
   /* Set a port to be a register */
   void set_port_is_register(const ModuleId& module,
                             const std::string& port_name,
+                            const bool& is_register);
+  void set_port_is_register(const ModuleId& module, const ModulePortId& port_id,
                             const bool& is_register);
   /* Set the preprocessing flag for a port */
   void set_port_preproc_flag(const ModuleId& module, const ModulePortId& port,
@@ -422,6 +426,26 @@ class ModuleManager {
                                       const size_t& instance_id,
                                       const ModulePortId& sink_port,
                                       const size_t& sink_pin);
+
+  /** @brief Create a wrapper module on an existing module. The wrapper module
+   * will herit all the ports with the same direction, width and names from the
+   * selected module. The wrapper module will contain the existing module. For
+   * example,
+   *
+   *     Wrapper module
+   *     +------------------------+
+   *     |  existing module       |
+   *     |  +------------------+  |
+   *     |  |                  |  |
+   * a ->+->+ a              b-+--+-> b
+   *     |  |                  |  |
+   *     |  +------------------+  |
+   *     +------------------------+
+   */
+  ModuleId create_wrapper_module(const ModuleId& existing_module,
+                                 const std::string& wrapper_module_name,
+                                 const std::string& instance_name,
+                                 const bool& add_nets);
 
  public: /* Public deconstructors */
   /* This is a strong function which will remove all the configurable children

--- a/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
@@ -159,6 +159,7 @@ BitstreamManager build_device_bitstream(const VprContext& vpr_ctx,
   VTR_ASSERT(true == openfpga_ctx.module_graph().valid_module_id(top_module));
 
   /* Create the core block when the fpga_core is added */
+  size_t num_blocks_to_reserve = 0;
   std::string core_block_name = generate_fpga_core_module_name();
   const ModuleId& core_module =
     openfpga_ctx.module_graph().find_module(core_block_name);
@@ -169,10 +170,12 @@ BitstreamManager build_device_bitstream(const VprContext& vpr_ctx,
      * functions */
     top_module = core_module;
     top_block = core_block;
+    /* Count in fpga core as a block to reserve */
+    num_blocks_to_reserve += 1;
   }
 
   /* Estimate the number of blocks to be added to the database */
-  size_t num_blocks_to_reserve = rec_estimate_device_bitstream_num_blocks(
+  num_blocks_to_reserve += rec_estimate_device_bitstream_num_blocks(
     openfpga_ctx.module_graph(), top_module);
   bitstream_manager.reserve_blocks(num_blocks_to_reserve);
   VTR_LOGV(verbose, "Reserved %lu configurable blocks\n",

--- a/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
@@ -155,9 +155,21 @@ BitstreamManager build_device_bitstream(const VprContext& vpr_ctx,
    */
   std::string top_block_name = generate_fpga_top_module_name();
   ConfigBlockId top_block = bitstream_manager.add_block(top_block_name);
-  const ModuleId& top_module =
-    openfpga_ctx.module_graph().find_module(top_block_name);
+  ModuleId top_module = openfpga_ctx.module_graph().find_module(top_block_name);
   VTR_ASSERT(true == openfpga_ctx.module_graph().valid_module_id(top_module));
+
+  /* Create the core block when the fpga_core is added */
+  std::string core_block_name = generate_fpga_core_module_name();
+  const ModuleId& core_module =
+    openfpga_ctx.module_graph().find_module(core_block_name);
+  if (openfpga_ctx.module_graph().valid_module_id(core_module)) {
+    ConfigBlockId core_block = bitstream_manager.add_block(core_block_name);
+    bitstream_manager.add_child_block(top_block, core_block);
+    /* Now we use the core_block as the top-level block for the remaining
+     * functions */
+    top_module = core_module;
+    top_block = core_block;
+  }
 
   /* Estimate the number of blocks to be added to the database */
   size_t num_blocks_to_reserve = rec_estimate_device_bitstream_num_blocks(

--- a/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
@@ -164,7 +164,9 @@ BitstreamManager build_device_bitstream(const VprContext& vpr_ctx,
   const ModuleId& core_module =
     openfpga_ctx.module_graph().find_module(core_block_name);
   if (openfpga_ctx.module_graph().valid_module_id(core_module)) {
-    ConfigBlockId core_block = bitstream_manager.add_block(core_block_name);
+    std::string core_inst_name =
+      openfpga_ctx.module_graph().instance_name(top_module, core_module, 0);
+    ConfigBlockId core_block = bitstream_manager.add_block(core_inst_name);
     bitstream_manager.add_child_block(top_block, core_block);
     /* Now we use the core_block as the top-level block for the remaining
      * functions */

--- a/openfpga/src/fpga_sdc/analysis_sdc_writer.cpp
+++ b/openfpga/src/fpga_sdc/analysis_sdc_writer.cpp
@@ -258,6 +258,15 @@ void print_analysis_sdc(const AnalysisSdcOption& option,
   ModuleId top_module =
     openfpga_ctx.module_graph().find_module(generate_fpga_top_module_name());
   VTR_ASSERT(true == openfpga_ctx.module_graph().valid_module_id(top_module));
+  /* Use the core module as the top when the fpga_core is added */
+  std::string core_block_name = generate_fpga_core_module_name();
+  const ModuleId& core_module =
+    openfpga_ctx.module_graph().find_module(core_block_name);
+  if (openfpga_ctx.module_graph().valid_module_id(core_module)) {
+    /* Now we use the core_block as the top-level block for the remaining
+     * functions */
+    top_module = core_module;
+  }
 
   /* Create clock and set I/O ports with input/output delays
    * FIXME: Now different I/Os have different delays due to multiple clock

--- a/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
+++ b/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
@@ -351,6 +351,15 @@ void print_pnr_sdc(const PnrSdcOption& sdc_options,
   ModuleId top_module = module_manager.find_module(top_module_name);
   VTR_ASSERT(true == module_manager.valid_module_id(top_module));
 
+  /* Use the core module as the top when the fpga_core is added */
+  std::string core_block_name = generate_fpga_core_module_name();
+  const ModuleId& core_module = module_manager.find_module(core_block_name);
+  if (module_manager.valid_module_id(core_module)) {
+    /* Now we use the core_block as the top-level block for the remaining
+     * functions */
+    top_module = core_module;
+  }
+
   /* Constrain global ports */
   if (true == sdc_options.constrain_global_port()) {
     print_pnr_sdc_global_ports(sdc_options, module_manager, top_module,

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -117,8 +117,8 @@ void fpga_fabric_verilog(
 
   /* Generate FPGA fabric */
   print_verilog_core_module(netlist_manager,
-                           const_cast<const ModuleManager &>(module_manager),
-                           src_dir_path, options);
+                            const_cast<const ModuleManager &>(module_manager),
+                            src_dir_path, options);
   print_verilog_top_module(netlist_manager,
                            const_cast<const ModuleManager &>(module_manager),
                            src_dir_path, options);

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -116,6 +116,9 @@ void fpga_fabric_verilog(
     std::string(DEFAULT_LB_DIR_NAME), options, options.verbose_output());
 
   /* Generate FPGA fabric */
+  print_verilog_core_module(netlist_manager,
+                           const_cast<const ModuleManager &>(module_manager),
+                           src_dir_path, options);
   print_verilog_top_module(netlist_manager,
                            const_cast<const ModuleManager &>(module_manager),
                            src_dir_path, options);

--- a/openfpga/src/fpga_verilog/verilog_top_module.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_module.cpp
@@ -22,6 +22,65 @@
 namespace openfpga {
 
 /********************************************************************
+ * Print the wrapper module for the FPGA fabric in Verilog format
+ *******************************************************************/
+void print_verilog_core_module(NetlistManager& netlist_manager,
+                              const ModuleManager& module_manager,
+                              const std::string& verilog_dir,
+                              const FabricVerilogOption& options) {
+  /* Create a module as the top-level fabric, and add it to the module manager
+   */
+  std::string core_module_name = generate_fpga_core_module_name();
+  ModuleId core_module = module_manager.find_module(core_module_name);
+  /* It could happen that the module does not exist, just return with no errors */
+  if (!module_manager.valid_module_id(core_module)) {
+    return;
+  }
+
+  /* Start printing out Verilog netlists */
+  /* Create the file name for Verilog netlist */
+  std::string verilog_fname(
+    generate_fpga_core_netlist_name(std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string verilog_fpath(verilog_dir + verilog_fname);
+
+  VTR_LOG("Writing Verilog netlist for wrapper module of FPGA fabric '%s'...",
+          verilog_fpath.c_str());
+
+  /* Create the file stream */
+  std::fstream fp;
+  fp.open(verilog_fpath, std::fstream::out | std::fstream::trunc);
+
+  check_file_stream(verilog_fpath.c_str(), fp);
+
+  print_verilog_file_header(
+    fp, std::string("Wrapper Verilog module for FPGA"), options.time_stamp());
+
+  /* Write the module content in Verilog format */
+  write_verilog_module_to_file(fp, module_manager, core_module,
+                               options.explicit_port_mapping(),
+                               options.default_net_type());
+
+  /* Add an empty line as a splitter */
+  fp << std::endl;
+
+  /* Close file handler */
+  fp.close();
+
+  /* Add fname to the netlist name list */
+  NetlistId nlist_id = NetlistId::INVALID();
+  if (options.use_relative_path()) {
+    nlist_id = netlist_manager.add_netlist(verilog_fname);
+  } else {
+    nlist_id = netlist_manager.add_netlist(verilog_fpath);
+  }
+  VTR_ASSERT(nlist_id);
+  netlist_manager.set_netlist_type(nlist_id,
+                                   NetlistManager::TOP_MODULE_NETLIST);
+
+  VTR_LOG("Done\n");
+}
+
+/********************************************************************
  * Print the top-level module for the FPGA fabric in Verilog format
  * This function will
  * 1. name the top-level module

--- a/openfpga/src/fpga_verilog/verilog_top_module.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_module.cpp
@@ -25,14 +25,15 @@ namespace openfpga {
  * Print the wrapper module for the FPGA fabric in Verilog format
  *******************************************************************/
 void print_verilog_core_module(NetlistManager& netlist_manager,
-                              const ModuleManager& module_manager,
-                              const std::string& verilog_dir,
-                              const FabricVerilogOption& options) {
+                               const ModuleManager& module_manager,
+                               const std::string& verilog_dir,
+                               const FabricVerilogOption& options) {
   /* Create a module as the top-level fabric, and add it to the module manager
    */
   std::string core_module_name = generate_fpga_core_module_name();
   ModuleId core_module = module_manager.find_module(core_module_name);
-  /* It could happen that the module does not exist, just return with no errors */
+  /* It could happen that the module does not exist, just return with no errors
+   */
   if (!module_manager.valid_module_id(core_module)) {
     return;
   }
@@ -52,8 +53,8 @@ void print_verilog_core_module(NetlistManager& netlist_manager,
 
   check_file_stream(verilog_fpath.c_str(), fp);
 
-  print_verilog_file_header(
-    fp, std::string("Wrapper Verilog module for FPGA"), options.time_stamp());
+  print_verilog_file_header(fp, std::string("Wrapper Verilog module for FPGA"),
+                            options.time_stamp());
 
   /* Write the module content in Verilog format */
   write_verilog_module_to_file(fp, module_manager, core_module,

--- a/openfpga/src/fpga_verilog/verilog_top_module.h
+++ b/openfpga/src/fpga_verilog/verilog_top_module.h
@@ -17,6 +17,11 @@
 /* begin namespace openfpga */
 namespace openfpga {
 
+void print_verilog_core_module(NetlistManager& netlist_manager,
+                              const ModuleManager& module_manager,
+                              const std::string& verilog_dir,
+                              const FabricVerilogOption& options);
+
 void print_verilog_top_module(NetlistManager& netlist_manager,
                               const ModuleManager& module_manager,
                               const std::string& verilog_dir,

--- a/openfpga/src/fpga_verilog/verilog_top_module.h
+++ b/openfpga/src/fpga_verilog/verilog_top_module.h
@@ -18,9 +18,9 @@
 namespace openfpga {
 
 void print_verilog_core_module(NetlistManager& netlist_manager,
-                              const ModuleManager& module_manager,
-                              const std::string& verilog_dir,
-                              const FabricVerilogOption& options);
+                               const ModuleManager& module_manager,
+                               const std::string& verilog_dir,
+                               const FabricVerilogOption& options);
 
 void print_verilog_top_module(NetlistManager& netlist_manager,
                               const ModuleManager& module_manager,

--- a/openfpga_flow/openfpga_shell_scripts/fpga_core_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/fpga_core_example_script.openfpga
@@ -1,0 +1,75 @@
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling route
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enable pin duplication on grid modules
+build_fabric --compress_routing #--verbose
+# Add a fpga core between fpga top and the underlying modules
+add_fpga_core_to_fabric --instance_name fpga_core_inst --verbose
+
+# Write the fabric hierarchy of module graph to a file
+# This is used by hierarchical PnR flows
+write_fabric_hierarchy --file ./fabric_hierarchy.txt
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose
+
+# Write fabric-dependent bitstream
+write_fabric_bitstream --file fabric_bitstream.bit --format plain_text
+
+# Write the Verilog netlist for FPGA fabric
+#  - Enable the use of explicit port mapping in Verilog netlist
+write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --print_user_defined_template --verbose
+
+# Write the Verilog testbench for FPGA fabric
+#  - We suggest the use of same output directory as fabric Verilog netlists
+#  - Must specify the reference benchmark file if you want to output any testbenches
+#  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
+#  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
+#  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping --include_signal_init --bitstream fabric_bitstream.bit 
+write_preconfigured_fabric_wrapper --embed_bitstream iverilog --file ./SRC  --explicit_port_mapping
+write_preconfigured_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --explicit_port_mapping 
+
+# Write the SDC files for PnR backend
+#  - Turn on every options here
+write_pnr_sdc --file ./SDC
+
+# Write SDC to disable timing for configure ports
+write_sdc_disable_timing_configure_ports --file ./SDC/disable_configure_ports.sdc
+
+# Write the SDC to run timing analysis for a mapped FPGA fabric
+write_analysis_sdc --file ./SDC_analysis
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/openfpga_flow/openfpga_shell_scripts/generate_bitstream_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/generate_bitstream_example_script.openfpga
@@ -24,6 +24,8 @@ lut_truth_table_fixup
 #    Note that this is turned on when bitstream generation 
 #    is the ONLY purpose of the flow!!!
 build_fabric --compress_routing --frame_view #--verbose
+# Add a fpga core between fpga top and the underlying modules
+add_fpga_core_to_fabric --instance_name fpga_core_inst --frame_view --verbose
 
 # Repack the netlist to physical pbs
 # This must be done before bitstream generator and testbench generation

--- a/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fpga_core_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fpga_core_example_script.openfpga
@@ -1,0 +1,48 @@
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling route --absorb_buffer_luts off
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enabled frame view creation to save runtime and memory
+#    Note that this is turned on when bitstream generation 
+#    is the ONLY purpose of the flow!!!
+build_fabric --compress_routing --frame_view #--verbose
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose 
+
+# Write fabric-dependent bitstream
+write_fabric_bitstream --file fabric_bitstream.txt --format plain_text
+write_fabric_bitstream --file fabric_bitstream.xml --format xml
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/openfpga_flow/openfpga_shell_scripts/write_full_testbench_fpga_core_example_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/write_full_testbench_fpga_core_example_script.openfpga
@@ -1,0 +1,73 @@
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling ideal ${OPENFPGA_VPR_DEVICE_LAYOUT}
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f ${OPENFPGA_SIM_SETTING_FILE}
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --activity_file ${ACTIVITY_FILE} --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enable pin duplication on grid modules
+build_fabric --compress_routing #--verbose
+# Add a fpga core between fpga top and the underlying modules
+add_fpga_core_to_fabric --instance_name fpga_core_inst --verbose
+
+# Write the fabric hierarchy of module graph to a file
+# This is used by hierarchical PnR flows
+write_fabric_hierarchy --file ./fabric_hierarchy.txt
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose
+
+# Write fabric-dependent bitstream
+write_fabric_bitstream --file fabric_bitstream.bit --format plain_text ${OPENFPGA_FAST_CONFIGURATION}
+
+# Write the Verilog netlist for FPGA fabric
+#  - Enable the use of explicit port mapping in Verilog netlist
+write_fabric_verilog --file ./SRC --explicit_port_mapping --include_timing --print_user_defined_template --verbose
+
+# Write the Verilog testbench for FPGA fabric
+#  - We suggest the use of same output directory as fabric Verilog netlists
+#  - Must specify the reference benchmark file if you want to output any testbenches
+#  - Enable top-level testbench which is a full verification including programming circuit and core logic of FPGA
+#  - Enable pre-configured top-level testbench which is a fast verification skipping programming phase
+#  - Simulation ini file is optional and is needed only when you need to interface different HDL simulators using openfpga flow-run scripts
+write_full_testbench --file ./SRC --reference_benchmark_file_path ${REFERENCE_VERILOG_TESTBENCH} --include_signal_init --explicit_port_mapping --bitstream fabric_bitstream.bit ${OPENFPGA_FAST_CONFIGURATION}
+
+# Write the SDC files for PnR backend
+#  - Turn on every options here
+write_pnr_sdc --file ./SDC
+
+# Write SDC to disable timing for configure ports
+write_sdc_disable_timing_configure_ports --file ./SDC/disable_configure_ports.sdc
+
+# Write the SDC to run timing analysis for a mapped FPGA fabric
+write_analysis_sdc --file ./SDC_analysis
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -15,6 +15,10 @@ echo -e "Test source commands in openfpga shell"
 run-task basic_tests/source_command/source_string $@
 run-task basic_tests/source_command/source_file $@
 
+echo -e "Testing testbenches using fpga core wrapper"
+run-task basic_tests/full_testbench/fpga_core_wrapper $@
+run-task basic_tests/preconfig_testbench/fpga_core_wrapper $@
+
 echo -e "Testing configuration chain of a K4N4 FPGA";
 run-task basic_tests/full_testbench/configuration_chain $@
 run-task basic_tests/full_testbench/configuration_chain_no_time_stamp $@

--- a/openfpga_flow/regression_test_scripts/fpga_bitstream_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_bitstream_reg_test.sh
@@ -20,6 +20,9 @@ echo -e "Testing bitstream generation for an 96x96 FPGA device";
 run-task fpga_bitstream/generate_bitstream/configuration_chain/device_96x96 $@
 run-task fpga_bitstream/generate_bitstream/ql_memory_bank_shift_register/device_72x72 $@
 
+echo -e "Testing bitstream generation when fpga core wrapper is added";
+run-task fpga_bitstream/generate_bitstream/fpga_core_wrapper $@
+
 echo -e "Testing loading architecture bitstream from an external file";
 run-task fpga_bitstream/load_external_architecture_bitstream $@
 

--- a/openfpga_flow/tasks/basic_tests/full_testbench/fpga_core_wrapper/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/fpga_core_wrapper/config/task.conf
@@ -1,0 +1,45 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_fpga_core_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/or2/or2.v
+bench2=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_latch/and2_latch.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2
+bench0_chan_width = 300
+
+bench1_top = or2
+bench1_chan_width = 300
+
+bench2_top = and2_latch
+bench2_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=

--- a/openfpga_flow/tasks/basic_tests/preconfig_testbench/fpga_core_wrapper/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/preconfig_testbench/fpga_core_wrapper/config/task.conf
@@ -1,0 +1,44 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fpga_core_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/or2/or2.v
+bench2=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_latch/and2_latch.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2
+bench0_chan_width = 300
+
+bench1_top = or2
+bench1_chan_width = 300
+
+bench2_top = and2_latch
+bench2_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/fpga_core_wrapper/config/task.conf
+++ b/openfpga_flow/tasks/fpga_bitstream/generate_bitstream/fpga_core_wrapper/config/task.conf
@@ -1,0 +1,33 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/generate_bitstream_fpga_core_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_40nm_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #1220 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Already detailed in #1220 

> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Added a new command ``add_fpga_core_to_fabric``, with the options to customize instance name, net addition etc.
- [x] Upgraded Verilog, bitstream and SDC generators accordingly.
- [x] Added new testcases to validate the feature. 
- [x] Updated documentation  

**Note that I/O customization is not yet supported. Will be addressed in a later PR**

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [x] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
