### PR TITLE
Fixed the bugs on module names using index

### DIFF
--- a/openfpga/src/fabric/build_grid_modules.cpp
+++ b/openfpga/src/fabric/build_grid_modules.cpp
@@ -1232,7 +1232,7 @@ static int build_physical_tile_module(
   /* TODO: Add a physical memory block */
   if (group_config_block) {
     status = add_physical_memory_module(module_manager, decoder_lib,
-                                        grid_module, circuit_lib,
+                                        grid_module, std::string(), circuit_lib,
                                         sram_orgz_type, sram_model, verbose);
     if (status != CMD_EXEC_SUCCESS) {
       return CMD_EXEC_FATAL_ERROR;

--- a/openfpga/src/fabric/build_memory_modules.cpp
+++ b/openfpga/src/fabric/build_memory_modules.cpp
@@ -1509,8 +1509,8 @@ int add_physical_memory_module(ModuleManager& module_manager,
   if (module_num_config_bits == 0) {
     return CMD_EXEC_SUCCESS;
   }
-  std::string phy_mem_module_name = generate_physical_memory_module_name(
-    std::string(), module_num_config_bits);
+  std::string phy_mem_module_name =
+    generate_physical_memory_module_name(std::string(), module_num_config_bits);
   VTR_LOGV(verbose, "Adding memory group module '%s' as a child to '%s'...\n",
            phy_mem_module_name.c_str(),
            module_manager.module_name(curr_module).c_str());

--- a/openfpga/src/fabric/build_memory_modules.cpp
+++ b/openfpga/src/fabric/build_memory_modules.cpp
@@ -1510,7 +1510,7 @@ int add_physical_memory_module(ModuleManager& module_manager,
     return CMD_EXEC_SUCCESS;
   }
   std::string phy_mem_module_name = generate_physical_memory_module_name(
-    module_manager.module_name(curr_module), module_num_config_bits);
+    std::string(), module_num_config_bits);
   VTR_LOGV(verbose, "Adding memory group module '%s' as a child to '%s'...\n",
            phy_mem_module_name.c_str(),
            module_manager.module_name(curr_module).c_str());

--- a/openfpga/src/fabric/build_memory_modules.cpp
+++ b/openfpga/src/fabric/build_memory_modules.cpp
@@ -1486,6 +1486,7 @@ int build_memory_group_module(
 int add_physical_memory_module(ModuleManager& module_manager,
                                DecoderLibrary& decoder_lib,
                                const ModuleId& curr_module,
+                               const std::string& suggested_module_name_prefix,
                                const CircuitLibrary& circuit_lib,
                                const e_config_protocol_type& sram_orgz_type,
                                const CircuitModelId& sram_model,
@@ -1509,8 +1510,12 @@ int add_physical_memory_module(ModuleManager& module_manager,
   if (module_num_config_bits == 0) {
     return CMD_EXEC_SUCCESS;
   }
+  std::string module_name_prefix = module_manager.module_name(curr_module);
+  if (!suggested_module_name_prefix.empty()) {
+    module_name_prefix = suggested_module_name_prefix;
+  }
   std::string phy_mem_module_name =
-    generate_physical_memory_module_name(std::string(), module_num_config_bits);
+    generate_physical_memory_module_name(module_name_prefix, module_num_config_bits);
   VTR_LOGV(verbose, "Adding memory group module '%s' as a child to '%s'...\n",
            phy_mem_module_name.c_str(),
            module_manager.module_name(curr_module).c_str());

--- a/openfpga/src/fabric/build_memory_modules.cpp
+++ b/openfpga/src/fabric/build_memory_modules.cpp
@@ -1514,8 +1514,8 @@ int add_physical_memory_module(ModuleManager& module_manager,
   if (!suggested_module_name_prefix.empty()) {
     module_name_prefix = suggested_module_name_prefix;
   }
-  std::string phy_mem_module_name =
-    generate_physical_memory_module_name(module_name_prefix, module_num_config_bits);
+  std::string phy_mem_module_name = generate_physical_memory_module_name(
+    module_name_prefix, module_num_config_bits);
   VTR_LOGV(verbose, "Adding memory group module '%s' as a child to '%s'...\n",
            phy_mem_module_name.c_str(),
            module_manager.module_name(curr_module).c_str());

--- a/openfpga/src/fabric/build_memory_modules.h
+++ b/openfpga/src/fabric/build_memory_modules.h
@@ -41,6 +41,7 @@ int build_memory_group_module(
 int add_physical_memory_module(ModuleManager& module_manager,
                                DecoderLibrary& decoder_lib,
                                const ModuleId& curr_module,
+                               const std::string& suggested_module_name_prefix,
                                const CircuitLibrary& circuit_lib,
                                const e_config_protocol_type& sram_orgz_type,
                                const CircuitModelId& sram_model,

--- a/openfpga/src/fabric/build_routing_modules.cpp
+++ b/openfpga/src/fabric/build_routing_modules.cpp
@@ -384,8 +384,8 @@ static void build_switch_block_module(
   const VprDeviceAnnotation& device_annotation, const DeviceGrid& grids,
   const RRGraphView& rr_graph, const CircuitLibrary& circuit_lib,
   const e_config_protocol_type& sram_orgz_type,
-  const CircuitModelId& sram_model, const DeviceRRGSB& device_rr_gsb, const RRGSB& rr_gsb,
-  const bool& group_config_block, const bool& verbose) {
+  const CircuitModelId& sram_model, const DeviceRRGSB& device_rr_gsb,
+  const RRGSB& rr_gsb, const bool& group_config_block, const bool& verbose) {
   /* Create a Module of Switch Block and add to module manager */
   vtr::Point<size_t> gsb_coordinate(rr_gsb.get_sb_x(), rr_gsb.get_sb_y());
   ModuleId sb_module = module_manager.add_module(
@@ -494,11 +494,12 @@ static void build_switch_block_module(
 
   /* Build a physical memory block */
   if (group_config_block) {
-    std::string mem_module_name_prefix = 
-      generate_switch_block_module_name_using_index(device_rr_gsb.get_sb_unique_module_index(gsb_coordinate));
-    add_physical_memory_module(module_manager, decoder_lib, sb_module, mem_module_name_prefix,
-                               circuit_lib, sram_orgz_type, sram_model,
-                               verbose);
+    std::string mem_module_name_prefix =
+      generate_switch_block_module_name_using_index(
+        device_rr_gsb.get_sb_unique_module_index(gsb_coordinate));
+    add_physical_memory_module(module_manager, decoder_lib, sb_module,
+                               mem_module_name_prefix, circuit_lib,
+                               sram_orgz_type, sram_model, verbose);
   }
 
   /* Add global ports to the pb_module:
@@ -893,8 +894,8 @@ static void build_connection_block_module(
   const VprDeviceAnnotation& device_annotation, const DeviceGrid& grids,
   const RRGraphView& rr_graph, const CircuitLibrary& circuit_lib,
   const e_config_protocol_type& sram_orgz_type,
-  const CircuitModelId& sram_model, const DeviceRRGSB& device_rr_gsb, const RRGSB& rr_gsb,
-  const t_rr_type& cb_type, const bool& group_config_block,
+  const CircuitModelId& sram_model, const DeviceRRGSB& device_rr_gsb,
+  const RRGSB& rr_gsb, const t_rr_type& cb_type, const bool& group_config_block,
   const bool& verbose) {
   /* Create the netlist */
   vtr::Point<size_t> gsb_coordinate(rr_gsb.get_cb_x(cb_type),
@@ -1024,11 +1025,13 @@ static void build_connection_block_module(
 
   /* Build a physical memory block */
   if (group_config_block) {
-    std::string mem_module_name_prefix = 
-      generate_connection_block_module_name_using_index(cb_type, device_rr_gsb.get_cb_unique_module_index(cb_type, gsb_coordinate));
-    add_physical_memory_module(module_manager, decoder_lib, cb_module, mem_module_name_prefix,
-                               circuit_lib, sram_orgz_type, sram_model,
-                               verbose);
+    std::string mem_module_name_prefix =
+      generate_connection_block_module_name_using_index(
+        cb_type,
+        device_rr_gsb.get_cb_unique_module_index(cb_type, gsb_coordinate));
+    add_physical_memory_module(module_manager, decoder_lib, cb_module,
+                               mem_module_name_prefix, circuit_lib,
+                               sram_orgz_type, sram_model, verbose);
   }
 
   /* Add global ports to the pb_module:
@@ -1109,8 +1112,8 @@ static void build_flatten_connection_block_modules(
       }
       build_connection_block_module(
         module_manager, decoder_lib, device_annotation, device_ctx.grid,
-        device_ctx.rr_graph, circuit_lib, sram_orgz_type, sram_model, device_rr_gsb, rr_gsb,
-        cb_type, group_config_block, verbose);
+        device_ctx.rr_graph, circuit_lib, sram_orgz_type, sram_model,
+        device_rr_gsb, rr_gsb, cb_type, group_config_block, verbose);
     }
   }
 }
@@ -1142,10 +1145,10 @@ void build_flatten_routing_modules(
       if (false == rr_gsb.is_sb_exist(device_ctx.rr_graph)) {
         continue;
       }
-      build_switch_block_module(module_manager, decoder_lib, device_annotation,
-                                device_ctx.grid, device_ctx.rr_graph,
-                                circuit_lib, sram_orgz_type, sram_model, device_rr_gsb, rr_gsb,
-                                group_config_block, verbose);
+      build_switch_block_module(
+        module_manager, decoder_lib, device_annotation, device_ctx.grid,
+        device_ctx.rr_graph, circuit_lib, sram_orgz_type, sram_model,
+        device_rr_gsb, rr_gsb, group_config_block, verbose);
     }
   }
 
@@ -1185,8 +1188,8 @@ void build_unique_routing_modules(
     const RRGSB& unique_mirror = device_rr_gsb.get_sb_unique_module(isb);
     build_switch_block_module(module_manager, decoder_lib, device_annotation,
                               device_ctx.grid, device_ctx.rr_graph, circuit_lib,
-                              sram_orgz_type, sram_model, device_rr_gsb, unique_mirror,
-                              group_config_block, verbose);
+                              sram_orgz_type, sram_model, device_rr_gsb,
+                              unique_mirror, group_config_block, verbose);
   }
 
   /* Build unique X-direction connection block modules */

--- a/openfpga/src/fabric/build_routing_modules.cpp
+++ b/openfpga/src/fabric/build_routing_modules.cpp
@@ -384,7 +384,7 @@ static void build_switch_block_module(
   const VprDeviceAnnotation& device_annotation, const DeviceGrid& grids,
   const RRGraphView& rr_graph, const CircuitLibrary& circuit_lib,
   const e_config_protocol_type& sram_orgz_type,
-  const CircuitModelId& sram_model, const RRGSB& rr_gsb,
+  const CircuitModelId& sram_model, const DeviceRRGSB& device_rr_gsb, const RRGSB& rr_gsb,
   const bool& group_config_block, const bool& verbose) {
   /* Create a Module of Switch Block and add to module manager */
   vtr::Point<size_t> gsb_coordinate(rr_gsb.get_sb_x(), rr_gsb.get_sb_y());
@@ -494,7 +494,9 @@ static void build_switch_block_module(
 
   /* Build a physical memory block */
   if (group_config_block) {
-    add_physical_memory_module(module_manager, decoder_lib, sb_module,
+    std::string mem_module_name_prefix = 
+      generate_switch_block_module_name_using_index(device_rr_gsb.get_sb_unique_module_index(gsb_coordinate));
+    add_physical_memory_module(module_manager, decoder_lib, sb_module, mem_module_name_prefix,
                                circuit_lib, sram_orgz_type, sram_model,
                                verbose);
   }
@@ -891,7 +893,7 @@ static void build_connection_block_module(
   const VprDeviceAnnotation& device_annotation, const DeviceGrid& grids,
   const RRGraphView& rr_graph, const CircuitLibrary& circuit_lib,
   const e_config_protocol_type& sram_orgz_type,
-  const CircuitModelId& sram_model, const RRGSB& rr_gsb,
+  const CircuitModelId& sram_model, const DeviceRRGSB& device_rr_gsb, const RRGSB& rr_gsb,
   const t_rr_type& cb_type, const bool& group_config_block,
   const bool& verbose) {
   /* Create the netlist */
@@ -1022,7 +1024,9 @@ static void build_connection_block_module(
 
   /* Build a physical memory block */
   if (group_config_block) {
-    add_physical_memory_module(module_manager, decoder_lib, cb_module,
+    std::string mem_module_name_prefix = 
+      generate_connection_block_module_name_using_index(cb_type, device_rr_gsb.get_cb_unique_module_index(cb_type, gsb_coordinate));
+    add_physical_memory_module(module_manager, decoder_lib, cb_module, mem_module_name_prefix,
                                circuit_lib, sram_orgz_type, sram_model,
                                verbose);
   }
@@ -1105,7 +1109,7 @@ static void build_flatten_connection_block_modules(
       }
       build_connection_block_module(
         module_manager, decoder_lib, device_annotation, device_ctx.grid,
-        device_ctx.rr_graph, circuit_lib, sram_orgz_type, sram_model, rr_gsb,
+        device_ctx.rr_graph, circuit_lib, sram_orgz_type, sram_model, device_rr_gsb, rr_gsb,
         cb_type, group_config_block, verbose);
     }
   }
@@ -1140,7 +1144,7 @@ void build_flatten_routing_modules(
       }
       build_switch_block_module(module_manager, decoder_lib, device_annotation,
                                 device_ctx.grid, device_ctx.rr_graph,
-                                circuit_lib, sram_orgz_type, sram_model, rr_gsb,
+                                circuit_lib, sram_orgz_type, sram_model, device_rr_gsb, rr_gsb,
                                 group_config_block, verbose);
     }
   }
@@ -1181,7 +1185,7 @@ void build_unique_routing_modules(
     const RRGSB& unique_mirror = device_rr_gsb.get_sb_unique_module(isb);
     build_switch_block_module(module_manager, decoder_lib, device_annotation,
                               device_ctx.grid, device_ctx.rr_graph, circuit_lib,
-                              sram_orgz_type, sram_model, unique_mirror,
+                              sram_orgz_type, sram_model, device_rr_gsb, unique_mirror,
                               group_config_block, verbose);
   }
 
@@ -1193,7 +1197,7 @@ void build_unique_routing_modules(
     build_connection_block_module(
       module_manager, decoder_lib, device_annotation, device_ctx.grid,
       device_ctx.rr_graph, circuit_lib, sram_orgz_type, sram_model,
-      unique_mirror, CHANX, group_config_block, verbose);
+      device_rr_gsb, unique_mirror, CHANX, group_config_block, verbose);
   }
 
   /* Build unique X-direction connection block modules */
@@ -1204,7 +1208,7 @@ void build_unique_routing_modules(
     build_connection_block_module(
       module_manager, decoder_lib, device_annotation, device_ctx.grid,
       device_ctx.rr_graph, circuit_lib, sram_orgz_type, sram_model,
-      unique_mirror, CHANY, group_config_block, verbose);
+      device_rr_gsb, unique_mirror, CHANY, group_config_block, verbose);
   }
 }
 

--- a/openfpga/src/fpga_verilog/verilog_routing.cpp
+++ b/openfpga/src/fpga_verilog/verilog_routing.cpp
@@ -85,9 +85,12 @@ static void print_verilog_routing_connection_box_unique_module(
                                     rr_gsb.get_cb_y(cb_type));
   std::string verilog_fname(generate_connection_block_netlist_name(
     cb_type, gsb_coordinate, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
-  std::string orig_module_name = generate_connection_block_module_name(cb_type, gsb_coordinate);
+  std::string orig_module_name =
+    generate_connection_block_module_name(cb_type, gsb_coordinate);
   if (module_name_map.name_exist(orig_module_name)) {
-    verilog_fname = generate_tile_module_netlist_name(module_name_map.name(orig_module_name), std::string(VERILOG_NETLIST_FILE_POSTFIX));
+    verilog_fname = generate_tile_module_netlist_name(
+      module_name_map.name(orig_module_name),
+      std::string(VERILOG_NETLIST_FILE_POSTFIX));
   }
 
   std::string verilog_fpath(subckt_dir + verilog_fname);
@@ -204,9 +207,12 @@ static void print_verilog_routing_switch_box_unique_module(
   std::string verilog_fname(generate_routing_block_netlist_name(
     SB_VERILOG_FILE_NAME_PREFIX, gsb_coordinate,
     std::string(VERILOG_NETLIST_FILE_POSTFIX)));
-  std::string orig_module_name = generate_switch_block_module_name(gsb_coordinate);
+  std::string orig_module_name =
+    generate_switch_block_module_name(gsb_coordinate);
   if (module_name_map.name_exist(orig_module_name)) {
-    verilog_fname = generate_tile_module_netlist_name(module_name_map.name(orig_module_name), std::string(VERILOG_NETLIST_FILE_POSTFIX));
+    verilog_fname = generate_tile_module_netlist_name(
+      module_name_map.name(orig_module_name),
+      std::string(VERILOG_NETLIST_FILE_POSTFIX));
   }
   std::string verilog_fpath(subckt_dir + verilog_fname);
 
@@ -225,8 +231,7 @@ static void print_verilog_routing_switch_box_unique_module(
 
   /* Create a Verilog Module based on the circuit model, and add to module
    * manager */
-  std::string sb_module_name =
-    module_name_map.name(orig_module_name);
+  std::string sb_module_name = module_name_map.name(orig_module_name);
   ModuleId sb_module = module_manager.find_module(sb_module_name);
   VTR_ASSERT(true == module_manager.valid_module_id(sb_module));
 

--- a/openfpga/src/fpga_verilog/verilog_routing.cpp
+++ b/openfpga/src/fpga_verilog/verilog_routing.cpp
@@ -85,6 +85,11 @@ static void print_verilog_routing_connection_box_unique_module(
                                     rr_gsb.get_cb_y(cb_type));
   std::string verilog_fname(generate_connection_block_netlist_name(
     cb_type, gsb_coordinate, std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string orig_module_name = generate_connection_block_module_name(cb_type, gsb_coordinate);
+  if (module_name_map.name_exist(orig_module_name)) {
+    verilog_fname = generate_tile_module_netlist_name(module_name_map.name(orig_module_name), std::string(VERILOG_NETLIST_FILE_POSTFIX));
+  }
+
   std::string verilog_fpath(subckt_dir + verilog_fname);
 
   /* Create the file stream */
@@ -102,8 +107,7 @@ static void print_verilog_routing_connection_box_unique_module(
 
   /* Create a Verilog Module based on the circuit model, and add to module
    * manager */
-  std::string cb_module_name = module_name_map.name(
-    generate_connection_block_module_name(cb_type, gsb_coordinate));
+  std::string cb_module_name = module_name_map.name(orig_module_name);
   ModuleId cb_module = module_manager.find_module(cb_module_name);
   VTR_ASSERT(true == module_manager.valid_module_id(cb_module));
 
@@ -200,6 +204,10 @@ static void print_verilog_routing_switch_box_unique_module(
   std::string verilog_fname(generate_routing_block_netlist_name(
     SB_VERILOG_FILE_NAME_PREFIX, gsb_coordinate,
     std::string(VERILOG_NETLIST_FILE_POSTFIX)));
+  std::string orig_module_name = generate_switch_block_module_name(gsb_coordinate);
+  if (module_name_map.name_exist(orig_module_name)) {
+    verilog_fname = generate_tile_module_netlist_name(module_name_map.name(orig_module_name), std::string(VERILOG_NETLIST_FILE_POSTFIX));
+  }
   std::string verilog_fpath(subckt_dir + verilog_fname);
 
   /* Create the file stream */
@@ -218,7 +226,7 @@ static void print_verilog_routing_switch_box_unique_module(
   /* Create a Verilog Module based on the circuit model, and add to module
    * manager */
   std::string sb_module_name =
-    module_name_map.name(generate_switch_block_module_name(gsb_coordinate));
+    module_name_map.name(orig_module_name);
   ModuleId sb_module = module_manager.find_module(sb_module_name);
   VTR_ASSERT(true == module_manager.valid_module_id(sb_module));
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #1415 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->

As stated in #1415
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Now the netlist name of routing blocks follow the indexed module names when option ``--name_use_index`` is enabled
- [x] Now the grouped configuration memory block follow the indexed module name when option ``--name_use_index`` and ``--group_config_block`` is enabled 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
