### PR TITLE
Now default_nettype is switched to ``wire`` by the end of each module that is generated by OpenFPGA

### DIFF
--- a/.github/workflows/install_dependencies_build.sh
+++ b/.github/workflows/install_dependencies_build.sh
@@ -62,4 +62,5 @@ apt-get install -y \
     clang-8 \
     clang-10 \
     clang-format-10 \
-    libxml2-utils
+    libxml2-utils \
+    libssl-dev

--- a/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
@@ -480,7 +480,7 @@ void print_verilog_module_end(std::fstream& fp,
   fp << std::endl;
 
   /* Reset default net type to be none */
-  print_verilog_default_net_type_declaration(fp, VERILOG_DEFAULT_NET_TYPE_NONE);
+  print_verilog_default_net_type_declaration(fp, VERILOG_DEFAULT_NET_TYPE_WIRE);
 }
 
 /************************************************

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/and2_formal_random_top_tb.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/and2_formal_random_top_tb.v
@@ -122,5 +122,5 @@ endmodule
 // ----- END Verilog module for and2_top_formal_verification_random_tb -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/and2_top_formal_verification.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/and2_top_formal_verification.v
@@ -498,5 +498,5 @@ endmodule
 // ----- END Verilog module for and2_top_formal_verification -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/fpga_top.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/fpga_top.v
@@ -456,7 +456,7 @@ endmodule
 // ----- END Verilog module for fpga_top -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_clb.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_clb.v
@@ -105,7 +105,7 @@ endmodule
 // ----- END Verilog module for grid_clb -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_bottom.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_bottom.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_bottom -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_left.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_left.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_left -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_right.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_right.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_right -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_top.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/grid_io_top.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_top -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_clb_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_clb_.v
@@ -420,7 +420,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_clb_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle.v
@@ -102,7 +102,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4.v
@@ -124,7 +124,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__ff.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__ff.v
@@ -58,7 +58,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__ff -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__lut4.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__lut4.v
@@ -62,7 +62,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__lut4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_io_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_io_.v
@@ -69,7 +69,7 @@ endmodule
 // ----- END Verilog module for logical_tile_io_mode_io_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_physical__iopad.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_physical__iopad.v
@@ -65,7 +65,7 @@ endmodule
 // ----- END Verilog module for logical_tile_io_mode_physical__iopad -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cbx_1__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cbx_1__0_.v
@@ -363,7 +363,7 @@ endmodule
 // ----- END Verilog module for cbx_1__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cbx_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cbx_1__1_.v
@@ -363,7 +363,7 @@ endmodule
 // ----- END Verilog module for cbx_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cby_0__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cby_0__1_.v
@@ -344,7 +344,7 @@ endmodule
 // ----- END Verilog module for cby_0__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cby_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/cby_1__1_.v
@@ -363,7 +363,7 @@ endmodule
 // ----- END Verilog module for cby_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_0__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_0__0_.v
@@ -520,7 +520,7 @@ endmodule
 // ----- END Verilog module for sb_0__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_0__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_0__1_.v
@@ -520,7 +520,7 @@ endmodule
 // ----- END Verilog module for sb_0__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_1__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_1__0_.v
@@ -520,7 +520,7 @@ endmodule
 // ----- END Verilog module for sb_1__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/routing/sb_1__1_.v
@@ -520,7 +520,7 @@ endmodule
 // ----- END Verilog module for sb_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/inv_buf_passgate.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/inv_buf_passgate.v
@@ -27,7 +27,7 @@ endmodule
 // ----- END Verilog module for const0 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -49,7 +49,7 @@ endmodule
 // ----- END Verilog module for const1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -83,7 +83,7 @@ endmodule
 // ----- END Verilog module for INVTX1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -117,7 +117,7 @@ endmodule
 // ----- END Verilog module for buf4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -151,7 +151,7 @@ endmodule
 // ----- END Verilog module for tap_buf4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -192,5 +192,5 @@ endmodule
 // ----- END Verilog module for TGATE -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/luts.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/luts.v
@@ -90,7 +90,7 @@ endmodule
 // ----- END Verilog module for lut4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/memories.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/memories.v
@@ -64,7 +64,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size6_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -126,7 +126,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size4_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -182,7 +182,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size3_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -238,7 +238,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size2_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -306,7 +306,7 @@ endmodule
 // ----- END Verilog module for mux_tree_size14_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -446,7 +446,7 @@ endmodule
 // ----- END Verilog module for lut4_DFF_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -496,7 +496,7 @@ endmodule
 // ----- END Verilog module for GPIO_DFF_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/mux_primitives.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/mux_primitives.v
@@ -54,7 +54,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -106,7 +106,7 @@ endmodule
 // ----- END Verilog module for mux_tree_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -158,7 +158,7 @@ endmodule
 // ----- END Verilog module for lut4_mux_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/muxes.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/muxes.v
@@ -122,7 +122,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size6 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -218,7 +218,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -302,7 +302,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size3 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -374,7 +374,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size2 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -590,7 +590,7 @@ endmodule
 // ----- END Verilog module for mux_tree_size14 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -819,7 +819,7 @@ endmodule
 // ----- END Verilog module for lut4_mux -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/user_defined_templates.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/user_defined_templates.v
@@ -43,7 +43,7 @@ endmodule
 // ----- END Verilog module for DFFSRQ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- Template Verilog module for DFF -----
@@ -79,7 +79,7 @@ endmodule
 // ----- END Verilog module for DFF -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- Template Verilog module for GPIO -----
@@ -115,6 +115,6 @@ endmodule
 // ----- END Verilog module for GPIO -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/wires.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/sub_module/wires.v
@@ -33,7 +33,7 @@ endmodule
 // ----- END Verilog module for direct_interc -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- END Verilog modules for regular wires -----

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/and2_formal_random_top_tb.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/and2_formal_random_top_tb.v
@@ -122,5 +122,5 @@ endmodule
 // ----- END Verilog module for and2_top_formal_verification_random_tb -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/and2_top_formal_verification.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/and2_top_formal_verification.v
@@ -2528,5 +2528,5 @@ endmodule
 // ----- END Verilog module for and2_top_formal_verification -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/fpga_top.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/fpga_top.v
@@ -2856,7 +2856,7 @@ endmodule
 // ----- END Verilog module for fpga_top -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_clb.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_clb.v
@@ -105,7 +105,7 @@ endmodule
 // ----- END Verilog module for grid_clb -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_bottom.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_bottom.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_bottom -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_left.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_left.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_left -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_right.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_right.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_right -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_top.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/grid_io_top.v
@@ -162,7 +162,7 @@ endmodule
 // ----- END Verilog module for grid_io_top -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_clb_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_clb_.v
@@ -420,7 +420,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_clb_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle.v
@@ -102,7 +102,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4.v
@@ -124,7 +124,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__ff.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__ff.v
@@ -58,7 +58,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__ff -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__lut4.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__lut4.v
@@ -62,7 +62,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_n1_lut4__ble4_mode_default__lut4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_io_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_io_.v
@@ -69,7 +69,7 @@ endmodule
 // ----- END Verilog module for logical_tile_io_mode_io_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_physical__iopad.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_physical__iopad.v
@@ -65,7 +65,7 @@ endmodule
 // ----- END Verilog module for logical_tile_io_mode_physical__iopad -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cbx_1__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cbx_1__0_.v
@@ -339,7 +339,7 @@ endmodule
 // ----- END Verilog module for cbx_1__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cbx_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cbx_1__1_.v
@@ -244,7 +244,7 @@ endmodule
 // ----- END Verilog module for cbx_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cbx_1__4_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cbx_1__4_.v
@@ -339,7 +339,7 @@ endmodule
 // ----- END Verilog module for cbx_1__4_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cby_0__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cby_0__1_.v
@@ -320,7 +320,7 @@ endmodule
 // ----- END Verilog module for cby_0__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cby_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cby_1__1_.v
@@ -225,7 +225,7 @@ endmodule
 // ----- END Verilog module for cby_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cby_4__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/cby_4__1_.v
@@ -339,7 +339,7 @@ endmodule
 // ----- END Verilog module for cby_4__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_0__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_0__0_.v
@@ -400,7 +400,7 @@ endmodule
 // ----- END Verilog module for sb_0__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_0__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_0__1_.v
@@ -400,7 +400,7 @@ endmodule
 // ----- END Verilog module for sb_0__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_0__4_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_0__4_.v
@@ -400,7 +400,7 @@ endmodule
 // ----- END Verilog module for sb_0__4_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_1__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_1__0_.v
@@ -376,7 +376,7 @@ endmodule
 // ----- END Verilog module for sb_1__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_1__1_.v
@@ -390,7 +390,7 @@ endmodule
 // ----- END Verilog module for sb_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_1__4_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_1__4_.v
@@ -428,7 +428,7 @@ endmodule
 // ----- END Verilog module for sb_1__4_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_4__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_4__0_.v
@@ -400,7 +400,7 @@ endmodule
 // ----- END Verilog module for sb_4__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_4__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_4__1_.v
@@ -428,7 +428,7 @@ endmodule
 // ----- END Verilog module for sb_4__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_4__4_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/routing/sb_4__4_.v
@@ -400,7 +400,7 @@ endmodule
 // ----- END Verilog module for sb_4__4_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/inv_buf_passgate.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/inv_buf_passgate.v
@@ -27,7 +27,7 @@ endmodule
 // ----- END Verilog module for const0 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -49,7 +49,7 @@ endmodule
 // ----- END Verilog module for const1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -83,7 +83,7 @@ endmodule
 // ----- END Verilog module for INVTX1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -117,7 +117,7 @@ endmodule
 // ----- END Verilog module for buf4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -151,7 +151,7 @@ endmodule
 // ----- END Verilog module for tap_buf4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -192,5 +192,5 @@ endmodule
 // ----- END Verilog module for TGATE -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/luts.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/luts.v
@@ -90,7 +90,7 @@ endmodule
 // ----- END Verilog module for lut4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/memories.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/memories.v
@@ -64,7 +64,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size4_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -120,7 +120,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size2_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -188,7 +188,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size10_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -256,7 +256,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size8_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -324,7 +324,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size9_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -392,7 +392,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size11_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -448,7 +448,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size3_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -510,7 +510,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size5_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -578,7 +578,7 @@ endmodule
 // ----- END Verilog module for mux_tree_size14_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -718,7 +718,7 @@ endmodule
 // ----- END Verilog module for lut4_DFF_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -768,7 +768,7 @@ endmodule
 // ----- END Verilog module for GPIO_DFF_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/mux_primitives.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/mux_primitives.v
@@ -54,7 +54,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -106,7 +106,7 @@ endmodule
 // ----- END Verilog module for mux_tree_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -158,7 +158,7 @@ endmodule
 // ----- END Verilog module for lut4_mux_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/muxes.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/muxes.v
@@ -98,7 +98,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -170,7 +170,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size2 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -338,7 +338,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size10 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -482,7 +482,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size8 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -638,7 +638,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size9 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -818,7 +818,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size11 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -902,7 +902,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size3 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1010,7 +1010,7 @@ endmodule
 // ----- END Verilog module for mux_tree_tapbuf_size5 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1226,7 +1226,7 @@ endmodule
 // ----- END Verilog module for mux_tree_size14 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1455,7 +1455,7 @@ endmodule
 // ----- END Verilog module for lut4_mux -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/user_defined_templates.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/user_defined_templates.v
@@ -43,7 +43,7 @@ endmodule
 // ----- END Verilog module for DFFSRQ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- Template Verilog module for DFF -----
@@ -79,7 +79,7 @@ endmodule
 // ----- END Verilog module for DFF -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- Template Verilog module for GPIO -----
@@ -115,6 +115,6 @@ endmodule
 // ----- END Verilog module for GPIO -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/wires.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/sub_module/wires.v
@@ -33,7 +33,7 @@ endmodule
 // ----- END Verilog module for direct_interc -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- END Verilog modules for regular wires -----

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/and2_formal_random_top_tb.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/and2_formal_random_top_tb.v
@@ -122,5 +122,5 @@ endmodule
 // ----- END Verilog module for and2_top_formal_verification_random_tb -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/and2_top_formal_verification.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/and2_top_formal_verification.v
@@ -1081,5 +1081,5 @@ endmodule
 // ----- END Verilog module for and2_top_formal_verification -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/fpga_top.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/fpga_top.v
@@ -1204,7 +1204,7 @@ endmodule
 // ----- END Verilog module for fpga_top -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_clb.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_clb.v
@@ -135,7 +135,7 @@ endmodule
 // ----- END Verilog module for grid_clb -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_bottom.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_bottom.v
@@ -173,7 +173,7 @@ endmodule
 // ----- END Verilog module for grid_io_bottom -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_left.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_left.v
@@ -173,7 +173,7 @@ endmodule
 // ----- END Verilog module for grid_io_left -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_right.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_right.v
@@ -173,7 +173,7 @@ endmodule
 // ----- END Verilog module for grid_io_right -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_top.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/grid_io_top.v
@@ -173,7 +173,7 @@ endmodule
 // ----- END Verilog module for grid_io_top -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_clb_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_clb_.v
@@ -503,7 +503,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_clb_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle.v
@@ -130,7 +130,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric.v
@@ -227,7 +227,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_physical__fabric -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__adder.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__adder.v
@@ -57,7 +57,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__adder -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__ff.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__ff.v
@@ -58,7 +58,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__ff -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__frac_logic.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__frac_logic.v
@@ -103,7 +103,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__frac_logic -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__frac_logic_mode_default__frac_lut4.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__frac_logic_mode_default__frac_lut4.v
@@ -75,7 +75,7 @@ endmodule
 // ----- END Verilog module for logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__frac_logic_mode_default__frac_lut4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_io_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_io_.v
@@ -73,7 +73,7 @@ endmodule
 // ----- END Verilog module for logical_tile_io_mode_io_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_physical__iopad.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/lb/logical_tile_io_mode_physical__iopad.v
@@ -69,7 +69,7 @@ endmodule
 // ----- END Verilog module for logical_tile_io_mode_physical__iopad -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cbx_1__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cbx_1__0_.v
@@ -413,7 +413,7 @@ endmodule
 // ----- END Verilog module for cbx_1__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cbx_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cbx_1__1_.v
@@ -253,7 +253,7 @@ endmodule
 // ----- END Verilog module for cbx_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cbx_1__2_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cbx_1__2_.v
@@ -293,7 +293,7 @@ endmodule
 // ----- END Verilog module for cbx_1__2_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cby_0__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cby_0__1_.v
@@ -313,7 +313,7 @@ endmodule
 // ----- END Verilog module for cby_0__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cby_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cby_1__1_.v
@@ -273,7 +273,7 @@ endmodule
 // ----- END Verilog module for cby_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cby_2__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/cby_2__1_.v
@@ -413,7 +413,7 @@ endmodule
 // ----- END Verilog module for cby_2__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_0__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_0__0_.v
@@ -427,7 +427,7 @@ endmodule
 // ----- END Verilog module for sb_0__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_0__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_0__1_.v
@@ -404,7 +404,7 @@ endmodule
 // ----- END Verilog module for sb_0__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_0__2_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_0__2_.v
@@ -389,7 +389,7 @@ endmodule
 // ----- END Verilog module for sb_0__2_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_1__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_1__0_.v
@@ -441,7 +441,7 @@ endmodule
 // ----- END Verilog module for sb_1__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_1__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_1__1_.v
@@ -429,7 +429,7 @@ endmodule
 // ----- END Verilog module for sb_1__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_1__2_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_1__2_.v
@@ -408,7 +408,7 @@ endmodule
 // ----- END Verilog module for sb_1__2_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_2__0_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_2__0_.v
@@ -465,7 +465,7 @@ endmodule
 // ----- END Verilog module for sb_2__0_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_2__1_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_2__1_.v
@@ -428,7 +428,7 @@ endmodule
 // ----- END Verilog module for sb_2__1_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_2__2_.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/routing/sb_2__2_.v
@@ -427,7 +427,7 @@ endmodule
 // ----- END Verilog module for sb_2__2_ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/inv_buf_passgate.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/inv_buf_passgate.v
@@ -27,7 +27,7 @@ endmodule
 // ----- END Verilog module for const0 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -49,7 +49,7 @@ endmodule
 // ----- END Verilog module for const1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -83,7 +83,7 @@ endmodule
 // ----- END Verilog module for INVTX1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -117,7 +117,7 @@ endmodule
 // ----- END Verilog module for buf4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -151,7 +151,7 @@ endmodule
 // ----- END Verilog module for tap_buf4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -189,7 +189,7 @@ endmodule
 // ----- END Verilog module for OR2 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 //----- Default net type -----
 `default_nettype none
@@ -230,5 +230,5 @@ endmodule
 // ----- END Verilog module for TGATE -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/luts.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/luts.v
@@ -107,7 +107,7 @@ endmodule
 // ----- END Verilog module for frac_lut4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/memories.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/memories.v
@@ -91,7 +91,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size4_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -152,7 +152,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size2_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -213,7 +213,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size3_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -316,7 +316,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size11_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -419,7 +419,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size9_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -522,7 +522,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size10_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -625,7 +625,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size13_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -714,7 +714,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size7_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -803,7 +803,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size8_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -892,7 +892,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size5_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1009,7 +1009,7 @@ endmodule
 // ----- END Verilog module for mux_2level_size20_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1084,7 +1084,7 @@ endmodule
 // ----- END Verilog module for mux_1level_tapbuf_size3_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1152,7 +1152,7 @@ endmodule
 // ----- END Verilog module for mux_1level_tapbuf_size2_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1318,7 +1318,7 @@ endmodule
 // ----- END Verilog module for frac_lut4_DFFR_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1372,7 +1372,7 @@ endmodule
 // ----- END Verilog module for GPIO_DFFR_mem -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/mux_primitives.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/mux_primitives.v
@@ -60,7 +60,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_basis_input3_mem3 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -112,7 +112,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -176,7 +176,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_basis_input4_mem4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -228,7 +228,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_basis_input2_mem2 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -298,7 +298,7 @@ endmodule
 // ----- END Verilog module for mux_2level_basis_input5_mem5 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -362,7 +362,7 @@ endmodule
 // ----- END Verilog module for mux_1level_tapbuf_basis_input4_mem4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -420,7 +420,7 @@ endmodule
 // ----- END Verilog module for mux_1level_tapbuf_basis_input3_mem3 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -472,7 +472,7 @@ endmodule
 // ----- END Verilog module for frac_lut4_mux_basis_input2_mem1 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/muxes.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/muxes.v
@@ -84,7 +84,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size4 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -156,7 +156,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size2 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -240,7 +240,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size3 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -371,7 +371,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size11 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -485,7 +485,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size9 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -611,7 +611,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size10 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -759,7 +759,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size13 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -870,7 +870,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size7 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -986,7 +986,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size8 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1080,7 +1080,7 @@ endmodule
 // ----- END Verilog module for mux_2level_tapbuf_size5 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1263,7 +1263,7 @@ endmodule
 // ----- END Verilog module for mux_2level_size20 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1333,7 +1333,7 @@ endmodule
 // ----- END Verilog module for mux_1level_tapbuf_size3 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1398,7 +1398,7 @@ endmodule
 // ----- END Verilog module for mux_1level_tapbuf_size2 -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 
@@ -1658,7 +1658,7 @@ endmodule
 // ----- END Verilog module for frac_lut4_mux -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/user_defined_templates.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/user_defined_templates.v
@@ -43,7 +43,7 @@ endmodule
 // ----- END Verilog module for DFFSRQ -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- Template Verilog module for DFFR -----
@@ -82,7 +82,7 @@ endmodule
 // ----- END Verilog module for DFFR -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- Template Verilog module for GPIO -----
@@ -118,7 +118,7 @@ endmodule
 // ----- END Verilog module for GPIO -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- Template Verilog module for ADDF -----
@@ -157,6 +157,6 @@ endmodule
 // ----- END Verilog module for ADDF -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/wires.v
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/sub_module/wires.v
@@ -33,7 +33,7 @@ endmodule
 // ----- END Verilog module for direct_interc -----
 
 //----- Default net type -----
-`default_nettype none
+`default_nettype wire
 
 
 // ----- END Verilog modules for regular wires -----


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- The syntax ``default_nettype`` is a standard of Verilog-2001. If not defined explicitly, the ``default_nettype`` is ``wire``.
- OpenFPGA has supported the syntax previously but it introduces some limitations when include third-party Verilog netlists.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
