### PR TITLE
Fixed the bug where the full testbench has to load longest bitstream for each chain in CCFF v2.0 

### DIFF
--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -398,7 +398,7 @@ static void print_verilog_top_testbench_global_config_done_ports_stimuli(
                                                            module_global_port));
 
     BasicPort stimuli_config_done_port(
-      std::string(TOP_TB_CONFIG_DONE_PORT_NAME), 1);
+      std::string(TOP_TB_CONFIG_ALL_DONE_PORT_NAME), 1);
     /* Wire the port to the input stimuli:
      * The wiring will be inverted if the default value of the global port is 1
      * Otherwise, the wiring will not be inverted!

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1627,12 +1627,14 @@ static void print_verilog_full_testbench_configuration_chain_bitstream(
         config_protocol.prog_clock_pin_ccff_head_indices(
           config_protocol.prog_clock_pins()[iclk]);
       size_t curr_regional_bitstream_max_size =
-        find_fabric_regional_bitstream_max_size(fabric_bitstream, curr_clk_ctrl_regions);
+        find_fabric_regional_bitstream_max_size(fabric_bitstream,
+                                                curr_clk_ctrl_regions);
       size_t curr_num_bits_to_skip = 0;
       if (true == fast_configuration) {
-        curr_num_bits_to_skip = 
+        curr_num_bits_to_skip =
           find_configuration_chain_fabric_bitstream_size_to_be_skipped(
-            fabric_bitstream, bitstream_manager, bit_value_to_skip, curr_clk_ctrl_regions);
+            fabric_bitstream, bitstream_manager, bit_value_to_skip,
+            curr_clk_ctrl_regions);
       }
       /* TODO: Try to apply different length as the bitstream size for ccffs are
        * different driven by differnt clocks! Tried but no luck yet. */
@@ -1917,11 +1919,12 @@ static void print_verilog_full_testbench_configuration_chain_bitstream(
     VTR_ASSERT(num_prog_clocks > 1);
     for (size_t iclk = 0; iclk < num_prog_clocks; ++iclk) {
       BasicPort curr_prog_clock_port(std::string(TOP_TB_PROG_CLOCK_PORT_NAME) +
-                                  std::string(TOP_TB_CLOCK_REG_POSTFIX),
-                                iclk, iclk);
+                                       std::string(TOP_TB_CLOCK_REG_POSTFIX),
+                                     iclk, iclk);
       fp << "always";
       fp << " @(negedge "
-         << generate_verilog_port(VERILOG_PORT_CONKT, curr_prog_clock_port) << ")";
+         << generate_verilog_port(VERILOG_PORT_CONKT, curr_prog_clock_port)
+         << ")";
       fp << " begin";
       fp << std::endl;
 

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1702,7 +1702,8 @@ static void print_verilog_full_testbench_configuration_chain_bitstream(
         find_fabric_regional_bitstream_max_size(fabric_bitstream,
                                                 curr_clk_ctrl_regions);
       fp << "\t";
-      fp << TOP_TB_BITSTREAM_INDEX_REG_NAME << iclk << " <= " << regional_bitstream_max_size - curr_regional_bitstream_max_size;
+      fp << TOP_TB_BITSTREAM_INDEX_REG_NAME << iclk << " <= "
+         << regional_bitstream_max_size - curr_regional_bitstream_max_size;
       fp << ";";
       fp << std::endl;
     }

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -1623,12 +1623,23 @@ static void print_verilog_full_testbench_configuration_chain_bitstream(
   /* Additional constants for multiple programming clock */
   if (num_prog_clocks > 1) {
     for (size_t iclk = 0; iclk < num_prog_clocks; ++iclk) {
+      std::vector<size_t> curr_clk_ctrl_regions =
+        config_protocol.prog_clock_pin_ccff_head_indices(
+          config_protocol.prog_clock_pins()[iclk]);
+      size_t curr_regional_bitstream_max_size =
+        find_fabric_regional_bitstream_max_size(fabric_bitstream, curr_clk_ctrl_regions);
+      size_t curr_num_bits_to_skip = 0;
+      if (true == fast_configuration) {
+        curr_num_bits_to_skip = 
+          find_configuration_chain_fabric_bitstream_size_to_be_skipped(
+            fabric_bitstream, bitstream_manager, bit_value_to_skip, curr_clk_ctrl_regions);
+      }
       /* TODO: Try to apply different length as the bitstream size for ccffs are
        * different driven by differnt clocks! Tried but no luck yet. */
       print_verilog_define_flag(
         fp,
         std::string(TOP_TB_BITSTREAM_LENGTH_VARIABLE) + std::to_string(iclk),
-        regional_bitstream_max_size - num_bits_to_skip);
+        curr_regional_bitstream_max_size - curr_num_bits_to_skip);
     }
   }
 
@@ -1905,9 +1916,12 @@ static void print_verilog_full_testbench_configuration_chain_bitstream(
   } else {
     VTR_ASSERT(num_prog_clocks > 1);
     for (size_t iclk = 0; iclk < num_prog_clocks; ++iclk) {
+      BasicPort curr_prog_clock_port(std::string(TOP_TB_PROG_CLOCK_PORT_NAME) +
+                                  std::string(TOP_TB_CLOCK_REG_POSTFIX),
+                                iclk, iclk);
       fp << "always";
       fp << " @(negedge "
-         << generate_verilog_port(VERILOG_PORT_CONKT, prog_clock_port) << ")";
+         << generate_verilog_port(VERILOG_PORT_CONKT, curr_prog_clock_port) << ")";
       fp << " begin";
       fp << std::endl;
 

--- a/openfpga/src/utils/fabric_bitstream_utils.cpp
+++ b/openfpga/src/utils/fabric_bitstream_utils.cpp
@@ -33,7 +33,7 @@ size_t find_fabric_regional_bitstream_max_size(
   for (const auto& region : fabric_bitstream.regions()) {
     if (!region_whitelist.empty() &&
         (std::find(region_whitelist.begin(), region_whitelist.end(),
-                   size_t(region)) != region_whitelist.end())) {
+                   size_t(region)) == region_whitelist.end())) {
       continue;
     }
     if (regional_bitstream_max_size <
@@ -65,7 +65,7 @@ size_t find_configuration_chain_fabric_bitstream_size_to_be_skipped(
   for (const auto& region : fabric_bitstream.regions()) {
     if (!region_whitelist.empty() &&
         (std::find(region_whitelist.begin(), region_whitelist.end(),
-                   size_t(region)) != region_whitelist.end())) {
+                   size_t(region)) == region_whitelist.end())) {
       continue;
     }
     size_t curr_region_num_bits_to_skip = 0;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #1140 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- When there are more than 1 programming clocks, there is a bug in the full testbench, where a complete bitstream has to be loaded more than once. In other words, when each programming clock is on, full bitstream size has to be given for the configuration chains.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- The restrictions have now been removed. Only part of the bitstream can be loaded.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
