### PR TITLE
Fixed a bug when Combo options are enabled: ``group_tile``, ``group_config_block`` and ``shrink_boundary``

### DIFF
--- a/openfpga/src/annotation/fabric_tile.cpp
+++ b/openfpga/src/annotation/fabric_tile.cpp
@@ -374,7 +374,8 @@ bool FabricTile::register_tile_in_lookup(const FabricTileId& tile_id,
   }
   /* Throw error if this coord is already registered! */
   if (tile_coord2id_lookup_[coord.x()][coord.y()]) {
-    VTR_LOG_ERROR("Tile at [%lu][%lu] has already been registered!\n", coord.x(), coord.y());
+    VTR_LOG_ERROR("Tile at [%lu][%lu] has already been registered!\n",
+                  coord.x(), coord.y());
     return false;
   }
   tile_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -401,7 +402,8 @@ bool FabricTile::register_pb_in_lookup(const FabricTileId& tile_id,
   /* Throw error if this coord is already registered! */
   if (pb_coord2id_lookup_[coord.x()][coord.y()]) {
     VTR_LOG_ERROR(
-      "Programmable block at [%lu][%lu] has already been registered!\n", coord.x(), coord.y());
+      "Programmable block at [%lu][%lu] has already been registered!\n",
+      coord.x(), coord.y());
     return false;
   }
   pb_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -429,7 +431,8 @@ bool FabricTile::register_cbx_in_lookup(const FabricTileId& tile_id,
   if (cbx_coord2id_lookup_[coord.x()][coord.y()]) {
     VTR_LOG_ERROR(
       "X-direction connection block at [%lu][%lu] has already been "
-      "registered!\n", coord.x(), coord.y());
+      "registered!\n",
+      coord.x(), coord.y());
     return false;
   }
   cbx_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -457,7 +460,8 @@ bool FabricTile::register_cby_in_lookup(const FabricTileId& tile_id,
   if (cby_coord2id_lookup_[coord.x()][coord.y()]) {
     VTR_LOG_ERROR(
       "Y-direction connection block at [%lu][%lu] has already been "
-      "registered!\n", coord.x(), coord.y());
+      "registered!\n",
+      coord.x(), coord.y());
     return false;
   }
   cby_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -483,7 +487,8 @@ bool FabricTile::register_sb_in_lookup(const FabricTileId& tile_id,
   }
   /* Throw error if this coord is already registered! */
   if (sb_coord2id_lookup_[coord.x()][coord.y()]) {
-    VTR_LOG_ERROR("Switch block at [%lu][%lu] has already been registered!\n", coord.x(), coord.y());
+    VTR_LOG_ERROR("Switch block at [%lu][%lu] has already been registered!\n",
+                  coord.x(), coord.y());
     return false;
   }
   sb_coord2id_lookup_[coord.x()][coord.y()] = tile_id;

--- a/openfpga/src/annotation/fabric_tile.cpp
+++ b/openfpga/src/annotation/fabric_tile.cpp
@@ -374,7 +374,7 @@ bool FabricTile::register_tile_in_lookup(const FabricTileId& tile_id,
   }
   /* Throw error if this coord is already registered! */
   if (tile_coord2id_lookup_[coord.x()][coord.y()]) {
-    VTR_LOG_ERROR("Tile at [%lu][%lu] has already been registered!\n");
+    VTR_LOG_ERROR("Tile at [%lu][%lu] has already been registered!\n", coord.x(), coord.y());
     return false;
   }
   tile_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -401,7 +401,7 @@ bool FabricTile::register_pb_in_lookup(const FabricTileId& tile_id,
   /* Throw error if this coord is already registered! */
   if (pb_coord2id_lookup_[coord.x()][coord.y()]) {
     VTR_LOG_ERROR(
-      "Programmable block at [%lu][%lu] has already been registered!\n");
+      "Programmable block at [%lu][%lu] has already been registered!\n", coord.x(), coord.y());
     return false;
   }
   pb_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -429,7 +429,7 @@ bool FabricTile::register_cbx_in_lookup(const FabricTileId& tile_id,
   if (cbx_coord2id_lookup_[coord.x()][coord.y()]) {
     VTR_LOG_ERROR(
       "X-direction connection block at [%lu][%lu] has already been "
-      "registered!\n");
+      "registered!\n", coord.x(), coord.y());
     return false;
   }
   cbx_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -457,7 +457,7 @@ bool FabricTile::register_cby_in_lookup(const FabricTileId& tile_id,
   if (cby_coord2id_lookup_[coord.x()][coord.y()]) {
     VTR_LOG_ERROR(
       "Y-direction connection block at [%lu][%lu] has already been "
-      "registered!\n");
+      "registered!\n", coord.x(), coord.y());
     return false;
   }
   cby_coord2id_lookup_[coord.x()][coord.y()] = tile_id;
@@ -483,7 +483,7 @@ bool FabricTile::register_sb_in_lookup(const FabricTileId& tile_id,
   }
   /* Throw error if this coord is already registered! */
   if (sb_coord2id_lookup_[coord.x()][coord.y()]) {
-    VTR_LOG_ERROR("Switch block at [%lu][%lu] has already been registered!\n");
+    VTR_LOG_ERROR("Switch block at [%lu][%lu] has already been registered!\n", coord.x(), coord.y());
     return false;
   }
   sb_coord2id_lookup_[coord.x()][coord.y()] = tile_id;

--- a/openfpga/src/fabric/build_tile_modules.cpp
+++ b/openfpga/src/fabric/build_tile_modules.cpp
@@ -881,11 +881,6 @@ static int build_tile_module_ports_from_cb(
     return CMD_EXEC_SUCCESS;
   }
 
-  /* Skip if the cb does not contain any configuration bits! */
-  if (true == connection_block_contain_only_routing_tracks(rr_gsb, cb_type)) {
-    return CMD_EXEC_SUCCESS;
-  }
-
   /* If we use compact routing hierarchy, we should find the unique module of
    * CB, which is added to the top module */
   if (true == compact_routing_hierarchy) {

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -190,6 +190,7 @@ echo -e "Testing group config block";
 run-task basic_tests/group_config_block/group_config_block_homo_full_testbench $@
 run-task basic_tests/group_config_block/group_config_block_homo_Lshape_full_testbench $@
 run-task basic_tests/group_config_block/group_config_block_homo_fabric_tile $@
+run-task basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lshape $@
 run-task basic_tests/group_config_block/group_config_block_homo_fabric_tile_core_wrapper $@
 run-task basic_tests/group_config_block/group_config_block_hetero_fabric_tile $@
 run-task basic_tests/group_config_block/group_config_block_hetero_fabric_tile_Lshape $@

--- a/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lshape/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lshape/config/task.conf
@@ -21,7 +21,7 @@ openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
 openfpga_group_tile_config_option=--group_tile ${PATH:TASK_DIR}/config/tile_config.xml
 openfpga_add_fpga_core_module=
-openfpga_vpr_device=4x4L
+openfpga_vpr_device=4x4L_io_boundary
 openfpga_vpr_route_chan_width=20
 
 [ARCHITECTURES]

--- a/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lshape/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lshape/config/task.conf
@@ -1,0 +1,38 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/group_config_block_full_testbench_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_group_tile_config_option=--group_tile ${PATH:TASK_DIR}/config/tile_config.xml
+openfpga_add_fpga_core_module=
+openfpga_vpr_device=4x4L
+openfpga_vpr_route_chan_width=20
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileableL_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/or2/or2.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = or2
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=

--- a/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lshape/config/tile_config.xml
+++ b/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lshape/config/tile_config.xml
@@ -1,0 +1,1 @@
+<tiles style="top_left"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileableL_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableL_40nm.xml
@@ -52,6 +52,23 @@
         </pinlocations>
       </sub_tile>
     </tile>
+    <!-- IMPORTANT: DO NOT USE 'io_top' which will conflict with the tile 'io' when placed on the top side!!! So, I rename with 'io_topL' here -->
+    <tile name="io_topL" area="0">
+      <sub_tile name="io_topL" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left"></loc>
+          <loc side="top"></loc>
+          <loc side="right"></loc>
+          <loc side="bottom">io_topL.outpad io_topL.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
     <tile name="clb" area="53894">
       <sub_tile name="clb">
         <equivalent_sites>
@@ -91,6 +108,15 @@
     </fixed_layout>
     <fixed_layout name="4x4L" width="6" height="6">
       <region type="EMPTY" startx="0" starty="2" endx="2" endy="5" priority="101"/>
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="4x4L_io_boundary" width="6" height="6">
+      <region type="EMPTY" startx="0" starty="2" endx="2" endy="5" priority="101"/>
+      <region type="io_top" startx="1" starty="2" endx="2" endy="2" priority="102"/>
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>
       <corners type="EMPTY" priority="101"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileableL_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableL_40nm.xml
@@ -116,7 +116,7 @@
     </fixed_layout>
     <fixed_layout name="4x4L_io_boundary" width="6" height="6">
       <region type="EMPTY" startx="0" starty="2" endx="2" endy="5" priority="101"/>
-      <region type="io_top" startx="1" starty="2" endx="2" endy="2" priority="102"/>
+      <region type="io_topL" startx="1" starty="2" endx="2" endy="2" priority="102"/>
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>
       <corners type="EMPTY" priority="101"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileableL_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileableL_40nm.xml
@@ -62,9 +62,9 @@
         <output name="inpad" num_pins="1"/>
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
         <pinlocations pattern="custom">
-          <loc side="left"></loc>
-          <loc side="top"></loc>
-          <loc side="right"></loc>
+          <loc side="left"/>
+          <loc side="top"/>
+          <loc side="right"/>
           <loc side="bottom">io_topL.outpad io_topL.inpad</loc>
         </pinlocations>
       </sub_tile>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 

- When the following options are enabled for a given FPGA fabric in L shape, fabric generation failed.

  - ``group_tile``
  - ``group_config_block``
  - ``shrink_boundary``

![image](https://github.com/lnis-uofu/OpenFPGA/assets/11499826/d1290ce3-4e55-44ae-97a1-eed2f940c9d0)

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Fixed a bug in the tile module builders
- [x] Added dedicated testcases  

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
