### PR TITLE
Fixed a bug on spotting pin index of subtiles

### DIFF
--- a/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
@@ -402,7 +402,6 @@ static void add_top_module_io_children(
 
   /* Now walk through the coordinates */
   for (vtr::Point<size_t> coord : coords) {
-    VTR_LOG("Adding coord [%lu][%lu]\n", coord.x(), coord.y());
     t_physical_tile_loc phy_tile_loc(coord.x(), coord.y(), layer);
     t_physical_tile_type_ptr grid_type = grids.get_physical_type(phy_tile_loc);
     /* Bypass EMPTY grid */

--- a/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
@@ -1387,8 +1387,6 @@ static int build_top_module_global_net_for_given_tile_module(
             generate_tile_module_port_name(grid_instance_name, grid_port_name);
           ModulePortId tile_grid_port_id =
             module_manager.find_module_port(tile_module, tile_grid_port_name);
-          VTR_LOG("Finding global port '%s' from grid '%s'\n",
-                  tile_grid_port_name.c_str(), tile_module_name.c_str());
           VTR_ASSERT(true == module_manager.valid_module_port_id(
                                tile_module, tile_grid_port_id));
 

--- a/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
@@ -1341,8 +1341,9 @@ static int build_top_module_global_net_for_given_tile_module(
             return CMD_EXEC_FATAL_ERROR;
           }
           grid_pin_start_index =
-            sub_tile.sub_tile_to_tile_pin_indices[(subtile_index - sub_tile.capacity.low) * sub_tile_num_pins +
-            tile_port.absolute_first_pin_index];
+            sub_tile.sub_tile_to_tile_pin_indices
+              [(subtile_index - sub_tile.capacity.low) * sub_tile_num_pins +
+               tile_port.absolute_first_pin_index];
           physical_tile_port = tile_port;
           break;
         }
@@ -1386,7 +1387,8 @@ static int build_top_module_global_net_for_given_tile_module(
             generate_tile_module_port_name(grid_instance_name, grid_port_name);
           ModulePortId tile_grid_port_id =
             module_manager.find_module_port(tile_module, tile_grid_port_name);
-          VTR_LOG("Finding global port '%s' from grid '%s'\n", tile_grid_port_name.c_str(), tile_module_name.c_str());
+          VTR_LOG("Finding global port '%s' from grid '%s'\n",
+                  tile_grid_port_name.c_str(), tile_module_name.c_str());
           VTR_ASSERT(true == module_manager.valid_module_port_id(
                                tile_module, tile_grid_port_id));
 

--- a/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
@@ -1341,8 +1341,8 @@ static int build_top_module_global_net_for_given_tile_module(
             return CMD_EXEC_FATAL_ERROR;
           }
           grid_pin_start_index =
-            (subtile_index - sub_tile.capacity.low) * sub_tile_num_pins +
-            tile_port.absolute_first_pin_index;
+            sub_tile.sub_tile_to_tile_pin_indices[(subtile_index - sub_tile.capacity.low) * sub_tile_num_pins +
+            tile_port.absolute_first_pin_index];
           physical_tile_port = tile_port;
           break;
         }
@@ -1386,6 +1386,7 @@ static int build_top_module_global_net_for_given_tile_module(
             generate_tile_module_port_name(grid_instance_name, grid_port_name);
           ModulePortId tile_grid_port_id =
             module_manager.find_module_port(tile_module, tile_grid_port_name);
+          VTR_LOG("Finding global port '%s' from grid '%s'\n", tile_grid_port_name.c_str(), tile_module_name.c_str());
           VTR_ASSERT(true == module_manager.valid_module_port_id(
                                tile_module, tile_grid_port_id));
 

--- a/openfpga/src/utils/check_tile_annotation.cpp
+++ b/openfpga/src/utils/check_tile_annotation.cpp
@@ -167,7 +167,8 @@ static int check_tile_annotation_conflicts_with_physical_tile(
             }
 
             /* Check if port property matches */
-            int grid_pin_index = sub_tile.sub_tile_to_tile_pin_indices[tile_port.absolute_first_pin_index];
+            int grid_pin_index = sub_tile.sub_tile_to_tile_pin_indices
+                                   [tile_port.absolute_first_pin_index];
 
             if (tile_port.is_clock !=
                 tile_annotation.global_port_is_clock(tile_global_port)) {
@@ -218,7 +219,8 @@ static int check_tile_annotation_conflicts_with_physical_tile(
           if (0 == found_matched_physical_tile_port) {
             VTR_LOGF_ERROR(
               __FILE__, __LINE__,
-              "Tile port '%s.%s[%ld:%ld]' in tile annotation '%s' does not match "
+              "Tile port '%s.%s[%ld:%ld]' in tile annotation '%s' does not "
+              "match "
               "any physical tile port!\n",
               required_tile_name.c_str(), required_tile_port.get_name().c_str(),
               required_tile_port.get_lsb(), required_tile_port.get_msb(),
@@ -228,7 +230,8 @@ static int check_tile_annotation_conflicts_with_physical_tile(
           if (1 < found_matched_physical_tile_port) {
             VTR_LOGF_ERROR(
               __FILE__, __LINE__,
-              "Tile port '%s.%s[%ld:%ld]' in tile annotation '%s' match more than "
+              "Tile port '%s.%s[%ld:%ld]' in tile annotation '%s' match more "
+              "than "
               "1 physical tile port!\n",
               required_tile_name.c_str(), required_tile_port.get_name().c_str(),
               required_tile_port.get_lsb(), required_tile_port.get_msb(),

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
@@ -182,7 +182,7 @@
     <global_port name="clk" is_clock="true" default_val="0">
       <tile name="clb" port="clk" x="-1" y="-1"/>
       <tile name="io" port="clk" x="-1" y="-1"/>
-      <tile name="io_input" port="clk" x="-1" y="-1"/>
+      <tile name="io_hybrid" port="clk" x="-1" y="-1"/>
     </global_port>
   </tile_annotations>
   <pb_type_annotations>

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
@@ -158,6 +158,13 @@
       <port type="input" prefix="outpad" lib_name="A" size="1"/>
       <port type="output" prefix="inpad" lib_name="Y" size="1"/>
     </circuit_model>
+    <circuit_model type="iopad" name="GPIN" prefix="GPIN" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
+      <port type="inout" prefix="PAD" lib_name="A" size="1" is_global="true" is_io="true" is_data_io="true"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
   </circuit_library>
   <configuration_protocol>
     <organization type="scan_chain" circuit_model_name="DFF"/>
@@ -175,6 +182,7 @@
     <global_port name="clk" is_clock="true" default_val="0">
       <tile name="clb" port="clk" x="-1" y="-1"/>
       <tile name="io" port="clk" x="-1" y="-1"/>
+      <tile name="io_input" port="clk" x="-1" y="-1"/>
     </global_port>
   </tile_annotations>
   <pb_type_annotations>
@@ -186,6 +194,12 @@
     <pb_type name="io[inpad_registered].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
     <pb_type name="io[inpad_registered].ff" physical_pb_type_name="io[physical].ff"/>
     <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
+    <pb_type name="io_input" physical_mode_name="physical" idle_mode_name="inpad"/>
+    <pb_type name="io_input[physical].iopad" circuit_model_name="GPIN" mode_bits="1"/>
+    <pb_type name="io_input[physical].ff" circuit_model_name="DFFSRQ"/>
+    <pb_type name="io_input[inpad].inpad" physical_pb_type_name="io_input[physical].iopad" mode_bits="1"/>
+    <pb_type name="io_input[inpad_registered].inpad" physical_pb_type_name="io_input[physical].iopad" mode_bits="1"/>
+    <pb_type name="io_input[inpad_registered].ff" physical_pb_type_name="io_input[physical].ff"/>
     <!-- End physical pb_type binding in complex block IO -->
     <!-- physical pb_type binding in complex block CLB -->
     <!-- physical mode will be the default mode if not specified -->

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -196,6 +196,7 @@ run-task basic_tests/group_config_block/group_config_block_homo_fabric_tile_Lsha
 run-task basic_tests/group_config_block/group_config_block_homo_fabric_tile_core_wrapper $@
 run-task basic_tests/group_config_block/group_config_block_hetero_fabric_tile $@
 run-task basic_tests/group_config_block/group_config_block_hetero_fabric_tile_Lshape $@
+run-task basic_tests/group_config_block/group_config_block_homo_fabric_tile_global_tile_clock_io_subtile $@
 
 echo -e "Testing global port definition from tiles";
 run-task basic_tests/global_tile_ports/global_tile_clock $@

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -179,6 +179,7 @@ run-task basic_tests/tile_organization/io_subtile_strong $@
 echo -e "Testing tile grouping on a homogeneous FPGA fabric (Full testbench)";
 run-task basic_tests/tile_organization/homo_fabric_tile $@
 echo -e "Testing tile grouping on a homogeneous FPGA fabric (Preconfigured testbench)";
+run-task basic_tests/tile_organization/fabric_tile_global_tile_clock_io_subtile $@
 run-task basic_tests/tile_organization/homo_fabric_tile_preconfig $@
 run-task basic_tests/tile_organization/homo_fabric_tile_2x2_preconfig $@
 run-task basic_tests/tile_organization/homo_fabric_tile_4x4_preconfig $@

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -198,6 +198,7 @@ run-task basic_tests/group_config_block/group_config_block_hetero_fabric_tile_Ls
 
 echo -e "Testing global port definition from tiles";
 run-task basic_tests/global_tile_ports/global_tile_clock $@
+run-task basic_tests/global_tile_ports/global_tile_clock_subtile $@
 run-task basic_tests/global_tile_ports/global_tile_reset $@
 run-task basic_tests/global_tile_ports/global_tile_4clock $@
 run-task basic_tests/global_tile_ports/global_tile_4clock_pin $@

--- a/openfpga_flow/tasks/basic_tests/global_tile_ports/global_tile_clock_subtile/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/global_tile_ports/global_tile_clock_subtile/config/task.conf
@@ -1,0 +1,35 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/global_tile_clock_full_testbench_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=2x2_hybrid_io
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_pipelined/and2_pipelined.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2_pipelined
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=

--- a/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_global_tile_clock_io_subtile/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_global_tile_clock_io_subtile/config/task.conf
@@ -1,0 +1,42 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/group_config_block_preconfig_testbench_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+openfpga_vpr_extra_options=
+openfpga_pb_pin_fixup_command=
+openfpga_vpr_device=2x2_hybrid_io
+openfpga_vpr_route_chan_width=20
+openfpga_group_tile_config_option=--group_tile ${PATH:TASK_DIR}/config/tile_config.xml
+openfpga_verilog_testbench_options=--explicit_port_mapping
+openfpga_add_fpga_core_module=
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_pipelined/and2_pipelined.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2_pipelined
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_global_tile_clock_io_subtile/config/tile_config.xml
+++ b/openfpga_flow/tasks/basic_tests/group_config_block/group_config_block_homo_fabric_tile_global_tile_clock_io_subtile/config/tile_config.xml
@@ -1,0 +1,1 @@
+<tiles style="top_left"/>

--- a/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_global_tile_clock_io_subtile/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_global_tile_clock_io_subtile/config/task.conf
@@ -1,0 +1,42 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/group_tile_preconfig_testbench_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_GlobalTileClk_registerable_io_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+openfpga_vpr_extra_options=
+openfpga_pb_pin_fixup_command=
+openfpga_vpr_device=2x2_hybrid_io
+openfpga_vpr_route_chan_width=20
+openfpga_group_tile_config_file=${PATH:TASK_DIR}/config/tile_config.xml
+openfpga_verilog_testbench_options=--explicit_port_mapping
+
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_pipelined/and2_pipelined.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2_pipelined
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_global_tile_clock_io_subtile/config/tile_config.xml
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_global_tile_clock_io_subtile/config/tile_config.xml
@@ -1,0 +1,1 @@
+<tiles style="top_left"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
@@ -297,12 +297,12 @@
           <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
         </pb_type>
         <interconnect>
-          <direct name="clk" input="io.clk" output="ff.clk"/>
+          <direct name="clk" input="io_input.clk" output="ff.clk"/>
           <!-- Create a selector between registered/combinational I/O -->
           <direct name="inpad" input="iopad.inpad" output="ff.D"/>
-          <mux name="mux1" input="iopad.inpad ff.Q" output="io.inpad">
-            <delay_constant max="4.5e-11" in_port="iopad.inpad" out_port="io.inpad"/>
-            <delay_constant max="4.243e-11" in_port="ff.Q" out_port="io.inpad"/>
+          <mux name="mux1" input="iopad.inpad ff.Q" output="io_input.inpad">
+            <delay_constant max="4.5e-11" in_port="iopad.inpad" out_port="io_input.inpad"/>
+            <delay_constant max="4.243e-11" in_port="ff.Q" out_port="io_input.inpad"/>
           </mux>
         </interconnect>
       </mode>
@@ -316,8 +316,8 @@
           <output name="inpad" num_pins="1"/>
         </pb_type>
         <interconnect>
-          <direct name="inpad" input="inpad.inpad" output="io.inpad">
-            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          <direct name="inpad" input="inpad.inpad" output="io_input.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io_input.inpad"/>
           </direct>
         </interconnect>
       </mode>
@@ -333,11 +333,11 @@
           <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
         </pb_type>
         <interconnect>
-          <direct name="clk" input="io.clk" output="ff.clk"/>
+          <direct name="clk" input="io_input.clk" output="ff.clk"/>
           <direct name="inpad" input="inpad.inpad" output="ff.D">
             <pack_pattern name="registered_io" in_port="inpad.inpad" out_port="ff.D"/>
           </direct>
-          <direct name="ff2inpad" input="ff.Q" output="io.inpad"/>
+          <direct name="ff2inpad" input="ff.Q" output="io_input.inpad"/>
         </interconnect>
       </mode>
       <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_GlobalTileClk_registerable_io_40nm.xml
@@ -34,10 +34,50 @@
         <port name="inpad"/>
       </output_ports>
     </model>
+    <model name="io_inpad">
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
   </models>
   <tiles>
     <tile name="io" area="0">
       <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad io.clk</loc>
+          <loc side="top">io.outpad io.inpad io.clk</loc>
+          <loc side="right">io.outpad io.inpad io.clk</loc>
+          <loc side="bottom">io.outpad io.inpad io.clk</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_hybrid" area="0">
+      <sub_tile name="io_input" capacity="2">
+        <equivalent_sites>
+          <site pb_type="io_input"/>
+        </equivalent_sites>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left">io_input.inpad io_input.clk</loc>
+          <loc side="top">io_input.inpad io_input.clk</loc>
+          <loc side="right">io_input.inpad io_input.clk</loc>
+          <loc side="bottom">io_input.inpad io_input.clk</loc>
+        </pinlocations>
+      </sub_tile>
+      <sub_tile name="io" capacity="6">
         <equivalent_sites>
           <site pb_type="io"/>
         </equivalent_sites>
@@ -83,6 +123,13 @@
     <fixed_layout name="2x2" width="4" height="4">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+    <fixed_layout name="2x2_hybrid_io" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io_hybrid" priority="100"/>
       <corners type="EMPTY" priority="101"/>
       <!--Fill with 'clb'-->
       <fill type="clb" priority="10"/>
@@ -222,6 +269,75 @@
           <direct name="outpad" input="io.outpad" output="outpad.outpad">
             <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
           </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <pb_type name="io_input">
+      <output name="inpad" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io_inpad" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="io.clk" output="ff.clk"/>
+          <!-- Create a selector between registered/combinational I/O -->
+          <direct name="inpad" input="iopad.inpad" output="ff.D"/>
+          <mux name="mux1" input="iopad.inpad ff.Q" output="io.inpad">
+            <delay_constant max="4.5e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+            <delay_constant max="4.243e-11" in_port="ff.Q" out_port="io.inpad"/>
+          </mux>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="inpad_registered">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="io.clk" output="ff.clk"/>
+          <direct name="inpad" input="inpad.inpad" output="ff.D">
+            <pack_pattern name="registered_io" in_port="inpad.inpad" out_port="ff.D"/>
+          </direct>
+          <direct name="ff2inpad" input="ff.Q" output="io.inpad"/>
         </interconnect>
       </mode>
       <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- See more bugs in Subtile support when the global tile clock feature is on:

Example architecture: 

```
    <tile name="io_hybrid" area="0">
      <sub_tile name="io_input" capacity="2">
        <equivalent_sites>
          <site pb_type="io_input"/>
        </equivalent_sites>
        <output name="inpad" num_pins="1"/>
        <clock name="clk" num_pins="1"/>
        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
        </fc>
        <pinlocations pattern="custom">
          <loc side="left">io_input.inpad io_input.clk</loc>
          <loc side="top">io_input.inpad io_input.clk</loc>
          <loc side="right">io_input.inpad io_input.clk</loc>
          <loc side="bottom">io_input.inpad io_input.clk</loc>
        </pinlocations>
      </sub_tile>
      <sub_tile name="io" capacity="6">
        <equivalent_sites>
          <site pb_type="io"/>
        </equivalent_sites>
        <input name="outpad" num_pins="1"/>
        <output name="inpad" num_pins="1"/>
        <clock name="clk" num_pins="1"/>
        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
        </fc>
        <pinlocations pattern="custom">
          <loc side="left">io.outpad io.inpad io.clk</loc>
          <loc side="top">io.outpad io.inpad io.clk</loc>
          <loc side="right">io.outpad io.inpad io.clk</loc>
          <loc side="bottom">io.outpad io.inpad io.clk</loc>
        </pinlocations>
      </sub_tile>
```
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Fixed the bug by using proper data from vtr 
- [x] Add a few test cases to validate more comb of features 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
