### PR TITLE
[ci] now cell lib test use ubunut 22.04

### DIFF
--- a/.github/workflows/cell_lib_test.yml
+++ b/.github/workflows/cell_lib_test.yml
@@ -13,7 +13,7 @@ jobs:
   # Test the RTL compilation compatibility
   verilog:
     name: RTL compilation and tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.9.1
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo bash .github/workflows/install_dependencies_run.sh
+          sudo bash .github/workflows/install_dependencies_run_ubuntu22p04.sh
 
       - name: Dump tool versions
         run: |

--- a/.github/workflows/install_dependencies_run.sh
+++ b/.github/workflows/install_dependencies_run.sh
@@ -1,3 +1,5 @@
+# Update as required by some packages
+apt-get update
 apt-get install --no-install-recommends -y \
 libdatetime-perl libc6 libffi-dev libgcc1 libreadline8 libstdc++6 \
 libtcl8.6 tcl python3.8 python3-pip zlib1g libbz2-1.0 \

--- a/.github/workflows/install_dependencies_run_ubuntu22p04.sh
+++ b/.github/workflows/install_dependencies_run_ubuntu22p04.sh
@@ -1,3 +1,5 @@
+# Update as required by some packages
+apt-get update
 apt-get install --no-install-recommends -y \
 libdatetime-perl libc6 libffi-dev libgcc1 libreadline8 libstdc++6 \
 libtcl8.6 tcl python3-pip zlib1g libbz2-1.0 \


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- CI ``cell_library_test`` failed on the master branch [8cac776](https://github.com/lnis-uofu/OpenFPGA/commit/8cac776b2843d08c2e00557d07c16a7f7a0b174f)
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- Migrate to Ubuntu 22.04.

**Later on, we will build compatibility to ubuntu 22.04!!!**

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
