### PR TITLE
No more empty tiles on edges when Shrink Boundary is enabled

### DIFF
--- a/openfpga/src/annotation/annotate_rr_graph.cpp
+++ b/openfpga/src/annotation/annotate_rr_graph.cpp
@@ -436,7 +436,6 @@ void annotate_device_rr_gsb(const DeviceContext& vpr_device_ctx,
                      vtr::Point<size_t>(vpr_device_ctx.grid.width() - 2,
                                         vpr_device_ctx.grid.height() - 2),
                      layer, vtr::Point<size_t>(ix, iy), include_clock);
-
       /* Add to device_rr_gsb */
       vtr::Point<size_t> gsb_coordinate = rr_gsb.get_sb_coordinate();
       device_rr_gsb.add_rr_gsb(gsb_coordinate, rr_gsb);

--- a/openfpga/src/annotation/device_rr_gsb.cpp
+++ b/openfpga/src/annotation/device_rr_gsb.cpp
@@ -78,7 +78,8 @@ size_t DeviceRRGSB::get_num_cb_unique_module(const t_rr_type& cb_type) const {
 }
 
 /* Identify if a GSB actually exists at a location */
-bool DeviceRRGSB::is_gsb_exist(const RRGraphView& rr_graph, const vtr::Point<size_t> coord) const {
+bool DeviceRRGSB::is_gsb_exist(const RRGraphView& rr_graph,
+                               const vtr::Point<size_t> coord) const {
   /* Out of range, does not exist */
   if (false == validate_coordinate(coord)) {
     return false;

--- a/openfpga/src/annotation/device_rr_gsb.cpp
+++ b/openfpga/src/annotation/device_rr_gsb.cpp
@@ -78,7 +78,7 @@ size_t DeviceRRGSB::get_num_cb_unique_module(const t_rr_type& cb_type) const {
 }
 
 /* Identify if a GSB actually exists at a location */
-bool DeviceRRGSB::is_gsb_exist(const vtr::Point<size_t> coord) const {
+bool DeviceRRGSB::is_gsb_exist(const RRGraphView& rr_graph, const vtr::Point<size_t> coord) const {
   /* Out of range, does not exist */
   if (false == validate_coordinate(coord)) {
     return false;
@@ -93,7 +93,7 @@ bool DeviceRRGSB::is_gsb_exist(const vtr::Point<size_t> coord) const {
     return true;
   }
 
-  if (true == get_gsb(coord).is_sb_exist()) {
+  if (true == get_gsb(coord).is_sb_exist(rr_graph)) {
     return true;
   }
 

--- a/openfpga/src/annotation/device_rr_gsb.h
+++ b/openfpga/src/annotation/device_rr_gsb.h
@@ -58,7 +58,7 @@ class DeviceRRGSB {
                                     const vtr::Point<size_t>& coordinate) const;
   size_t get_num_cb_unique_module(const t_rr_type& cb_type)
     const; /* get the number of unique mirrors of CBs */
-  bool is_gsb_exist(const vtr::Point<size_t> coord) const;
+  bool is_gsb_exist(const RRGraphView& rr_graph, const vtr::Point<size_t> coord) const;
   /* Get the index of the unique Switch block module with a given GSB
    * coordinate. Note: Do NOT use sb coordinate!!! */
   size_t get_sb_unique_module_index(const vtr::Point<size_t>& coordinate) const;

--- a/openfpga/src/annotation/device_rr_gsb.h
+++ b/openfpga/src/annotation/device_rr_gsb.h
@@ -58,7 +58,8 @@ class DeviceRRGSB {
                                     const vtr::Point<size_t>& coordinate) const;
   size_t get_num_cb_unique_module(const t_rr_type& cb_type)
     const; /* get the number of unique mirrors of CBs */
-  bool is_gsb_exist(const RRGraphView& rr_graph, const vtr::Point<size_t> coord) const;
+  bool is_gsb_exist(const RRGraphView& rr_graph,
+                    const vtr::Point<size_t> coord) const;
   /* Get the index of the unique Switch block module with a given GSB
    * coordinate. Note: Do NOT use sb coordinate!!! */
   size_t get_sb_unique_module_index(const vtr::Point<size_t>& coordinate) const;

--- a/openfpga/src/annotation/fabric_tile.cpp
+++ b/openfpga/src/annotation/fabric_tile.cpp
@@ -400,7 +400,8 @@ bool FabricTile::register_pb_in_lookup(const FabricTileId& tile_id,
     return false;
   }
   /* Throw error if this coord is already registered! */
-  if (pb_coord2id_lookup_[coord.x()][coord.y()] && pb_coord2id_lookup_[coord.x()][coord.y()] != tile_id) {
+  if (pb_coord2id_lookup_[coord.x()][coord.y()] &&
+      pb_coord2id_lookup_[coord.x()][coord.y()] != tile_id) {
     VTR_LOG_ERROR(
       "Programmable block at [%lu][%lu] has already been registered!\n",
       coord.x(), coord.y());

--- a/openfpga/src/annotation/fabric_tile.cpp
+++ b/openfpga/src/annotation/fabric_tile.cpp
@@ -400,7 +400,7 @@ bool FabricTile::register_pb_in_lookup(const FabricTileId& tile_id,
     return false;
   }
   /* Throw error if this coord is already registered! */
-  if (pb_coord2id_lookup_[coord.x()][coord.y()]) {
+  if (pb_coord2id_lookup_[coord.x()][coord.y()] && pb_coord2id_lookup_[coord.x()][coord.y()] != tile_id) {
     VTR_LOG_ERROR(
       "Programmable block at [%lu][%lu] has already been registered!\n",
       coord.x(), coord.y());

--- a/openfpga/src/base/openfpga_build_fabric_template.h
+++ b/openfpga/src/base/openfpga_build_fabric_template.h
@@ -69,9 +69,9 @@ void compress_routing_hierarchy_template(T& openfpga_ctx,
     "Detected %lu unique switch blocks from a total of %d (compression "
     "rate=%.2f%)\n",
     openfpga_ctx.device_rr_gsb().get_num_sb_unique_module(),
-    find_device_rr_gsb_num_sb_modules(openfpga_ctx.device_rr_gsb()),
+    find_device_rr_gsb_num_sb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph),
     100. *
-      ((float)find_device_rr_gsb_num_sb_modules(openfpga_ctx.device_rr_gsb()) /
+      ((float)find_device_rr_gsb_num_sb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph) /
          (float)openfpga_ctx.device_rr_gsb().get_num_sb_unique_module() -
        1.));
 
@@ -79,9 +79,9 @@ void compress_routing_hierarchy_template(T& openfpga_ctx,
     "Detected %lu unique general switch blocks from a total of %d (compression "
     "rate=%.2f%)\n",
     openfpga_ctx.device_rr_gsb().get_num_gsb_unique_module(),
-    find_device_rr_gsb_num_gsb_modules(openfpga_ctx.device_rr_gsb()),
+    find_device_rr_gsb_num_gsb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph),
     100. *
-      ((float)find_device_rr_gsb_num_gsb_modules(openfpga_ctx.device_rr_gsb()) /
+      ((float)find_device_rr_gsb_num_gsb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph) /
          (float)openfpga_ctx.device_rr_gsb().get_num_gsb_unique_module() -
        1.));
 }

--- a/openfpga/src/base/openfpga_build_fabric_template.h
+++ b/openfpga/src/base/openfpga_build_fabric_template.h
@@ -69,21 +69,23 @@ void compress_routing_hierarchy_template(T& openfpga_ctx,
     "Detected %lu unique switch blocks from a total of %d (compression "
     "rate=%.2f%)\n",
     openfpga_ctx.device_rr_gsb().get_num_sb_unique_module(),
-    find_device_rr_gsb_num_sb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph),
-    100. *
-      ((float)find_device_rr_gsb_num_sb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph) /
-         (float)openfpga_ctx.device_rr_gsb().get_num_sb_unique_module() -
-       1.));
+    find_device_rr_gsb_num_sb_modules(openfpga_ctx.device_rr_gsb(),
+                                      g_vpr_ctx.device().rr_graph),
+    100. * ((float)find_device_rr_gsb_num_sb_modules(
+              openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph) /
+              (float)openfpga_ctx.device_rr_gsb().get_num_sb_unique_module() -
+            1.));
 
   VTR_LOG(
     "Detected %lu unique general switch blocks from a total of %d (compression "
     "rate=%.2f%)\n",
     openfpga_ctx.device_rr_gsb().get_num_gsb_unique_module(),
-    find_device_rr_gsb_num_gsb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph),
-    100. *
-      ((float)find_device_rr_gsb_num_gsb_modules(openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph) /
-         (float)openfpga_ctx.device_rr_gsb().get_num_gsb_unique_module() -
-       1.));
+    find_device_rr_gsb_num_gsb_modules(openfpga_ctx.device_rr_gsb(),
+                                       g_vpr_ctx.device().rr_graph),
+    100. * ((float)find_device_rr_gsb_num_gsb_modules(
+              openfpga_ctx.device_rr_gsb(), g_vpr_ctx.device().rr_graph) /
+              (float)openfpga_ctx.device_rr_gsb().get_num_gsb_unique_module() -
+            1.));
 }
 
 /********************************************************************

--- a/openfpga/src/fabric/build_device_module.cpp
+++ b/openfpga/src/fabric/build_device_module.cpp
@@ -111,7 +111,8 @@ int build_device_module_graph(
   /* Build tile modules if defined */
   if (tile_config.is_valid()) {
     /* Build detailed tile-level information */
-    status = build_fabric_tile(fabric_tile, tile_config, vpr_device_ctx.grid, vpr_device_ctx.rr_graph,
+    status = build_fabric_tile(fabric_tile, tile_config, vpr_device_ctx.grid,
+                               vpr_device_ctx.rr_graph,
                                openfpga_ctx.device_rr_gsb(), verbose);
     if (CMD_EXEC_FATAL_ERROR == status) {
       return status;

--- a/openfpga/src/fabric/build_device_module.cpp
+++ b/openfpga/src/fabric/build_device_module.cpp
@@ -111,7 +111,7 @@ int build_device_module_graph(
   /* Build tile modules if defined */
   if (tile_config.is_valid()) {
     /* Build detailed tile-level information */
-    status = build_fabric_tile(fabric_tile, tile_config, vpr_device_ctx.grid,
+    status = build_fabric_tile(fabric_tile, tile_config, vpr_device_ctx.grid, vpr_device_ctx.rr_graph,
                                openfpga_ctx.device_rr_gsb(), verbose);
     if (CMD_EXEC_FATAL_ERROR == status) {
       return status;

--- a/openfpga/src/fabric/build_fabric_tile.cpp
+++ b/openfpga/src/fabric/build_fabric_tile.cpp
@@ -30,6 +30,7 @@ namespace openfpga {
 static int build_fabric_tile_style_top_left(FabricTile& fabric_tile,
                                             const DeviceGrid& grids,
                                             const size_t& layer,
+                                            const RRGraphView& rr_graph,
                                             const DeviceRRGSB& device_rr_gsb,
                                             const bool& verbose) {
   int status_code = CMD_EXEC_SUCCESS;
@@ -48,7 +49,7 @@ static int build_fabric_tile_style_top_left(FabricTile& fabric_tile,
        */
       if (true == is_empty_type(phy_tile_type)) {
         skip_add_pb = true;
-        if (!device_rr_gsb.is_gsb_exist(curr_gsb_coord)) {
+        if (!device_rr_gsb.is_gsb_exist(rr_graph, curr_gsb_coord)) {
           VTR_LOGV(verbose, "Skip tile[%lu][%lu] as it is empty\n",
                    curr_tile_coord.x(), curr_tile_coord.y());
           continue;
@@ -114,7 +115,7 @@ static int build_fabric_tile_style_top_left(FabricTile& fabric_tile,
        *  +----------+ +----------+
        *
        */
-      if (!device_rr_gsb.is_gsb_exist(curr_gsb_coord)) {
+      if (!device_rr_gsb.is_gsb_exist(rr_graph, curr_gsb_coord)) {
         continue;
       }
       const RRGSB& curr_rr_gsb = device_rr_gsb.get_gsb(curr_gsb_coord);
@@ -124,7 +125,7 @@ static int build_fabric_tile_style_top_left(FabricTile& fabric_tile,
                                         curr_rr_gsb.get_sb_coordinate());
         }
       }
-      if (curr_rr_gsb.is_sb_exist()) {
+      if (curr_rr_gsb.is_sb_exist(rr_graph)) {
         fabric_tile.add_sb_coordinate(curr_tile_id,
                                       curr_rr_gsb.get_sb_coordinate());
       }
@@ -138,7 +139,8 @@ static int build_fabric_tile_style_top_left(FabricTile& fabric_tile,
  * Build tile-level information for a given FPGA fabric, w.r.t. to configuration
  *******************************************************************/
 int build_fabric_tile(FabricTile& fabric_tile, const TileConfig& tile_config,
-                      const DeviceGrid& grids, const DeviceRRGSB& device_rr_gsb,
+                      const DeviceGrid& grids, const RRGraphView& rr_graph,
+                      const DeviceRRGSB& device_rr_gsb,
                       const bool& verbose) {
   vtr::ScopedStartFinishTimer timer(
     "Build tile-level information for the FPGA fabric");
@@ -149,7 +151,7 @@ int build_fabric_tile(FabricTile& fabric_tile, const TileConfig& tile_config,
 
   /* Depending on the selected style, follow different approaches */
   if (tile_config.style() == TileConfig::e_style::TOP_LEFT) {
-    status_code = build_fabric_tile_style_top_left(fabric_tile, grids, 0,
+    status_code = build_fabric_tile_style_top_left(fabric_tile, grids, 0, rr_graph,
                                                    device_rr_gsb, verbose);
   } else {
     /* Error out for styles that are not supported yet! */

--- a/openfpga/src/fabric/build_fabric_tile.cpp
+++ b/openfpga/src/fabric/build_fabric_tile.cpp
@@ -140,8 +140,7 @@ static int build_fabric_tile_style_top_left(FabricTile& fabric_tile,
  *******************************************************************/
 int build_fabric_tile(FabricTile& fabric_tile, const TileConfig& tile_config,
                       const DeviceGrid& grids, const RRGraphView& rr_graph,
-                      const DeviceRRGSB& device_rr_gsb,
-                      const bool& verbose) {
+                      const DeviceRRGSB& device_rr_gsb, const bool& verbose) {
   vtr::ScopedStartFinishTimer timer(
     "Build tile-level information for the FPGA fabric");
 
@@ -151,8 +150,8 @@ int build_fabric_tile(FabricTile& fabric_tile, const TileConfig& tile_config,
 
   /* Depending on the selected style, follow different approaches */
   if (tile_config.style() == TileConfig::e_style::TOP_LEFT) {
-    status_code = build_fabric_tile_style_top_left(fabric_tile, grids, 0, rr_graph,
-                                                   device_rr_gsb, verbose);
+    status_code = build_fabric_tile_style_top_left(
+      fabric_tile, grids, 0, rr_graph, device_rr_gsb, verbose);
   } else {
     /* Error out for styles that are not supported yet! */
     VTR_LOG_ERROR("Tile style '%s' is not supported yet!\n",

--- a/openfpga/src/fabric/build_fabric_tile.h
+++ b/openfpga/src/fabric/build_fabric_tile.h
@@ -20,7 +20,7 @@
 namespace openfpga {
 
 int build_fabric_tile(FabricTile& fabric_tile, const TileConfig& tile_config,
-                      const DeviceGrid& grids, const DeviceRRGSB& device_rr_gsb,
+                      const DeviceGrid& grids, const RRGraphView& rr_graph, const DeviceRRGSB& device_rr_gsb,
                       const bool& verbose);
 
 } /* end namespace openfpga */

--- a/openfpga/src/fabric/build_fabric_tile.h
+++ b/openfpga/src/fabric/build_fabric_tile.h
@@ -20,8 +20,8 @@
 namespace openfpga {
 
 int build_fabric_tile(FabricTile& fabric_tile, const TileConfig& tile_config,
-                      const DeviceGrid& grids, const RRGraphView& rr_graph, const DeviceRRGSB& device_rr_gsb,
-                      const bool& verbose);
+                      const DeviceGrid& grids, const RRGraphView& rr_graph,
+                      const DeviceRRGSB& device_rr_gsb, const bool& verbose);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/fabric/build_routing_modules.cpp
+++ b/openfpga/src/fabric/build_routing_modules.cpp
@@ -1135,7 +1135,7 @@ void build_flatten_routing_modules(
   for (size_t ix = 0; ix < sb_range.x(); ++ix) {
     for (size_t iy = 0; iy < sb_range.y(); ++iy) {
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(ix, iy);
-      if (false == rr_gsb.is_sb_exist()) {
+      if (false == rr_gsb.is_sb_exist(device_ctx.rr_graph)) {
         continue;
       }
       build_switch_block_module(module_manager, decoder_lib, device_annotation,

--- a/openfpga/src/fabric/build_tile_modules.cpp
+++ b/openfpga/src/fabric/build_tile_modules.cpp
@@ -69,7 +69,7 @@ static int build_tile_module_port_and_nets_between_sb_and_pb(
   const bool& compact_routing_hierarchy, const bool& frame_view,
   const bool& verbose) {
   /* Skip those Switch blocks that do not exist */
-  if (false == rr_gsb.is_sb_exist()) {
+  if (false == rr_gsb.is_sb_exist(rr_graph)) {
     return CMD_EXEC_SUCCESS;
   }
 
@@ -514,7 +514,7 @@ static int build_tile_module_port_and_nets_between_sb_and_cb(
   vtr::Point<size_t> module_gsb_sb_coordinate(rr_gsb.get_x(), rr_gsb.get_y());
 
   /* Skip those Switch blocks that do not exist */
-  if (false == rr_gsb.is_sb_exist()) {
+  if (false == rr_gsb.is_sb_exist(rr_graph)) {
     return CMD_EXEC_SUCCESS;
   }
 

--- a/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
@@ -187,8 +187,8 @@ static vtr::Matrix<size_t> add_top_module_grid_instances(
  *******************************************************************/
 static vtr::Matrix<size_t> add_top_module_switch_block_instances(
   ModuleManager& module_manager, const ModuleId& top_module,
-  const RRGraphView& rr_graph,
-  const DeviceRRGSB& device_rr_gsb, const bool& compact_routing_hierarchy) {
+  const RRGraphView& rr_graph, const DeviceRRGSB& device_rr_gsb,
+  const bool& compact_routing_hierarchy) {
   vtr::ScopedStartFinishTimer timer("Add switch block instances to top module");
 
   vtr::Point<size_t> sb_range = device_rr_gsb.get_gsb_range();
@@ -455,7 +455,8 @@ int build_top_module_fine_grained_child_instances(
     add_top_module_grid_instances(module_manager, top_module, grids, layer);
   /* Add all the SBs across the fabric */
   vtr::Matrix<size_t> sb_instance_ids = add_top_module_switch_block_instances(
-    module_manager, top_module, rr_graph, device_rr_gsb, compact_routing_hierarchy);
+    module_manager, top_module, rr_graph, device_rr_gsb,
+    compact_routing_hierarchy);
   /* Add all the CBX and CBYs across the fabric */
   cb_instance_ids[CHANX] = add_top_module_connection_block_instances(
     module_manager, top_module, device_rr_gsb, CHANX,

--- a/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_fine_grained_instance.cpp
@@ -187,6 +187,7 @@ static vtr::Matrix<size_t> add_top_module_grid_instances(
  *******************************************************************/
 static vtr::Matrix<size_t> add_top_module_switch_block_instances(
   ModuleManager& module_manager, const ModuleId& top_module,
+  const RRGraphView& rr_graph,
   const DeviceRRGSB& device_rr_gsb, const bool& compact_routing_hierarchy) {
   vtr::ScopedStartFinishTimer timer("Add switch block instances to top module");
 
@@ -202,7 +203,7 @@ static vtr::Matrix<size_t> add_top_module_switch_block_instances(
        * module of SB */
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(ix, iy);
 
-      if (false == rr_gsb.is_sb_exist()) {
+      if (false == rr_gsb.is_sb_exist(rr_graph)) {
         continue;
       }
 
@@ -454,7 +455,7 @@ int build_top_module_fine_grained_child_instances(
     add_top_module_grid_instances(module_manager, top_module, grids, layer);
   /* Add all the SBs across the fabric */
   vtr::Matrix<size_t> sb_instance_ids = add_top_module_switch_block_instances(
-    module_manager, top_module, device_rr_gsb, compact_routing_hierarchy);
+    module_manager, top_module, rr_graph, device_rr_gsb, compact_routing_hierarchy);
   /* Add all the CBX and CBYs across the fabric */
   cb_instance_ids[CHANX] = add_top_module_connection_block_instances(
     module_manager, top_module, device_rr_gsb, CHANX,
@@ -508,7 +509,7 @@ int build_top_module_fine_grained_child_instances(
   if (true == fabric_key.empty()) {
     organize_top_module_memory_modules(
       module_manager, top_module, circuit_lib, config_protocol, sram_model,
-      grids, layer, grid_instance_ids, device_rr_gsb, sb_instance_ids,
+      grids, layer, grid_instance_ids, device_rr_gsb, rr_graph, sb_instance_ids,
       cb_instance_ids, compact_routing_hierarchy);
   } else {
     VTR_ASSERT_SAFE(false == fabric_key.empty());

--- a/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
@@ -292,7 +292,7 @@ static int build_top_module_tile_nets_between_sb_and_pb(
   const size_t& sb_idx_in_curr_fabric_tile,
   const bool& compact_routing_hierarchy, const bool& verbose) {
   /* Skip those Switch blocks that do not exist */
-  if (false == rr_gsb.is_sb_exist()) {
+  if (false == rr_gsb.is_sb_exist(rr_graph)) {
     return CMD_EXEC_SUCCESS;
   }
 
@@ -736,7 +736,7 @@ static int build_top_module_tile_nets_between_sb_and_cb(
     generate_switch_block_module_name(sb_coord_in_unique_tile);
 
   /* Skip those Switch blocks that do not exist */
-  if (false == rr_gsb.is_sb_exist()) {
+  if (false == rr_gsb.is_sb_exist(rr_graph)) {
     return CMD_EXEC_SUCCESS;
   }
 

--- a/openfpga/src/fabric/build_top_module_connection.cpp
+++ b/openfpga/src/fabric/build_top_module_connection.cpp
@@ -69,7 +69,7 @@ static void add_top_module_nets_connect_grids_and_sb(
   const RRGSB& rr_gsb, const vtr::Matrix<size_t>& sb_instance_ids,
   const bool& compact_routing_hierarchy) {
   /* Skip those Switch blocks that do not exist */
-  if (false == rr_gsb.is_sb_exist()) {
+  if (false == rr_gsb.is_sb_exist(rr_graph)) {
     return;
   }
 
@@ -232,7 +232,7 @@ static void add_top_module_nets_connect_grids_and_sb_with_duplicated_pins(
   const RRGSB& rr_gsb, const vtr::Matrix<size_t>& sb_instance_ids,
   const bool& compact_routing_hierarchy) {
   /* Skip those Switch blocks that do not exist */
-  if (false == rr_gsb.is_sb_exist()) {
+  if (false == rr_gsb.is_sb_exist(rr_graph)) {
     return;
   }
 
@@ -617,7 +617,7 @@ static void add_top_module_nets_connect_sb_and_cb(
   vtr::Point<size_t> module_gsb_sb_coordinate(rr_gsb.get_x(), rr_gsb.get_y());
 
   /* Skip those Switch blocks that do not exist */
-  if (false == rr_gsb.is_sb_exist()) {
+  if (false == rr_gsb.is_sb_exist(rr_graph)) {
     return;
   }
 

--- a/openfpga/src/fabric/build_top_module_memory.cpp
+++ b/openfpga/src/fabric/build_top_module_memory.cpp
@@ -134,7 +134,8 @@ static void organize_top_module_tile_memory_modules(
   const e_config_protocol_type& sram_orgz_type,
   const CircuitModelId& sram_model, const DeviceGrid& grids,
   const vtr::Matrix<size_t>& grid_instance_ids,
-  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph, const vtr::Matrix<size_t>& sb_instance_ids,
+  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph,
+  const vtr::Matrix<size_t>& sb_instance_ids,
   const std::map<t_rr_type, vtr::Matrix<size_t>>& cb_instance_ids,
   const bool& compact_routing_hierarchy, const size_t& layer,
   const vtr::Point<size_t>& tile_coord, const e_side& tile_border_side) {
@@ -438,7 +439,8 @@ void organize_top_module_memory_modules(
   const CircuitLibrary& circuit_lib, const ConfigProtocol& config_protocol,
   const CircuitModelId& sram_model, const DeviceGrid& grids,
   const size_t& layer, const vtr::Matrix<size_t>& grid_instance_ids,
-  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph, const vtr::Matrix<size_t>& sb_instance_ids,
+  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph,
+  const vtr::Matrix<size_t>& sb_instance_ids,
   const std::map<t_rr_type, vtr::Matrix<size_t>>& cb_instance_ids,
   const bool& compact_routing_hierarchy) {
   /* Ensure clean vectors to return */
@@ -496,8 +498,9 @@ void organize_top_module_memory_modules(
       /* Identify the GSB that surrounds the grid */
       organize_top_module_tile_memory_modules(
         module_manager, top_module, circuit_lib, config_protocol.type(),
-        sram_model, grids, grid_instance_ids, device_rr_gsb, rr_graph, sb_instance_ids,
-        cb_instance_ids, compact_routing_hierarchy, layer, io_coord, io_side);
+        sram_model, grids, grid_instance_ids, device_rr_gsb, rr_graph,
+        sb_instance_ids, cb_instance_ids, compact_routing_hierarchy, layer,
+        io_coord, io_side);
     }
   }
 
@@ -524,8 +527,9 @@ void organize_top_module_memory_modules(
   for (const vtr::Point<size_t>& core_coord : core_coords) {
     organize_top_module_tile_memory_modules(
       module_manager, top_module, circuit_lib, config_protocol.type(),
-      sram_model, grids, grid_instance_ids, device_rr_gsb, rr_graph, sb_instance_ids,
-      cb_instance_ids, compact_routing_hierarchy, layer, core_coord, NUM_SIDES);
+      sram_model, grids, grid_instance_ids, device_rr_gsb, rr_graph,
+      sb_instance_ids, cb_instance_ids, compact_routing_hierarchy, layer,
+      core_coord, NUM_SIDES);
   }
 
   /* Split memory modules into different regions */

--- a/openfpga/src/fabric/build_top_module_memory.cpp
+++ b/openfpga/src/fabric/build_top_module_memory.cpp
@@ -134,7 +134,7 @@ static void organize_top_module_tile_memory_modules(
   const e_config_protocol_type& sram_orgz_type,
   const CircuitModelId& sram_model, const DeviceGrid& grids,
   const vtr::Matrix<size_t>& grid_instance_ids,
-  const DeviceRRGSB& device_rr_gsb, const vtr::Matrix<size_t>& sb_instance_ids,
+  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph, const vtr::Matrix<size_t>& sb_instance_ids,
   const std::map<t_rr_type, vtr::Matrix<size_t>>& cb_instance_ids,
   const bool& compact_routing_hierarchy, const size_t& layer,
   const vtr::Point<size_t>& tile_coord, const e_side& tile_border_side) {
@@ -165,7 +165,7 @@ static void organize_top_module_tile_memory_modules(
      * we will update the memory module and instance list
      */
     /* If the CB does not exist, we can skip addition */
-    if (true == rr_gsb.is_sb_exist()) {
+    if (true == rr_gsb.is_sb_exist(rr_graph)) {
       if (0 < find_module_num_config_bits(module_manager, sb_module,
                                           circuit_lib, sram_model,
                                           sram_orgz_type)) {
@@ -438,7 +438,7 @@ void organize_top_module_memory_modules(
   const CircuitLibrary& circuit_lib, const ConfigProtocol& config_protocol,
   const CircuitModelId& sram_model, const DeviceGrid& grids,
   const size_t& layer, const vtr::Matrix<size_t>& grid_instance_ids,
-  const DeviceRRGSB& device_rr_gsb, const vtr::Matrix<size_t>& sb_instance_ids,
+  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph, const vtr::Matrix<size_t>& sb_instance_ids,
   const std::map<t_rr_type, vtr::Matrix<size_t>>& cb_instance_ids,
   const bool& compact_routing_hierarchy) {
   /* Ensure clean vectors to return */
@@ -496,7 +496,7 @@ void organize_top_module_memory_modules(
       /* Identify the GSB that surrounds the grid */
       organize_top_module_tile_memory_modules(
         module_manager, top_module, circuit_lib, config_protocol.type(),
-        sram_model, grids, grid_instance_ids, device_rr_gsb, sb_instance_ids,
+        sram_model, grids, grid_instance_ids, device_rr_gsb, rr_graph, sb_instance_ids,
         cb_instance_ids, compact_routing_hierarchy, layer, io_coord, io_side);
     }
   }
@@ -524,7 +524,7 @@ void organize_top_module_memory_modules(
   for (const vtr::Point<size_t>& core_coord : core_coords) {
     organize_top_module_tile_memory_modules(
       module_manager, top_module, circuit_lib, config_protocol.type(),
-      sram_model, grids, grid_instance_ids, device_rr_gsb, sb_instance_ids,
+      sram_model, grids, grid_instance_ids, device_rr_gsb, rr_graph, sb_instance_ids,
       cb_instance_ids, compact_routing_hierarchy, layer, core_coord, NUM_SIDES);
   }
 

--- a/openfpga/src/fabric/build_top_module_memory.h
+++ b/openfpga/src/fabric/build_top_module_memory.h
@@ -14,6 +14,7 @@
 #include "config_protocol.h"
 #include "decoder_library.h"
 #include "device_grid.h"
+#include "rr_graph_view.h"
 #include "device_rr_gsb.h"
 #include "fabric_key.h"
 #include "memory_bank_shift_register_banks.h"
@@ -33,7 +34,7 @@ void organize_top_module_memory_modules(
   const CircuitLibrary& circuit_lib, const ConfigProtocol& config_protocol,
   const CircuitModelId& sram_model, const DeviceGrid& grids,
   const size_t& layer, const vtr::Matrix<size_t>& grid_instance_ids,
-  const DeviceRRGSB& device_rr_gsb, const vtr::Matrix<size_t>& sb_instance_ids,
+  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph, const vtr::Matrix<size_t>& sb_instance_ids,
   const std::map<t_rr_type, vtr::Matrix<size_t>>& cb_instance_ids,
   const bool& compact_routing_hierarchy);
 

--- a/openfpga/src/fabric/build_top_module_memory.h
+++ b/openfpga/src/fabric/build_top_module_memory.h
@@ -14,11 +14,11 @@
 #include "config_protocol.h"
 #include "decoder_library.h"
 #include "device_grid.h"
-#include "rr_graph_view.h"
 #include "device_rr_gsb.h"
 #include "fabric_key.h"
 #include "memory_bank_shift_register_banks.h"
 #include "module_manager.h"
+#include "rr_graph_view.h"
 #include "vtr_ndmatrix.h"
 #include "vtr_vector.h"
 
@@ -34,7 +34,8 @@ void organize_top_module_memory_modules(
   const CircuitLibrary& circuit_lib, const ConfigProtocol& config_protocol,
   const CircuitModelId& sram_model, const DeviceGrid& grids,
   const size_t& layer, const vtr::Matrix<size_t>& grid_instance_ids,
-  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph, const vtr::Matrix<size_t>& sb_instance_ids,
+  const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph,
+  const vtr::Matrix<size_t>& sb_instance_ids,
   const std::map<t_rr_type, vtr::Matrix<size_t>>& cb_instance_ids,
   const bool& compact_routing_hierarchy);
 

--- a/openfpga/src/fpga_bitstream/build_routing_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_routing_bitstream.cpp
@@ -616,7 +616,7 @@ void build_routing_bitstream(
        * Some of them do NOT exist due to heterogeneous blocks (width > 1)
        * We will skip those modules
        */
-      if (false == rr_gsb.is_sb_exist()) {
+      if (false == rr_gsb.is_sb_exist(rr_graph)) {
         continue;
       }
 

--- a/openfpga/src/fpga_sdc/analysis_sdc_routing_writer.cpp
+++ b/openfpga/src/fpga_sdc/analysis_sdc_routing_writer.cpp
@@ -579,7 +579,7 @@ void print_analysis_sdc_disable_unused_sbs(
        * We will skip those modules
        */
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(ix, iy);
-      if (false == rr_gsb.is_sb_exist()) {
+      if (false == rr_gsb.is_sb_exist(rr_graph)) {
         continue;
       }
 

--- a/openfpga/src/fpga_sdc/pnr_sdc_routing_writer.cpp
+++ b/openfpga/src/fpga_sdc/pnr_sdc_routing_writer.cpp
@@ -211,7 +211,7 @@ void print_pnr_sdc_flatten_routing_constrain_sb_timing(
   for (size_t ix = 0; ix < sb_range.x(); ++ix) {
     for (size_t iy = 0; iy < sb_range.y(); ++iy) {
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(ix, iy);
-      if (false == rr_gsb.is_sb_exist()) {
+      if (false == rr_gsb.is_sb_exist(rr_graph)) {
         continue;
       }
 
@@ -248,7 +248,7 @@ void print_pnr_sdc_compact_routing_constrain_sb_timing(
 
   for (size_t isb = 0; isb < device_rr_gsb.get_num_sb_unique_module(); ++isb) {
     const RRGSB& rr_gsb = device_rr_gsb.get_sb_unique_module(isb);
-    if (false == rr_gsb.is_sb_exist()) {
+    if (false == rr_gsb.is_sb_exist(rr_graph)) {
       continue;
     }
 

--- a/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
+++ b/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
@@ -87,7 +87,8 @@ static void print_pnr_sdc_constrain_configurable_memory_outputs(
 static void print_pnr_sdc_flatten_routing_disable_switch_block_outputs(
   const std::string& sdc_dir, const bool& flatten_names,
   const bool& include_time_stamp, const ModuleManager& module_manager,
-  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
+  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb,
+  const RRGraphView& rr_graph) {
   /* Create the file name for Verilog netlist */
   std::string sdc_fname(sdc_dir +
                         std::string(SDC_DISABLE_SB_OUTPUTS_FILE_NAME));
@@ -212,7 +213,8 @@ static void print_pnr_sdc_flatten_routing_disable_switch_block_outputs(
 static void print_pnr_sdc_compact_routing_disable_switch_block_outputs(
   const std::string& sdc_dir, const bool& flatten_names,
   const bool& include_time_stamp, const ModuleManager& module_manager,
-  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
+  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb,
+  const RRGraphView& rr_graph) {
   /* Create the file name for Verilog netlist */
   std::string sdc_fname(sdc_dir +
                         std::string(SDC_DISABLE_SB_OUTPUTS_FILE_NAME));
@@ -391,12 +393,14 @@ int print_pnr_sdc(
     if (true == compact_routing_hierarchy) {
       print_pnr_sdc_compact_routing_disable_switch_block_outputs(
         sdc_options.sdc_dir(), sdc_options.flatten_names(),
-        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb, device_ctx.rr_graph);
+        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb,
+        device_ctx.rr_graph);
     } else {
       VTR_ASSERT_SAFE(false == compact_routing_hierarchy);
       print_pnr_sdc_flatten_routing_disable_switch_block_outputs(
         sdc_options.sdc_dir(), sdc_options.flatten_names(),
-        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb, device_ctx.rr_graph);
+        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb,
+        device_ctx.rr_graph);
     }
   }
 
@@ -419,7 +423,8 @@ int print_pnr_sdc(
       (true == sdc_options.output_hierarchy()) &&
       (true == compact_routing_hierarchy)) {
     print_pnr_sdc_routing_sb_hierarchy(sdc_options.sdc_dir(), module_manager,
-                                       top_module, device_rr_gsb, device_ctx.rr_graph);
+                                       top_module, device_rr_gsb,
+                                       device_ctx.rr_graph);
   }
 
   /* Output routing constraints for Connection Blocks */

--- a/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
+++ b/openfpga/src/fpga_sdc/pnr_sdc_writer.cpp
@@ -87,7 +87,7 @@ static void print_pnr_sdc_constrain_configurable_memory_outputs(
 static void print_pnr_sdc_flatten_routing_disable_switch_block_outputs(
   const std::string& sdc_dir, const bool& flatten_names,
   const bool& include_time_stamp, const ModuleManager& module_manager,
-  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb) {
+  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
   /* Create the file name for Verilog netlist */
   std::string sdc_fname(sdc_dir +
                         std::string(SDC_DISABLE_SB_OUTPUTS_FILE_NAME));
@@ -124,7 +124,7 @@ static void print_pnr_sdc_flatten_routing_disable_switch_block_outputs(
     for (size_t iy = 0; iy < sb_range.y(); ++iy) {
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(ix, iy);
 
-      if (false == rr_gsb.is_sb_exist()) {
+      if (false == rr_gsb.is_sb_exist(rr_graph)) {
         continue;
       }
 
@@ -212,7 +212,7 @@ static void print_pnr_sdc_flatten_routing_disable_switch_block_outputs(
 static void print_pnr_sdc_compact_routing_disable_switch_block_outputs(
   const std::string& sdc_dir, const bool& flatten_names,
   const bool& include_time_stamp, const ModuleManager& module_manager,
-  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb) {
+  const ModuleId& top_module, const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
   /* Create the file name for Verilog netlist */
   std::string sdc_fname(sdc_dir +
                         std::string(SDC_DISABLE_SB_OUTPUTS_FILE_NAME));
@@ -246,7 +246,7 @@ static void print_pnr_sdc_compact_routing_disable_switch_block_outputs(
   for (size_t isb = 0; isb < device_rr_gsb.get_num_sb_unique_module(); ++isb) {
     const RRGSB& rr_gsb = device_rr_gsb.get_sb_unique_module(isb);
 
-    if (false == rr_gsb.is_sb_exist()) {
+    if (false == rr_gsb.is_sb_exist(rr_graph)) {
       continue;
     }
 
@@ -391,12 +391,12 @@ int print_pnr_sdc(
     if (true == compact_routing_hierarchy) {
       print_pnr_sdc_compact_routing_disable_switch_block_outputs(
         sdc_options.sdc_dir(), sdc_options.flatten_names(),
-        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb);
+        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb, device_ctx.rr_graph);
     } else {
       VTR_ASSERT_SAFE(false == compact_routing_hierarchy);
       print_pnr_sdc_flatten_routing_disable_switch_block_outputs(
         sdc_options.sdc_dir(), sdc_options.flatten_names(),
-        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb);
+        sdc_options.time_stamp(), module_manager, top_module, device_rr_gsb, device_ctx.rr_graph);
     }
   }
 
@@ -419,7 +419,7 @@ int print_pnr_sdc(
       (true == sdc_options.output_hierarchy()) &&
       (true == compact_routing_hierarchy)) {
     print_pnr_sdc_routing_sb_hierarchy(sdc_options.sdc_dir(), module_manager,
-                                       top_module, device_rr_gsb);
+                                       top_module, device_rr_gsb, device_ctx.rr_graph);
   }
 
   /* Output routing constraints for Connection Blocks */

--- a/openfpga/src/fpga_sdc/sdc_hierarchy_writer.cpp
+++ b/openfpga/src/fpga_sdc/sdc_hierarchy_writer.cpp
@@ -31,7 +31,8 @@ namespace openfpga {
 void print_pnr_sdc_routing_sb_hierarchy(const std::string& sdc_dir,
                                         const ModuleManager& module_manager,
                                         const ModuleId& top_module,
-                                        const DeviceRRGSB& device_rr_gsb) {
+                                        const DeviceRRGSB& device_rr_gsb,
+                                        const RRGraphView& rr_graph) {
   std::string fname(sdc_dir + std::string(SDC_SB_HIERARCHY_FILE_NAME));
 
   std::string timer_message =
@@ -59,7 +60,7 @@ void print_pnr_sdc_routing_sb_hierarchy(const std::string& sdc_dir,
 
   for (size_t isb = 0; isb < device_rr_gsb.get_num_sb_unique_module(); ++isb) {
     const RRGSB& rr_gsb = device_rr_gsb.get_sb_unique_module(isb);
-    if (false == rr_gsb.is_sb_exist()) {
+    if (false == rr_gsb.is_sb_exist(rr_graph)) {
       continue;
     }
 

--- a/openfpga/src/fpga_sdc/sdc_hierarchy_writer.h
+++ b/openfpga/src/fpga_sdc/sdc_hierarchy_writer.h
@@ -17,7 +17,8 @@ namespace openfpga {
 void print_pnr_sdc_routing_sb_hierarchy(const std::string& sdc_dir,
                                         const ModuleManager& module_manager,
                                         const ModuleId& top_module,
-                                        const DeviceRRGSB& device_rr_gsb);
+                                        const DeviceRRGSB& device_rr_gsb,
+                                        const RRGraphView& rr_graph);
 
 void print_pnr_sdc_routing_cb_hierarchy(const std::string& sdc_dir,
                                         const ModuleManager& module_manager,

--- a/openfpga/src/fpga_spice/spice_api.cpp
+++ b/openfpga/src/fpga_spice/spice_api.cpp
@@ -95,7 +95,8 @@ int fpga_fabric_spice(const ModuleManager& module_manager,
   } else {
     VTR_ASSERT(false == options.compress_routing());
     print_spice_flatten_routing_modules(netlist_manager, module_manager,
-                                        device_rr_gsb, device_ctx.rr_graph, rr_dir_path);
+                                        device_rr_gsb, device_ctx.rr_graph,
+                                        rr_dir_path);
   }
 
   /* Generate grids */

--- a/openfpga/src/fpga_spice/spice_api.cpp
+++ b/openfpga/src/fpga_spice/spice_api.cpp
@@ -95,7 +95,7 @@ int fpga_fabric_spice(const ModuleManager& module_manager,
   } else {
     VTR_ASSERT(false == options.compress_routing());
     print_spice_flatten_routing_modules(netlist_manager, module_manager,
-                                        device_rr_gsb, rr_dir_path);
+                                        device_rr_gsb, device_ctx.rr_graph, rr_dir_path);
   }
 
   /* Generate grids */

--- a/openfpga/src/fpga_spice/spice_routing.cpp
+++ b/openfpga/src/fpga_spice/spice_routing.cpp
@@ -259,6 +259,7 @@ static void print_spice_flatten_connection_block_modules(
 void print_spice_flatten_routing_modules(NetlistManager& netlist_manager,
                                          const ModuleManager& module_manager,
                                          const DeviceRRGSB& device_rr_gsb,
+                                         const RRGraphView& rr_graph,
                                          const std::string& subckt_dir) {
   /* Create a vector to contain all the Verilog netlist names that have been
    * generated in this function */
@@ -270,7 +271,7 @@ void print_spice_flatten_routing_modules(NetlistManager& netlist_manager,
   for (size_t ix = 0; ix < sb_range.x(); ++ix) {
     for (size_t iy = 0; iy < sb_range.y(); ++iy) {
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(ix, iy);
-      if (true != rr_gsb.is_sb_exist()) {
+      if (true != rr_gsb.is_sb_exist(rr_graph)) {
         continue;
       }
       print_spice_routing_switch_box_unique_module(

--- a/openfpga/src/fpga_spice/spice_routing.h
+++ b/openfpga/src/fpga_spice/spice_routing.h
@@ -9,6 +9,7 @@
 #include "module_manager.h"
 #include "mux_library.h"
 #include "netlist_manager.h"
+#include "rr_graph_view.h"
 
 /********************************************************************
  * Function declaration
@@ -20,6 +21,7 @@ namespace openfpga {
 void print_spice_flatten_routing_modules(NetlistManager& netlist_manager,
                                          const ModuleManager& module_manager,
                                          const DeviceRRGSB& device_rr_gsb,
+                                         const RRGraphView& rr_graph,
                                          const std::string& subckt_dir);
 
 void print_spice_unique_routing_modules(NetlistManager& netlist_manager,

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -117,7 +117,8 @@ int fpga_fabric_verilog(
     VTR_ASSERT(false == options.compress_routing());
     print_verilog_flatten_routing_modules(
       netlist_manager, const_cast<const ModuleManager &>(module_manager),
-      device_rr_gsb, device_ctx.rr_graph, rr_dir_path, std::string(DEFAULT_RR_DIR_NAME), options);
+      device_rr_gsb, device_ctx.rr_graph, rr_dir_path,
+      std::string(DEFAULT_RR_DIR_NAME), options);
   }
 
   /* Generate grids */

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -117,7 +117,7 @@ int fpga_fabric_verilog(
     VTR_ASSERT(false == options.compress_routing());
     print_verilog_flatten_routing_modules(
       netlist_manager, const_cast<const ModuleManager &>(module_manager),
-      device_rr_gsb, rr_dir_path, std::string(DEFAULT_RR_DIR_NAME), options);
+      device_rr_gsb, device_ctx.rr_graph, rr_dir_path, std::string(DEFAULT_RR_DIR_NAME), options);
   }
 
   /* Generate grids */

--- a/openfpga/src/fpga_verilog/verilog_routing.cpp
+++ b/openfpga/src/fpga_verilog/verilog_routing.cpp
@@ -280,6 +280,7 @@ static void print_verilog_flatten_connection_block_modules(
 void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
                                            const ModuleManager& module_manager,
                                            const DeviceRRGSB& device_rr_gsb,
+                                           const RRGraphView& rr_graph,
                                            const std::string& subckt_dir,
                                            const std::string& subckt_dir_name,
                                            const FabricVerilogOption& options) {
@@ -293,7 +294,7 @@ void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
   for (size_t ix = 0; ix < sb_range.x(); ++ix) {
     for (size_t iy = 0; iy < sb_range.y(); ++iy) {
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(ix, iy);
-      if (true != rr_gsb.is_sb_exist()) {
+      if (true != rr_gsb.is_sb_exist(rr_graph)) {
         continue;
       }
       print_verilog_routing_switch_box_unique_module(

--- a/openfpga/src/fpga_verilog/verilog_routing.h
+++ b/openfpga/src/fpga_verilog/verilog_routing.h
@@ -10,6 +10,7 @@
 #include "module_manager.h"
 #include "mux_library.h"
 #include "netlist_manager.h"
+#include "rr_graph_view.h"
 
 /********************************************************************
  * Function declaration
@@ -21,6 +22,7 @@ namespace openfpga {
 void print_verilog_flatten_routing_modules(NetlistManager& netlist_manager,
                                            const ModuleManager& module_manager,
                                            const DeviceRRGSB& device_rr_gsb,
+                                           const RRGraphView& rr_graph,
                                            const std::string& subckt_dir,
                                            const std::string& subckt_dir_name,
                                            const FabricVerilogOption& options);

--- a/openfpga/src/utils/device_rr_gsb_utils.cpp
+++ b/openfpga/src/utils/device_rr_gsb_utils.cpp
@@ -34,7 +34,8 @@ size_t find_device_rr_gsb_num_cb_modules(const DeviceRRGSB& device_rr_gsb,
  * This function aims to find out the number of switch block
  * modules in the device rr_gsb array
  *******************************************************************/
-size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
+size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb,
+                                         const RRGraphView& rr_graph) {
   size_t counter = 0;
   for (size_t x = 0; x < device_rr_gsb.get_gsb_range().x(); ++x) {
     for (size_t y = 0; y < device_rr_gsb.get_gsb_range().y(); ++y) {
@@ -51,11 +52,13 @@ size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb, const
 /********************************************************************
  * This function aims to find out the number of GSBs
  *******************************************************************/
-size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
+size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb,
+                                          const RRGraphView& rr_graph) {
   size_t counter = 0;
   for (size_t x = 0; x < device_rr_gsb.get_gsb_range().x(); ++x) {
     for (size_t y = 0; y < device_rr_gsb.get_gsb_range().y(); ++y) {
-      if (true == device_rr_gsb.is_gsb_exist(rr_graph, vtr::Point<size_t>(x, y))) {
+      if (true ==
+          device_rr_gsb.is_gsb_exist(rr_graph, vtr::Point<size_t>(x, y))) {
         counter++;
       }
     }

--- a/openfpga/src/utils/device_rr_gsb_utils.cpp
+++ b/openfpga/src/utils/device_rr_gsb_utils.cpp
@@ -34,12 +34,12 @@ size_t find_device_rr_gsb_num_cb_modules(const DeviceRRGSB& device_rr_gsb,
  * This function aims to find out the number of switch block
  * modules in the device rr_gsb array
  *******************************************************************/
-size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb) {
+size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
   size_t counter = 0;
   for (size_t x = 0; x < device_rr_gsb.get_gsb_range().x(); ++x) {
     for (size_t y = 0; y < device_rr_gsb.get_gsb_range().y(); ++y) {
       const RRGSB& rr_gsb = device_rr_gsb.get_gsb(x, y);
-      if (true == rr_gsb.is_sb_exist()) {
+      if (true == rr_gsb.is_sb_exist(rr_graph)) {
         counter++;
       }
     }
@@ -51,11 +51,11 @@ size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb) {
 /********************************************************************
  * This function aims to find out the number of GSBs
  *******************************************************************/
-size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb) {
+size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph) {
   size_t counter = 0;
   for (size_t x = 0; x < device_rr_gsb.get_gsb_range().x(); ++x) {
     for (size_t y = 0; y < device_rr_gsb.get_gsb_range().y(); ++y) {
-      if (true == device_rr_gsb.is_gsb_exist(vtr::Point<size_t>(x, y))) {
+      if (true == device_rr_gsb.is_gsb_exist(rr_graph, vtr::Point<size_t>(x, y))) {
         counter++;
       }
     }

--- a/openfpga/src/utils/device_rr_gsb_utils.h
+++ b/openfpga/src/utils/device_rr_gsb_utils.h
@@ -20,9 +20,11 @@ namespace openfpga {
 size_t find_device_rr_gsb_num_cb_modules(const DeviceRRGSB& device_rr_gsb,
                                          const t_rr_type& cb_type);
 
-size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph);
+size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb,
+                                         const RRGraphView& rr_graph);
 
-size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph);
+size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb,
+                                          const RRGraphView& rr_graph);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/utils/device_rr_gsb_utils.h
+++ b/openfpga/src/utils/device_rr_gsb_utils.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "device_rr_gsb.h"
+#include "rr_graph_view.h"
 
 /********************************************************************
  * Function declaration
@@ -19,9 +20,9 @@ namespace openfpga {
 size_t find_device_rr_gsb_num_cb_modules(const DeviceRRGSB& device_rr_gsb,
                                          const t_rr_type& cb_type);
 
-size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb);
+size_t find_device_rr_gsb_num_sb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph);
 
-size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb);
+size_t find_device_rr_gsb_num_gsb_modules(const DeviceRRGSB& device_rr_gsb, const RRGraphView& rr_graph);
 
 } /* end namespace openfpga */
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
- Some empty tiles are seen when the ``shrink_boundary`` option of tileable rr_graph builder is enabled. See the red circle in the following figure.

![image](https://github.com/lnis-uofu/OpenFPGA/assets/11499826/dedb9cc6-90d6-4276-a5f3-05f315d2b30b)


> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Hotfix to remove these empty tiles
- [x] Remove a meanless error when building tile modules 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [x] FPGA-SDC
> - [x] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
