### PR TITLE
Now Subtile index is supported in Custom Pin Location

### DIFF
--- a/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
@@ -390,7 +390,10 @@ static void add_top_module_io_children(
   }
   /* If width is odd, add the missing vertical line */
   if ((grids.width() - 2) % 2 == 1) {
-    if (xmin == xmax) {
+    /* Note: Do NOT add a coord two time! So when ymin == ymax, should skip this
+     * point. Think about a fabric of 3x3, where the point (1,1) is added twice
+     */
+    if (xmin == xmax && ymin != ymax) {
       for (size_t iy = ymin; iy < ymax + 1; iy++) {
         coords.push_back(vtr::Point<size_t>(xmin, iy));
       }
@@ -399,6 +402,7 @@ static void add_top_module_io_children(
 
   /* Now walk through the coordinates */
   for (vtr::Point<size_t> coord : coords) {
+    VTR_LOG("Adding coord [%lu][%lu]\n", coord.x(), coord.y());
     t_physical_tile_loc phy_tile_loc(coord.x(), coord.y(), layer);
     t_physical_tile_type_ptr grid_type = grids.get_physical_type(phy_tile_loc);
     /* Bypass EMPTY grid */

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -175,6 +175,7 @@ echo -e "Testing tiles with I/O in center grid";
 run-task basic_tests/tile_organization/tileable_io $@
 echo -e "Testing tiles with I/O consisting of subtiles";
 run-task basic_tests/tile_organization/io_subtile $@
+run-task basic_tests/tile_organization/io_subtile_strong $@
 echo -e "Testing tile grouping on a homogeneous FPGA fabric (Full testbench)";
 run-task basic_tests/tile_organization/homo_fabric_tile $@
 echo -e "Testing tile grouping on a homogeneous FPGA fabric (Preconfigured testbench)";

--- a/openfpga_flow/tasks/basic_tests/tile_organization/io_subtile_strong/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/io_subtile_strong/config/task.conf
@@ -1,0 +1,36 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_IoSubtile_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=3x3
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_IoSubtile_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/or2/or2.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = or2
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_IoSubtile_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_IoSubtile_40nm.xml
@@ -51,9 +51,9 @@
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
         <pinlocations pattern="custom">
           <loc side="left">fpga_output_center[1:0].outpad</loc>
-          <loc side="top"></loc>
+          <loc side="top"/>
           <loc side="right">fpga_output_center[3:2].outpad</loc>
-          <loc side="bottom"></loc>
+          <loc side="bottom"/>
         </pinlocations>
       </sub_tile>
     </tile>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_IoSubtile_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_IoSubtile_40nm.xml
@@ -32,7 +32,7 @@
     <tile name="hybrid_io_tile_center" area="0">
       <sub_tile name="fpga_input_center" capacity="6">
         <equivalent_sites>
-          <site pb_type="fpga_input_center"/>
+          <site pb_type="fpga_input"/>
         </equivalent_sites>
         <output name="inpad" num_pins="1"/>
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
@@ -45,7 +45,7 @@
       </sub_tile>
       <sub_tile name="fpga_output_center" capacity="4">
         <equivalent_sites>
-          <site pb_type="fpga_output_center"/>
+          <site pb_type="fpga_output"/>
         </equivalent_sites>
         <input name="outpad" num_pins="1"/>
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_IoSubtile_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_IoSubtile_40nm.xml
@@ -29,6 +29,34 @@
     </model>
   </models>
   <tiles>
+    <tile name="hybrid_io_tile_center" area="0">
+      <sub_tile name="fpga_input_center" capacity="6">
+        <equivalent_sites>
+          <site pb_type="fpga_input_center"/>
+        </equivalent_sites>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">fpga_input_center[1:0].inpad</loc>
+          <loc side="top">fpga_input_center[3:2].inpad</loc>
+          <loc side="right">fpga_input_center[4:4].inpad</loc>
+          <loc side="bottom">fpga_input_center[5:5].inpad</loc>
+        </pinlocations>
+      </sub_tile>
+      <sub_tile name="fpga_output_center" capacity="4">
+        <equivalent_sites>
+          <site pb_type="fpga_output_center"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">fpga_output_center[1:0].outpad</loc>
+          <loc side="top"></loc>
+          <loc side="right">fpga_output_center[3:2].outpad</loc>
+          <loc side="bottom"></loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
     <tile name="hybrid_io_tile" area="0">
       <sub_tile name="fpga_input" capacity="4">
         <equivalent_sites>
@@ -85,6 +113,14 @@
     <fixed_layout name="2x2" width="4" height="4">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="hybrid_io_tile" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="3x3" width="5" height="5">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="hybrid_io_tile" priority="100"/>
+      <single type="hybrid_io_tile_center" x="2" y="2" priority="100"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- When trying to customize pin location for subtiles, the subtile index cannot be used. 

For example,

```
 <tile name="hybrid_io_tile_center" area="0">
      <sub_tile name="fpga_input_center" capacity="6">
        <equivalent_sites>
          <site pb_type="fpga_input"/>
        </equivalent_sites>
        <output name="inpad" num_pins="1"/>
        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
        <pinlocations pattern="custom">
          <loc side="left">fpga_input_center[1:0].inpad</loc>
          <loc side="top">fpga_input_center[3:2].inpad</loc>
          <loc side="right">fpga_input_center[4:4].inpad</loc>
          <loc side="bottom">fpga_input_center[5:5].inpad</loc>
        </pinlocations>
      </sub_tile>
      <sub_tile name="fpga_output_center" capacity="4">
        <equivalent_sites>
          <site pb_type="fpga_output"/>
        </equivalent_sites>
        <input name="outpad" num_pins="1"/>
        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
        <pinlocations pattern="custom">
          <loc side="left">fpga_output_center[1:0].outpad</loc>
          <loc side="top"/>
          <loc side="right">fpga_output_center[3:2].outpad</loc>
          <loc side="bottom"/>
        </pinlocations>
      </sub_tile>
    </tile>
```

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Fixed the bug 
- [x] Also fixed a bug in the I/O children list where some I/O coordinate is added twice (tested on a 3x3 fabric, where [1,1] is added twice) 
- [x] Added a new testcase to validate this. 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
