### PR TITLE
Now use relative index to name module ports of tile modules

### DIFF
--- a/openfpga/src/fabric/build_tile_modules.cpp
+++ b/openfpga/src/fabric/build_tile_modules.cpp
@@ -203,7 +203,8 @@ static int build_tile_module_port_and_nets_between_sb_and_pb(
         std::string temp_sb_module_name = generate_switch_block_module_name(
           fabric_tile.sb_coordinates(fabric_tile_id)[isb]);
         if (name_module_using_index) {
-          temp_sb_module_name = generate_switch_block_module_name_using_index(isb);
+          temp_sb_module_name =
+            generate_switch_block_module_name_using_index(isb);
         }
         src_grid_port.set_name(generate_tile_module_port_name(
           temp_sb_module_name, sink_sb_port.get_name()));
@@ -434,8 +435,7 @@ static int build_tile_module_port_and_nets_between_cb_and_pb(
             cb_type, cb_inst_rr_gsb.get_cb_coordinate(cb_type));
         if (name_module_using_index) {
           cb_instance_name_in_tile =
-            generate_connection_block_module_name_using_index(
-              cb_type, icb);
+            generate_connection_block_module_name_using_index(cb_type, icb);
         }
         src_cb_port.set_name(generate_tile_module_port_name(
           cb_instance_name_in_tile, src_cb_port.get_name()));
@@ -700,7 +700,8 @@ static int build_tile_module_port_and_nets_between_sb_and_cb(
       std::string temp_sb_module_name = generate_switch_block_module_name(
         fabric_tile.sb_coordinates(fabric_tile_id)[isb]);
       if (name_module_using_index) {
-        temp_sb_module_name = generate_switch_block_module_name_using_index(isb);
+        temp_sb_module_name =
+          generate_switch_block_module_name_using_index(isb);
       }
       chan_input_port.set_name(generate_tile_module_port_name(
         temp_sb_module_name, chan_input_port.get_name()));
@@ -920,8 +921,7 @@ static int build_tile_module_ports_from_cb(
     cb_type, unique_rr_gsb.get_cb_coordinate(cb_type));
   if (name_module_using_index) {
     cb_instance_name_in_tile =
-      generate_connection_block_module_name_using_index(
-        cb_type, icb);
+      generate_connection_block_module_name_using_index(cb_type, icb);
   }
   vtr::Point<size_t> tile_coord =
     fabric_tile.tile_coordinate(curr_fabric_tile_id);

--- a/openfpga/src/fabric/build_tile_modules.cpp
+++ b/openfpga/src/fabric/build_tile_modules.cpp
@@ -203,9 +203,7 @@ static int build_tile_module_port_and_nets_between_sb_and_pb(
         std::string temp_sb_module_name = generate_switch_block_module_name(
           fabric_tile.sb_coordinates(fabric_tile_id)[isb]);
         if (name_module_using_index) {
-          temp_sb_module_name = generate_switch_block_module_name_using_index(
-            device_rr_gsb.get_sb_unique_module_index(
-              fabric_tile.sb_coordinates(fabric_tile_id)[isb]));
+          temp_sb_module_name = generate_switch_block_module_name_using_index(isb);
         }
         src_grid_port.set_name(generate_tile_module_port_name(
           temp_sb_module_name, sink_sb_port.get_name()));
@@ -437,8 +435,7 @@ static int build_tile_module_port_and_nets_between_cb_and_pb(
         if (name_module_using_index) {
           cb_instance_name_in_tile =
             generate_connection_block_module_name_using_index(
-              cb_type, device_rr_gsb.get_cb_unique_module_index(
-                         cb_type, cb_inst_rr_gsb.get_cb_coordinate(cb_type)));
+              cb_type, icb);
         }
         src_cb_port.set_name(generate_tile_module_port_name(
           cb_instance_name_in_tile, src_cb_port.get_name()));
@@ -703,9 +700,7 @@ static int build_tile_module_port_and_nets_between_sb_and_cb(
       std::string temp_sb_module_name = generate_switch_block_module_name(
         fabric_tile.sb_coordinates(fabric_tile_id)[isb]);
       if (name_module_using_index) {
-        temp_sb_module_name = generate_switch_block_module_name_using_index(
-          device_rr_gsb.get_sb_unique_module_index(
-            fabric_tile.sb_coordinates(fabric_tile_id)[isb]));
+        temp_sb_module_name = generate_switch_block_module_name_using_index(isb);
       }
       chan_input_port.set_name(generate_tile_module_port_name(
         temp_sb_module_name, chan_input_port.get_name()));
@@ -926,8 +921,7 @@ static int build_tile_module_ports_from_cb(
   if (name_module_using_index) {
     cb_instance_name_in_tile =
       generate_connection_block_module_name_using_index(
-        cb_type, device_rr_gsb.get_cb_unique_module_index(
-                   cb_type, unique_rr_gsb.get_cb_coordinate(cb_type)));
+        cb_type, icb);
   }
   vtr::Point<size_t> tile_coord =
     fabric_tile.tile_coordinate(curr_fabric_tile_id);

--- a/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
@@ -853,8 +853,8 @@ static int build_top_module_tile_nets_between_sb_and_cb(
         cb_type, unique_cb_rr_gsb.get_cb_coordinate(cb_type));
     if (name_module_using_index) {
       cb_instance_name_in_unique_tile =
-        generate_connection_block_module_name_using_index(
-          cb_type, cb_idx_in_cb_tile);
+        generate_connection_block_module_name_using_index(cb_type,
+                                                          cb_idx_in_cb_tile);
     }
     std::string cb_tile_module_name =
       generate_tile_module_name(cb_unique_tile_coord);

--- a/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
+++ b/openfpga/src/fabric/build_top_module_child_tile_instance.cpp
@@ -306,8 +306,7 @@ static int build_top_module_tile_nets_between_sb_and_pb(
     generate_switch_block_module_name(sink_sb_coord_in_unique_tile);
   if (name_module_using_index) {
     sink_sb_instance_name_in_unique_tile =
-      generate_switch_block_module_name_using_index(
-        device_rr_gsb.get_sb_unique_module_index(sink_sb_coord_in_unique_tile));
+      generate_switch_block_module_name_using_index(sb_idx_in_curr_fabric_tile);
   }
 
   /* We could have two different coordinators, one is the instance, the other is
@@ -547,8 +546,7 @@ static int build_top_module_tile_nets_between_cb_and_pb(
   if (name_module_using_index) {
     src_cb_instance_name_in_unique_tile =
       generate_connection_block_module_name_using_index(
-        cb_type, device_rr_gsb.get_cb_unique_module_index(
-                   cb_type, src_cb_inst_rr_gsb.get_cb_coordinate(cb_type)));
+        cb_type, cb_idx_in_curr_fabric_tile);
   }
 
   /* We could have two different coordinators, one is the instance, the other is
@@ -750,8 +748,7 @@ static int build_top_module_tile_nets_between_sb_and_cb(
     generate_switch_block_module_name(sb_coord_in_unique_tile);
   if (name_module_using_index) {
     sb_instance_name_in_unique_tile =
-      generate_switch_block_module_name_using_index(
-        device_rr_gsb.get_sb_unique_module_index(sb_coord_in_unique_tile));
+      generate_switch_block_module_name_using_index(sb_idx_in_curr_fabric_tile);
   }
 
   /* Skip those Switch blocks that do not exist */
@@ -857,8 +854,7 @@ static int build_top_module_tile_nets_between_sb_and_cb(
     if (name_module_using_index) {
       cb_instance_name_in_unique_tile =
         generate_connection_block_module_name_using_index(
-          cb_type, device_rr_gsb.get_cb_unique_module_index(
-                     cb_type, unique_cb_rr_gsb.get_cb_coordinate(cb_type)));
+          cb_type, cb_idx_in_cb_tile);
     }
     std::string cb_tile_module_name =
       generate_tile_module_name(cb_unique_tile_coord);

--- a/openfpga_flow/tasks/basic_tests/module_naming/using_index/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/module_naming/using_index/config/task.conf
@@ -21,7 +21,7 @@ openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
 openfpga_group_tile_config_option=--group_tile ${PATH:TASK_DIR}/config/tile_config.xml
 openfpga_add_fpga_core_module=
-openfpga_vpr_device=auto
+openfpga_vpr_device=4x4
 openfpga_vpr_route_chan_width=20
 openfpga_fabric_module_name_options=--name_module_using_index
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- In the tile modules, the names of ports have to be unique. However, when the option ``--name_module_using_index`` is enabled, the port name includes a prefix of unique SB/CB modules, to indicate the source of the port (in the context of subblocks inside the tile). However, this may cause naming conflicts when there are multiple same SB/CB modules in the same tile.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
 - Now we use the relative index of CB/SB in each tile. For example, sb_1__1_ is the first SB in the tile module, it is named as sb_0_, while the sb_1__2_ is the second SB in the tile module, it is names as sb_1_

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
