### PR TITLE
Support different routing channel width in X and and Y axis

### DIFF
--- a/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124X_L12Y_40nm_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124X_L12Y_40nm_frame_openfpga.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0"?>
+<!-- Architecture annotation for OpenFPGA framework
+     This annotation supports the k6_N10_40nm.xml 
+     - General purpose logic block
+       - K = 6, N = 10, I = 40
+       - Single mode
+     - Routing architecture
+       - L = 4, fc_in = 0.15, fc_out = 0.1
+  -->
+<openfpga_architecture>
+  <technology_library>
+    <device_library>
+      <device_model name="logic" type="transistor">
+        <lib type="industry" corner="TOP_TT" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="0.9" pn_ratio="2"/>
+        <pmos name="pch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+        <nmos name="nch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+      </device_model>
+      <device_model name="io" type="transistor">
+        <lib type="academia" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="2.5" pn_ratio="3"/>
+        <pmos name="pch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+        <nmos name="nch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+      </device_model>
+    </device_library>
+    <variation_library>
+      <variation name="logic_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+      <variation name="io_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+    </variation_library>
+  </technology_library>
+  <circuit_library>
+    <circuit_model type="inv_buf" name="INVTX1" prefix="INVTX1" is_default="true">
+      <design_technology type="cmos" topology="inverter" size="1"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="buf4" prefix="buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="2" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="tap_buf4" prefix="tap_buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="3" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="gate" name="OR2" prefix="OR2" is_default="true">
+      <design_technology type="cmos" topology="OR"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="a" size="1"/>
+      <port type="input" prefix="b" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="a b" out_port="out">
+        10e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="a b" out_port="out">
+        10e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="pass_gate" name="TGATE" prefix="TGATE" is_default="true">
+      <design_technology type="cmos" topology="transmission_gate" nmos_size="1" pmos_size="2"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="input" prefix="sel" size="1"/>
+      <port type="input" prefix="selb" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="chan_wire" name="chan_segment" prefix="track_seg" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+    </circuit_model>
+    <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level_tapbuf" prefix="mux_2level_tapbuf" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_1level_tapbuf" prefix="mux_1level_tapbuf" is_default="true" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="one_level" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0"/>
+    </circuit_model>
+    <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
+      <design_technology type="cmos" fracturable_lut="true"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_inverter exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_buffer exist="true" circuit_model_name="buf4"/>
+      <lut_intermediate_buffer exist="true" circuit_model_name="buf4" location_map="-1-"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="4" tri_state_map="---1" circuit_model_name="OR2"/>
+      <port type="output" prefix="lut3_out" size="2" lut_frac_level="3" lut_output_mask="0,1"/>
+      <port type="output" prefix="lut4_out" size="1" lut_output_mask="0"/>
+      <port type="sram" prefix="sram" size="16"/>
+      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="LATCHR" default_val="1"/>
+    </circuit_model>
+    <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
+    <circuit_model type="sram" name="LATCHR" prefix="LATCHR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="bl" prefix="bl" lib_name="D" size="1"/>
+      <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+      <port type="output" prefix="Q" lib_name="Q" size="1"/>
+      <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true" is_data_io="true"/>
+      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="LATCHR" default_val="1"/>
+      <port type="input" prefix="outpad" lib_name="A" size="1"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
+    <circuit_model type="hard_logic" name="ADDF" prefix="ADDF" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/adder.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="a" lib_name="A" size="1"/>
+      <port type="input" prefix="b" lib_name="B" size="1"/>
+      <port type="input" prefix="cin" lib_name="CI" size="1"/>
+      <port type="output" prefix="sumout" lib_name="SUM" size="1"/>
+      <port type="output" prefix="cout" lib_name="CO" size="1"/>
+    </circuit_model>
+    <circuit_model type="hard_logic" name="dpram_128x8" prefix="dpram_128x8" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dpram.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dpram1k.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="waddr" size="7"/>
+      <port type="input" prefix="raddr" size="7"/>
+      <port type="input" prefix="d_in" size="8"/>
+      <port type="input" prefix="wen" size="1"/>
+      <port type="input" prefix="ren" size="1"/>
+      <port type="output" prefix="d_out" size="8"/>
+      <port type="clock" prefix="clk" size="1" is_global="true" default_val="0"/>
+    </circuit_model>
+  </circuit_library>
+  <configuration_protocol>
+    <organization type="frame_based" circuit_model_name="LATCHR"/>
+  </configuration_protocol>
+  <connection_block>
+    <switch name="ipin_cblock" circuit_model_name="mux_2level_tapbuf"/>
+  </connection_block>
+  <switch_block>
+    <switch name="L1" circuit_model_name="mux_2level_tapbuf"/>
+    <switch name="L2" circuit_model_name="mux_2level_tapbuf"/>
+    <switch name="L4" circuit_model_name="mux_2level_tapbuf"/>
+  </switch_block>
+  <routing_segment>
+    <segment name="L1x" circuit_model_name="chan_segment"/>
+    <segment name="L2x" circuit_model_name="chan_segment"/>
+    <segment name="L4x" circuit_model_name="chan_segment"/>
+    <segment name="L1y" circuit_model_name="chan_segment"/>
+    <segment name="L2y" circuit_model_name="chan_segment"/>
+  </routing_segment>
+  <direct_connection>
+    <direct name="adder_carry" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
+  </direct_connection>
+  <pb_type_annotations>
+    <!-- physical pb_type binding in complex block IO -->
+    <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
+    <!-- End physical pb_type binding in complex block IO -->
+    <!-- physical pb_type binding in complex block CLB -->
+    <!-- physical mode will be the default mode if not specified -->
+    <pb_type name="clb">
+      <!-- Binding interconnect to circuit models as their physical implementation, if not defined, we use the default model -->
+      <interconnect name="crossbar" circuit_model_name="mux_2level"/>
+    </pb_type>
+    <pb_type name="clb.fle" physical_mode_name="physical"/>
+    <pb_type name="clb.fle[physical].fabric.frac_logic.frac_lut4" circuit_model_name="frac_lut4" mode_bits="0"/>
+    <pb_type name="clb.fle[physical].fabric.ff" circuit_model_name="DFFSRQ"/>
+    <pb_type name="clb.fle[physical].fabric.adder" circuit_model_name="ADDF"/>
+    <!-- Binding operating pb_type to physical pb_type -->
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.lut3" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="1" physical_pb_type_index_factor="0.5">
+      <!-- Binding the lut3 to the first 3 inputs of fracturable lut4 -->
+      <port name="in" physical_mode_port="in[0:2]"/>
+      <port name="out" physical_mode_port="lut3_out[0:0]" physical_mode_pin_rotate_offset="1"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff" physical_pb_type_name="clb.fle[physical].fabric.ff"/>
+    <!-- Binding operating pb_types in mode 'arithmetic' -->
+    <pb_type name="clb.fle[arithmetic].arithmetic.lut3" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="1" physical_pb_type_index_factor="0.5">
+      <!-- Binding the lut4 to the first 3 inputs of fracturable lut6 -->
+      <port name="in" physical_mode_port="in[0:2]"/>
+      <port name="out" physical_mode_port="lut3_out[0:0]" physical_mode_pin_rotate_offset="1"/>
+    </pb_type>
+    <pb_type name="clb.fle[arithmetic].arithmetic.adder" physical_pb_type_name="clb.fle[physical].fabric.adder"/>
+    <pb_type name="clb.fle[arithmetic].arithmetic.ff" physical_pb_type_name="clb.fle[physical].fabric.ff"/>
+    <!-- Binding operating pb_types in mode 'ble4' -->
+    <pb_type name="clb.fle[n1_lut4].ble4.lut4" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="0">
+      <!-- Binding the lut4 to the first 4 inputs of fracturable lut4 -->
+      <port name="in" physical_mode_port="in[0:3]"/>
+      <port name="out" physical_mode_port="lut4_out"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff" physical_pb_type_name="clb.fle[physical].fabric.ff" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
+    <!-- End physical pb_type binding in complex block IO -->
+    <!-- physical pb_type binding in complex block memory -->
+    <pb_type name="memory[mem_128x8_dp].mem_128x8_dp" circuit_model_name="dpram_128x8"/>
+    <!-- END physical pb_type binding in complex block memory -->
+  </pb_type_annotations>
+</openfpga_architecture>

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -149,6 +149,8 @@ echo -e "Testing K4N4 with multiple lengths of routing segments";
 run-task basic_tests/k4_series/k4n4_L124 $@
 echo -e "Testing K4N4 with routing channel width distribution: x = 0.8, y = 1.0";
 run-task basic_tests/k4_series/k4n4_chandistr $@
+echo -e "Testing K4N4 with routing channel width distribution: x = 0.8, y = 1.0 and wire segment distribution: x=L124, Y=L12";
+run-task basic_tests/k4_series/k4n4_chandistr_segdist $@
 echo -e "Testing K4N4 with 32-bit fracturable multiplier";
 run-task basic_tests/k4_series/k4n4_frac_mult $@
 echo -e "Testing K4N5 with pattern based local routing";

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -147,6 +147,8 @@ echo -e "Testing K4N4 with LUTRAM";
 run-task basic_tests/k4_series/k4n4_lutram $@
 echo -e "Testing K4N4 with multiple lengths of routing segments";
 run-task basic_tests/k4_series/k4n4_L124 $@
+echo -e "Testing K4N4 with routing channel width distribution: x = 0.8, y = 1.0";
+run-task basic_tests/k4_series/k4n4_chandistr $@
 echo -e "Testing K4N4 with 32-bit fracturable multiplier";
 run-task basic_tests/k4_series/k4n4_frac_mult $@
 echo -e "Testing K4N5 with pattern based local routing";

--- a/openfpga_flow/tasks/basic_tests/k4_series/k4n4_chandistr/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/k4_series/k4n4_chandistr/config/task.conf
@@ -1,0 +1,38 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_route_chan_width_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124_40nm_frame_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=4x4
+openfpga_vpr_route_chan_width=40
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_ChanWidth0p8_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_act = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.act
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/basic_tests/k4_series/k4n4_chandistr_segdist/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/k4_series/k4n4_chandistr_segdist/config/task.conf
@@ -20,7 +20,7 @@ openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scrip
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124X_L12Y_40nm_frame_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
 openfpga_vpr_device_layout=4x4
-openfpga_vpr_route_chan_width=40
+openfpga_vpr_route_chan_width=60
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124X_L12Y_ChanWidth0p8_40nm.xml

--- a/openfpga_flow/tasks/basic_tests/k4_series/k4n4_chandistr_segdist/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/k4_series/k4n4_chandistr_segdist/config/task.conf
@@ -1,0 +1,38 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_route_chan_width_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124X_L12Y_40nm_frame_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=4x4
+openfpga_vpr_route_chan_width=40
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124X_L12Y_ChanWidth0p8_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_act = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.act
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124X_L12Y_ChanWidth0p8_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124X_L12Y_ChanWidth0p8_40nm.xml
@@ -1,0 +1,733 @@
+<?xml version="1.0"?>
+<!-- 
+  Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 4, N = 4, fracturable 4 LUTs (can operate as one 4-LUT or two 3-LUTs with all 3 inputs shared) 
+    with optionally registered outputs
+  - Routing architecture:
+    25% L = 1, fc_in = 0.25, Fc_out = 0.2
+    25% L = 2, fc_in = 0.25, Fc_out = 0.2
+    50% L = 4, fc_in = 0.25, Fc_out = 0.2
+
+  Details on Modelling:
+
+  Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+         If you need to register the I/O, define clocks in the circuit models
+         These clocks can be handled in back-end
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[3:0] clb.I[5:0]</loc>
+          <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="7"/>
+        <input name="raddr" num_pins="7"/>
+        <input name="d_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="0.800000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	       book area formula. This means the mux transistors are about 5x minimum drive strength.
+	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+	       2.5x when looking up in Jeff's tables.
+	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment axis="x" name="L1x" freq="1.000000" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment axis="x" name="L2x" freq="1.000000" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment axis="x" name="L4x" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+    <segment axis="y" name="L1y" freq="1.000000" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment axis="y" name="L2y" freq="1.000000" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+           If you need to register the I/O, define clocks in the circuit models
+           These clocks can be handled in back-end
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
+             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+             The outputs of the fracturable logic element can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>
+              <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>
+              <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                           we instead take the average of these numbers to get more stable results
+                      82e-12
+                      173e-12
+                      261e-12
+                      263e-12
+                      398e-12
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  235e-12
+                  235e-12
+                  235e-12
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- BEGIN arithmetic mode of dual lut3 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="3" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  -->
+              <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  195e-12
+                  195e-12
+                  195e-12
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <complete name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>
+              <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
+              </direct>
+              <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>
+              </mux>
+              <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>
+                <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  398e-12
+                  397e-12
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                261e-12
+                261e-12
+                261e-12
+                261e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+		     The delays below come from Stratix IV. the delay through a connection block
+		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+		     delay within the crossbar is 95 ps. 
+		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+               naive specification).
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">
+          <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="7"/>
+      <input name="raddr" num_pins="7"/>
+      <input name="d_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 128x8=1Kbit memory block
+           Note: the delay numbers are extracted from VPR flagship XML without modification
+                 Should align to the process technology we using to create the 1K dual-port RAM
+        -->
+      <mode name="mem_128x8_dp">
+        <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="7" port_class="address"/>
+          <input name="raddr" num_pins="7" port_class="address"/>
+          <input name="d_in" num_pins="8" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
+</architecture>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_ChanWidth0p8_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_ChanWidth0p8_40nm.xml
@@ -1,0 +1,723 @@
+<?xml version="1.0"?>
+<!-- 
+  Flagship Heterogeneous Architecture (No Carry Chains) for VTR 7.0.
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 4, N = 4, fracturable 4 LUTs (can operate as one 4-LUT or two 3-LUTs with all 3 inputs shared) 
+    with optionally registered outputs
+  - Routing architecture:
+    25% L = 1, fc_in = 0.25, Fc_out = 0.2
+    25% L = 2, fc_in = 0.25, Fc_out = 0.2
+    50% L = 4, fc_in = 0.25, Fc_out = 0.2
+
+  Details on Modelling:
+
+  Based on flagship k4_frac_N4_mem32K_40nm.xml architecture.
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut4">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut3_out"/>
+        <port name="lut4_out"/>
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="d_out" clock="clk"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+         If you need to register the I/O, define clocks in the circuit models
+         These clocks can be handled in back-end
+     -->
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="12" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="8" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[3:0] clb.I[5:0]</loc>
+          <loc side="bottom">clb.cout clb.O[7:4] clb.I[11:6]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="7"/>
+        <input name="raddr" num_pins="7"/>
+        <input name="d_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="d_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="4x4" width="6" height="6">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="0.800000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	       book area formula. This means the mux transistors are about 5x minimum drive strength.
+	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+	       2.5x when looking up in Jeff's tables.
+	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="L1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L1" freq="1.000000" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L1"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L2" freq="1.000000" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L2"/>
+      <sb type="pattern">1 1 1</sb>
+      <cb type="pattern">1 1</cb>
+    </segment>
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="L4"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+           If you need to register the I/O, define clocks in the circuit models
+           These clocks can be handled in back-end
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="12" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="8" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
+             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+             The outputs of the fracturable logic element can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                <input name="in" num_pins="4"/>
+                <output name="lut3_out" num_pins="2"/>
+                <output name="lut4_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut4.in"/>
+                <direct name="direct2" input="frac_lut4.lut3_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut4.lut4_out frac_lut4.lut3_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct3" input="adder[0:0].cout" output="fabric.cout"/>
+              <direct name="direct4" input="frac_logic.out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct5" input="frac_logic.out[1:1]" output="adder[0:0].b"/>
+              <complete name="direct6" input="fabric.clk" output="ff[1:0].clk"/>
+              <mux name="mux1" input="frac_logic.out[0:0] adder[0].cout" output="ff[0:0].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[0:0]" out_port="ff[0:0].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].cout" out_port="ff[0:0].D"/>
+              </mux>
+              <mux name="mux2" input="frac_logic.out[1:1] adder[0].sumout" output="ff[1:1].D">
+                <delay_constant max="25e-12" in_port="frac_logic.out[1:1]" out_port="ff[1:1].D"/>
+                <delay_constant max="45e-12" in_port="adder[0].sumout" out_port="ff[1:1].D"/>
+              </mux>
+              <mux name="mux3" input="adder[0].cout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].cout frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux4" input="adder[0].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="adder[0].sumout frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- Dual 3-LUT mode definition begin -->
+        <mode name="n2_lut3">
+          <pb_type name="lut3inter" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <output name="out" num_pins="2"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble3" num_pb="2">
+              <input name="in" num_pins="3"/>
+              <output name="out" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <!-- Define the LUT -->
+              <pb_type name="lut3" blif_model=".names" num_pb="1" class="lut">
+                <input name="in" num_pins="3" port_class="lut_in"/>
+                <output name="out" num_pins="1" port_class="lut_out"/>
+                <!-- LUT timing using delay matrix -->
+                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                           we instead take the average of these numbers to get more stable results
+                      82e-12
+                      173e-12
+                      261e-12
+                      263e-12
+                      398e-12
+                      -->
+                <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  235e-12
+                  235e-12
+                  235e-12
+                </delay_matrix>
+              </pb_type>
+              <!-- Define the flip-flop -->
+              <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                <input name="D" num_pins="1" port_class="D"/>
+                <output name="Q" num_pins="1" port_class="Q"/>
+                <clock name="clk" num_pins="1" port_class="clock"/>
+                <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="ble3.in[2:0]" output="lut3[0:0].in[2:0]"/>
+                <direct name="direct2" input="lut3[0:0].out" output="ff[0:0].D">
+                  <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                  <pack_pattern name="ble3" in_port="lut3[0:0].out" out_port="ff[0:0].D"/>
+                </direct>
+                <direct name="direct3" input="ble3.clk" output="ff[0:0].clk"/>
+                <mux name="mux1" input="ff[0:0].Q lut3.out[0:0]" output="ble3.out[0:0]">
+                  <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                  <delay_constant max="25e-12" in_port="lut3.out[0:0]" out_port="ble3.out[0:0]"/>
+                  <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="ble3.out[0:0]"/>
+                </mux>
+              </interconnect>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut3inter.in" output="ble3[0:0].in"/>
+              <direct name="direct2" input="lut3inter.in" output="ble3[1:1].in"/>
+              <direct name="direct3" input="ble3[1:0].out" output="lut3inter.out"/>
+              <complete name="complete1" input="lut3inter.clk" output="ble3[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="lut3inter.in"/>
+            <direct name="direct2" input="lut3inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut3inter.clk"/>
+          </interconnect>
+        </mode>
+        <!-- Dual 3-LUT mode definition end -->
+        <!-- BEGIN arithmetic mode of dual lut3 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="1">
+            <input name="in" num_pins="3"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut3" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="3" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  -->
+              <delay_matrix type="max" in_port="lut3.in" out_port="lut3.out">
+                  195e-12
+                  195e-12
+                  195e-12
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <complete name="clock" input="arithmetic.clk" output="ff.clk"/>
+              <direct name="lut_in1" input="arithmetic.in[2:0]" output="lut3[0:0].in[2:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[2:0]" output="lut3[1:1].in[2:0]"/>
+              <direct name="lut_to_add1" input="lut3[0:0].out" output="adder.a">
+              </direct>
+              <direct name="lut_to_add2" input="lut3[1:1].out" output="adder.b">
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="cout" input="ff[0:0].Q adder.cout" output="arithmetic.out[0:0]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[0:0]"/>
+                <delay_constant max="45e-12" in_port="ff[0:0].Q" out_port="arithmetic.out[0:0]"/>
+              </mux>
+              <mux name="sumout" input="ff[1:1].Q adder.sumout" output="arithmetic.out[1:1]">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out[1:1]"/>
+                <delay_constant max="45e-12" in_port="ff[1:1].Q" out_port="arithmetic.out[1:1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[2:0]" output="arithmetic[0:0].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[0:0].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <direct name="direct4" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  398e-12
+                  397e-12
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                261e-12
+                261e-12
+                261e-12
+                261e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 4-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+		     The delays below come from Stratix IV. the delay through a connection block
+		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+		     delay within the crossbar is 95 ps. 
+		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+               naive specification).
+          -->
+        <direct name="clbouts1" input="fle[3:0].out[0:0]" output="clb.O[3:0]"/>
+        <direct name="clbouts2" input="fle[3:0].out[1:1]" output="clb.O[7:4]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[3:3].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[3:3].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[2:0].cout" output="fle[3:1].cin">
+          <pack_pattern name="chain" in_port="fle[2:0].cout" out_port="fle[3:1].cin"/>
+        </direct>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="7"/>
+      <input name="raddr" num_pins="7"/>
+      <input name="d_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="d_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 128x8=1Kbit memory block
+           Note: the delay numbers are extracted from VPR flagship XML without modification
+                 Should align to the process technology we using to create the 1K dual-port RAM
+        -->
+      <mode name="mem_128x8_dp">
+        <pb_type name="mem_128x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="waddr" num_pins="7" port_class="address"/>
+          <input name="raddr" num_pins="7" port_class="address"/>
+          <input name="d_in" num_pins="8" port_class="data_in"/>
+          <input name="wen" num_pins="1" port_class="write_en"/>
+          <input name="ren" num_pins="1" port_class="write_en"/>
+          <output name="d_out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.d_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_128x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_128x8_dp.d_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_128x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_128x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_128x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_128x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.d_in" output="mem_128x8_dp.d_in">
+            <delay_constant max="132e-12" in_port="memory.d_in" out_port="mem_128x8_dp.d_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_128x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_128x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_128x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_128x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_128x8_dp.d_out" output="memory.d_out">
+            <delay_constant max="40e-12" in_port="mem_128x8_dp.d_out" out_port="memory.d_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_128x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
+</architecture>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- VPR supports different routing channel width in X and Y axis. For example, X-direction routing channel width is 30 while Y-direction routing channel width is 20. This is very useful to alleviate routing congestion when some programmable blocks have a large number of pins to access routing on some sides.
- VPR also support different wire distribution in X and Y axis routing channels. For example, X-direction routing channel width is 30 but contains 80% L1 and 20% L4, while Y-direction routing channel width is 20 but contains 80% L1 and 20% L8. This is very useful in optimizing routing architecture when some programmable block pins require different wire lengths.

**However, these features are yet tested in OpenFPGA!!!**

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects: 
- [x] Update openfpga to support the two features above.
- [x] Added two testcases to validate the new features.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [x] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
