### PR TITLE
Upgrade VTR to resolve the bugs in tileable routing architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         run: ccache -s
       - name: Upload artifact
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.config.cc == 'gcc-11'}}
+        if: ${{ matrix.config.cc == 'gcc-9'}}
         with:
           name: openfpga
           path: |
@@ -438,7 +438,7 @@ jobs:
           chmod +x build/yosys/bin/yosys-config
           chmod +x build/yosys/bin/yosys-filterlib
           chmod +x build/yosys/bin/yosys-smtbmc
-      - name: ${{matrix.config.name}}_GCC-11_(Ubuntu 20.04)
+      - name: ${{matrix.config.name}}_GCC-9_(Ubuntu 20.04)
         shell: bash
         run: source openfpga.sh && source openfpga_flow/regression_test_scripts/${{matrix.config.name}}.sh --debug --show_thread_logs
       - name: Upload artifact
@@ -482,7 +482,7 @@ jobs:
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v3
 
-      - name: ${{matrix.config.name}}_GCC-11_(Ubuntu 20.04)
+      - name: ${{matrix.config.name}}_GCC-9_(Ubuntu 20.04)
         shell: bash
         run: |
           bash .github/workflows/install_dependencies_run.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "Build Compatibility: GCC-7 (Ubuntu 20.04)"
-            cc: gcc-7
-            cxx: g++-7
           - name: "Build Compatibility: GCC-8 (Ubuntu 20.04)"
             cc: gcc-8
             cxx: g++-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         run: ccache -s
       - name: Upload artifact
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.config.cc == 'gcc-8'}}
+        if: ${{ matrix.config.cc == 'gcc-11'}}
         with:
           name: openfpga
           path: |
@@ -438,7 +438,7 @@ jobs:
           chmod +x build/yosys/bin/yosys-config
           chmod +x build/yosys/bin/yosys-filterlib
           chmod +x build/yosys/bin/yosys-smtbmc
-      - name: ${{matrix.config.name}}_GCC-8_(Ubuntu 20.04)
+      - name: ${{matrix.config.name}}_GCC-11_(Ubuntu 20.04)
         shell: bash
         run: source openfpga.sh && source openfpga_flow/regression_test_scripts/${{matrix.config.name}}.sh --debug --show_thread_logs
       - name: Upload artifact
@@ -482,7 +482,7 @@ jobs:
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v3
 
-      - name: ${{matrix.config.name}}_GCC-8_(Ubuntu 20.04)
+      - name: ${{matrix.config.name}}_GCC-11_(Ubuntu 20.04)
         shell: bash
         run: |
           bash .github/workflows/install_dependencies_run.sh

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ help:
 checkout: 
 # Update all the submodules
 	git submodule init
-	git submodule update --init --depth 1
+	git submodule update --init --recursive
 
 prebuild:
 # Run cmake to generate Makefile under the build directory, before compilation

--- a/docs/source/manual/arch_lang/addon_vpr_syntax.rst
+++ b/docs/source/manual/arch_lang/addon_vpr_syntax.rst
@@ -88,11 +88,58 @@ Layout
 
   .. warning:: Do NOT enable ``shrink_boundary`` if you are not using the tileable routing resource graph generator!
 
+.. option:: opin2all_sides="<bool>"
+
+  Allow each output pin of a programmable block to drive the routing tracks on all the sides of its adjacent switch block (see an illustrative example in :numref:`fig_opin2all_sides`). This can improve the routability of an FPGA fabric with an increase in the sizes of routing multiplexers in each switch block. 
+  By default, it is ``false``.
+
+  .. _fig_opin2all_sides:
+  
+  .. figure:: ./figures/opin2all_sides.svg
+     :width: 100%
+     :alt: Impact of opin2all_sides
+  
+     Impact on routing architecture when the opin-to-all-sides: (a) disabled; (b) enabled.
+
+  .. warning:: Do NOT enable ``opin2all_sides`` if you are not using the tileable routing resource graph generator!
+
+.. option:: concat_wire="<bool>"
+
+  In each switch block, allow each routing track which ends to drive another routing track on the opposite side, as such a wire can be continued in the same direction (see an illustrative example in :numref:`fig_concat_wire`). In other words, routing wires can be concatenated in the same direction across an FPGA fabric. This can improve the routability of an FPGA fabric with an increase in the sizes of routing multiplexers in each switch block. 
+  By default, it is ``false``.
+
+  .. _fig_concat_wire:
+  
+  .. figure:: ./figures/concat_wire.svg
+     :width: 100%
+     :alt: Impact of concat_wire
+  
+     Impact on routing architecture when the wire concatenation: (a) disabled; (b) enabled.
+
+  .. warning:: Do NOT enable ``concat_wire`` if you are not using the tileable routing resource graph generator!
+
+.. option:: concat_pass_wire="<bool>"
+
+  In each switch block, allow each routing track which passes to drive another routing track on the opposite side, as such a pass wire can be continued in the same direction (see an illustrative example in :numref:`fig_concat_pass_wire`). This can improve the routability of an FPGA fabric with an increase in the sizes of routing multiplexers in each switch block. 
+  By default, it is ``false``.
+
+  .. warning:: Please enable this option if you are looking for device support which is created by any release which is before v1.1.541!!!
+
+  .. _fig_concat_wire:
+  
+  .. figure:: ./figures/concat_pass_wire.svg
+     :width: 100%
+     :alt: Impact of concat_pass_wire
+  
+     Impact on routing architecture when the pass wire concatenation: (a) disabled; (b) enabled.
+
+  .. warning:: Do NOT enable ``concat_pass_wire`` if you are not using the tileable routing resource graph generator!
+
 A quick example to show tileable routing is enabled, other options, e.g., through channels are disabled:
 
 .. code-block:: xml
 
-  <layout tileable="true" through_channel="false" shrink_boundary="false">
+  <layout tileable="true" through_channel="false" shrink_boundary="false" opin2all_sides="false" concat_wire="false" concat_pass_wire="false">
   </layout>
 
 Switch Block

--- a/docs/source/manual/arch_lang/figures/concat_pass_wire.svg
+++ b/docs/source/manual/arch_lang/figures/concat_pass_wire.svg
@@ -1,0 +1,574 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="364.54 140.62 715.76 406.36" width="715.76" height="406.36">
+  <defs>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -3 7 6" markerWidth="7" markerHeight="6" color="black">
+      <g>
+        <path d="M 4.8 0 L 0 -1.8 L 0 1.8 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="concat_pass_wire" fill="none" stroke-opacity="1" fill-opacity="1" stroke="none" stroke-dasharray="none">
+    <title>concat_pass_wire</title>
+    <g id="concat_pass_wire_base">
+      <title>base</title>
+      <g id="Group_1411">
+        <g id="Graphic_362">
+          <rect x="403.24" y="178.38365" width="249.84" height="256.4605" fill="white"/>
+          <rect x="403.24" y="178.38365" width="249.84" height="256.4605" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Group_513">
+          <g id="Graphic_363">
+            <rect x="648.04" y="198.68417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="648.04" y="198.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_368">
+            <rect x="648.04" y="344.32614" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="648.04" y="344.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_367">
+            <rect x="648.04" y="228.232" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="648.04" y="228.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_366">
+            <rect x="648.04" y="257.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="257.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_510">
+            <rect x="648.04" y="289.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="289.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_509">
+            <rect x="648.04" y="316.87548" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="648.04" y="316.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_511">
+            <rect x="648.04" y="371.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="371.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_512">
+            <rect x="648.04" y="399.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="399.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_514">
+          <g id="Graphic_526">
+            <rect x="397.04" y="199.68417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="397.04" y="199.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_523">
+            <rect x="397.04" y="345.32614" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="397.04" y="345.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_522">
+            <rect x="397.04" y="229.232" width="12.96" height="12.96" fill="#80ff80"/>
+            <rect x="397.04" y="229.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_521">
+            <rect x="397.04" y="258.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="258.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_518">
+            <rect x="397.04" y="290.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="290.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_517">
+            <rect x="397.04" y="317.87548" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="397.04" y="317.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_516">
+            <rect x="397.04" y="372.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="372.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_515">
+            <rect x="397.04" y="400.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="400.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_527">
+          <g id="Graphic_539">
+            <rect x="623.53215" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="623.53215" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_536">
+            <rect x="477.8902" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="477.8902" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_535">
+            <rect x="593.9843" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="593.9843" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_534">
+            <rect x="564.4365" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="564.4365" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_531">
+            <rect x="532.7915" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="532.7915" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_530">
+            <rect x="505.34085" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="505.34085" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_529">
+            <rect x="450.4395" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="450.4395" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_528">
+            <rect x="422.98886" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="422.98886" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_540">
+          <g id="Graphic_552">
+            <rect x="623.53215" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="623.53215" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_549">
+            <rect x="477.8902" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="477.8902" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_548">
+            <rect x="593.9843" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="593.9843" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_547">
+            <rect x="564.4365" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="564.4365" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_544">
+            <rect x="532.7915" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="532.7915" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_543">
+            <rect x="505.34085" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="505.34085" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_542">
+            <rect x="450.4395" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="450.4395" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_541">
+            <rect x="422.98886" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="422.98886" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Line_972">
+          <line x1="429.88" y1="171.32417" x2="430.2512" y2="151.86237" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_973">
+          <line x1="457.52" y1="142.80835" x2="457.52" y2="160.58" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_975">
+          <line x1="485.16" y1="170.48" x2="485.5312" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_974">
+          <line x1="512.8" y1="141.96417" x2="512.8" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_979">
+          <line x1="540.44" y1="172.16835" x2="540.8112" y2="152.70655" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_978">
+          <line x1="571.26" y1="143.65253" x2="571.26" y2="161.42417" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_977">
+          <line x1="602.08" y1="170.48" x2="602.4512" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_976">
+          <line x1="629.72" y1="141.96417" x2="629.72" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_987">
+          <line x1="429.3205" y1="473.7113" x2="429.6917" y2="454.24953" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_986">
+          <line x1="456.9605" y1="445.1955" x2="456.9605" y2="462.96715" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_985">
+          <line x1="484.6005" y1="472.86715" x2="484.9717" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_984">
+          <line x1="512.2405" y1="444.35133" x2="512.2405" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_983">
+          <line x1="539.8805" y1="474.5555" x2="540.2517" y2="455.0937" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_982">
+          <line x1="570.7005" y1="446.0397" x2="570.7005" y2="463.8113" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_981">
+          <line x1="601.5205" y1="472.86715" x2="601.8917" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_980">
+          <line x1="629.1605" y1="444.35133" x2="629.1605" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_988">
+          <line x1="366.04" y1="205.84416" x2="387.14035" y2="206.02432" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_989">
+          <line x1="397.04" y1="236.12417" x2="377.93965" y2="236.28225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_991">
+          <line x1="366.56" y1="265.72417" x2="387.14054" y2="265.94024" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_990">
+          <line x1="394.04" y1="297.32417" x2="374.93965" y2="297.48225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_995">
+          <line x1="367.56" y1="323.70746" x2="384.1407" y2="323.90783" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_994">
+          <line x1="396.04" y1="350.64746" x2="374.9397" y2="350.81083" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_993">
+          <line x1="365.56" y1="378.69075" x2="386.14054" y2="378.9068" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_992">
+          <line x1="395.04" y1="407.18746" x2="375.93965" y2="407.34554" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1378">
+          <line x1="665.5342" y1="204.64416" x2="704.1402" y2="204.89886" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1377">
+          <line x1="710.3468" y1="234.92417" x2="674.1398" y2="234.69445" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1376">
+          <line x1="666.20714" y1="264.52417" x2="701.11745" y2="264.77348" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1375">
+          <line x1="710.48684" y1="296.12417" x2="674.13986" y2="296.3128" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1374">
+          <line x1="667.5013" y1="322.50746" x2="700.5871" y2="322.75376" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1373">
+          <line x1="710.48684" y1="350.63164" x2="674.1379" y2="349.88955" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1372">
+          <line x1="665.2438" y1="377.49074" x2="704.14" y2="377.60306" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1371">
+          <line x1="708.5197" y1="405.63164" x2="674.7633" y2="405.3191" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Graphic_1396">
+          <rect x="397.04" y="419.5437" width="12.96" height="12.96" fill="yellow"/>
+          <rect x="397.04" y="419.5437" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+      </g>
+      <g id="Group_1412">
+        <g id="Graphic_1482">
+          <rect x="769" y="178.38365" width="249.84" height="256.4605" fill="white"/>
+          <rect x="769" y="178.38365" width="249.84" height="256.4605" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Group_1473">
+          <g id="Graphic_1481">
+            <rect x="1013.8" y="198.68417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="1013.8" y="198.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1480">
+            <rect x="1013.8" y="344.32614" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="1013.8" y="344.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1479">
+            <rect x="1013.8" y="228.232" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="1013.8" y="228.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1478">
+            <rect x="1013.8" y="257.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="257.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1477">
+            <rect x="1013.8" y="289.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="289.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1476">
+            <rect x="1013.8" y="316.87548" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="1013.8" y="316.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1475">
+            <rect x="1013.8" y="371.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="371.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1474">
+            <rect x="1013.8" y="399.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="399.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1464">
+          <g id="Graphic_1472">
+            <rect x="762.8" y="199.68417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="762.8" y="199.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1471">
+            <rect x="762.8" y="345.32614" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="762.8" y="345.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1470">
+            <rect x="762.8" y="229.232" width="12.96" height="12.96" fill="#80ff80"/>
+            <rect x="762.8" y="229.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1469">
+            <rect x="762.8" y="258.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="258.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1468">
+            <rect x="762.8" y="290.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="290.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1467">
+            <rect x="762.8" y="317.87548" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="762.8" y="317.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1466">
+            <rect x="762.8" y="372.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="372.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1465">
+            <rect x="762.8" y="400.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="400.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1455">
+          <g id="Graphic_1463">
+            <rect x="989.2921" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="989.2921" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1462">
+            <rect x="843.6502" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="843.6502" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1461">
+            <rect x="959.7443" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="959.7443" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1460">
+            <rect x="930.1965" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="930.1965" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1459">
+            <rect x="898.5515" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="898.5515" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1458">
+            <rect x="871.1008" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="871.1008" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1457">
+            <rect x="816.1995" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="816.1995" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1456">
+            <rect x="788.7489" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="788.7489" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1446">
+          <g id="Graphic_1454">
+            <rect x="989.2921" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="989.2921" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1453">
+            <rect x="843.6502" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="843.6502" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1452">
+            <rect x="959.7443" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="959.7443" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1451">
+            <rect x="930.1965" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="930.1965" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1450">
+            <rect x="898.5515" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="898.5515" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1449">
+            <rect x="871.1008" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="871.1008" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1448">
+            <rect x="816.1995" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="816.1995" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1447">
+            <rect x="788.7489" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="788.7489" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Line_1445">
+          <line x1="795.64" y1="171.32417" x2="796.0112" y2="151.86237" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1444">
+          <line x1="823.28" y1="142.80835" x2="823.28" y2="160.58" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1443">
+          <line x1="850.92" y1="170.48" x2="851.2912" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1442">
+          <line x1="878.56" y1="141.96417" x2="878.56" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1441">
+          <line x1="906.2" y1="172.16835" x2="906.5712" y2="152.70655" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1440">
+          <line x1="937.02" y1="143.65253" x2="937.02" y2="161.42417" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1439">
+          <line x1="967.84" y1="170.48" x2="968.2112" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1438">
+          <line x1="995.48" y1="141.96417" x2="995.48" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1437">
+          <line x1="795.0805" y1="473.7113" x2="795.4517" y2="454.24953" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1436">
+          <line x1="822.7205" y1="445.1955" x2="822.7205" y2="462.96715" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1435">
+          <line x1="850.3605" y1="472.86715" x2="850.7317" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1434">
+          <line x1="878.0005" y1="444.35133" x2="878.0005" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1433">
+          <line x1="905.6405" y1="474.5555" x2="906.0117" y2="455.0937" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1432">
+          <line x1="936.4605" y1="446.0397" x2="936.4605" y2="463.8113" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1431">
+          <line x1="967.2805" y1="472.86715" x2="967.6517" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1430">
+          <line x1="994.9205" y1="444.35133" x2="994.9205" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1429">
+          <line x1="731.8" y1="205.84416" x2="752.90035" y2="206.02432" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1428">
+          <line x1="762.8" y1="236.12417" x2="743.69964" y2="236.28225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1427">
+          <line x1="732.32" y1="265.72417" x2="752.9005" y2="265.94024" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1426">
+          <line x1="759.8" y1="297.32417" x2="740.69964" y2="297.48225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1425">
+          <line x1="733.32" y1="323.70746" x2="749.9007" y2="323.90783" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1424">
+          <line x1="761.8" y1="350.64746" x2="740.6997" y2="350.81083" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1423">
+          <line x1="731.32" y1="378.69075" x2="751.9005" y2="378.9068" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1422">
+          <line x1="760.8" y1="407.18746" x2="741.69964" y2="407.34554" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1421">
+          <line x1="1031.2942" y1="204.64416" x2="1069.9002" y2="204.89886" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1420">
+          <line x1="1076.1068" y1="234.92417" x2="1039.8998" y2="234.69445" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1419">
+          <line x1="1031.9671" y1="264.52417" x2="1066.8774" y2="264.77348" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1418">
+          <line x1="1076.2468" y1="296.12417" x2="1039.8998" y2="296.3128" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1417">
+          <line x1="1033.2613" y1="322.50746" x2="1066.3471" y2="322.75376" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1416">
+          <line x1="1076.2468" y1="350.63164" x2="1039.8979" y2="349.88955" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1415">
+          <line x1="1031.0038" y1="377.49074" x2="1069.9" y2="377.60306" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1414">
+          <line x1="1074.2797" y1="405.63164" x2="1040.5233" y2="405.3191" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Graphic_1413">
+          <rect x="762.8" y="419.5437" width="12.96" height="12.96" fill="yellow"/>
+          <rect x="762.8" y="419.5437" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+      </g>
+    </g>
+    <g id="concat_pass_wire_wires">
+      <title>wires</title>
+      <g id="Line_1501">
+        <line x1="410" y1="266" x2="562.93445" y2="420.82253" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1509">
+        <line x1="776.16" y1="266" x2="788.8524" y2="196.19192" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1508">
+        <line x1="776.16" y1="266" x2="1001.6421" y2="209.8603" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1507">
+        <line x1="776.16" y1="266" x2="929.0944" y2="420.82253" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+    </g>
+    <g id="concat_pass_wire_legend">
+      <title>legend</title>
+      <g id="Graphic_1490">
+        <text transform="translate(366.54814 145.5255)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">(a)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1499">
+        <rect x="505.44" y="488.88" width="454.32" height="57.6" fill="white"/>
+        <rect x="505.44" y="488.88" width="454.32" height="57.6" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1498">
+        <rect x="514.1" y="496.6278" width="12.96" height="12.96" fill="#40ff40"/>
+        <rect x="514.1" y="496.6278" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1497">
+        <text transform="translate(538.1717 492.45767)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">Starting routing tracks</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1496">
+        <rect x="725.2653" y="496.58" width="12.96" height="12.96" fill="#ff4040"/>
+        <rect x="725.2653" y="496.58" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1495">
+        <text transform="translate(741.1591 492.45767)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="2.25" y="16">Ending routing tracks </tspan>
+        </text>
+      </g>
+      <g id="Graphic_1494">
+        <rect x="514.1" y="522.5078" width="12.96" height="12.96" fill="#80ffff"/>
+        <rect x="514.1" y="522.5078" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1493">
+        <text transform="translate(532.7875 517.6055)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="2.25" y="16">Passing routing tracks </tspan>
+        </text>
+      </g>
+      <g id="Graphic_1492">
+        <rect x="725.2653" y="523.5078" width="12.96" height="12.96" fill="yellow"/>
+        <rect x="725.2653" y="523.5078" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1491">
+        <text transform="translate(753.9636 518.6055)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">Output pin of blocks</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1500">
+        <text transform="translate(751.7481 145.5255)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">(b)</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/source/manual/arch_lang/figures/concat_wire.svg
+++ b/docs/source/manual/arch_lang/figures/concat_wire.svg
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="364.54 140.62 715.76 406.36" width="715.76" height="406.36">
+  <defs>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -3 7 6" markerWidth="7" markerHeight="6" color="black">
+      <g>
+        <path d="M 4.8 0 L 0 -1.8 L 0 1.8 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="concat_wire" fill="none" stroke-opacity="1" fill-opacity="1" stroke="none" stroke-dasharray="none">
+    <title>concat_wire</title>
+    <g id="concat_wire_base">
+      <title>base</title>
+      <g id="Group_1411">
+        <g id="Graphic_362">
+          <rect x="403.24" y="178.38365" width="249.84" height="256.4605" fill="white"/>
+          <rect x="403.24" y="178.38365" width="249.84" height="256.4605" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Group_513">
+          <g id="Graphic_363">
+            <rect x="648.04" y="198.68417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="648.04" y="198.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_368">
+            <rect x="648.04" y="344.32614" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="648.04" y="344.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_367">
+            <rect x="648.04" y="228.232" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="648.04" y="228.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_366">
+            <rect x="648.04" y="257.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="257.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_510">
+            <rect x="648.04" y="289.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="289.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_509">
+            <rect x="648.04" y="316.87548" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="648.04" y="316.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_511">
+            <rect x="648.04" y="371.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="371.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_512">
+            <rect x="648.04" y="399.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="399.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_514">
+          <g id="Graphic_526">
+            <rect x="397.04" y="199.68417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="397.04" y="199.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_523">
+            <rect x="397.04" y="345.32614" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="397.04" y="345.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_522">
+            <rect x="397.04" y="229.232" width="12.96" height="12.96" fill="#80ff80"/>
+            <rect x="397.04" y="229.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_521">
+            <rect x="397.04" y="258.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="258.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_518">
+            <rect x="397.04" y="290.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="290.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_517">
+            <rect x="397.04" y="317.87548" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="397.04" y="317.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_516">
+            <rect x="397.04" y="372.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="372.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_515">
+            <rect x="397.04" y="400.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="400.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_527">
+          <g id="Graphic_539">
+            <rect x="623.53215" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="623.53215" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_536">
+            <rect x="477.8902" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="477.8902" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_535">
+            <rect x="593.9843" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="593.9843" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_534">
+            <rect x="564.4365" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="564.4365" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_531">
+            <rect x="532.7915" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="532.7915" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_530">
+            <rect x="505.34085" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="505.34085" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_529">
+            <rect x="450.4395" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="450.4395" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_528">
+            <rect x="422.98886" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="422.98886" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_540">
+          <g id="Graphic_552">
+            <rect x="623.53215" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="623.53215" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_549">
+            <rect x="477.8902" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="477.8902" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_548">
+            <rect x="593.9843" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="593.9843" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_547">
+            <rect x="564.4365" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="564.4365" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_544">
+            <rect x="532.7915" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="532.7915" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_543">
+            <rect x="505.34085" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="505.34085" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_542">
+            <rect x="450.4395" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="450.4395" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_541">
+            <rect x="422.98886" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="422.98886" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Line_972">
+          <line x1="429.88" y1="171.32417" x2="430.2512" y2="151.86237" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_973">
+          <line x1="457.52" y1="142.80835" x2="457.52" y2="160.58" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_975">
+          <line x1="485.16" y1="170.48" x2="485.5312" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_974">
+          <line x1="512.8" y1="141.96417" x2="512.8" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_979">
+          <line x1="540.44" y1="172.16835" x2="540.8112" y2="152.70655" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_978">
+          <line x1="571.26" y1="143.65253" x2="571.26" y2="161.42417" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_977">
+          <line x1="602.08" y1="170.48" x2="602.4512" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_976">
+          <line x1="629.72" y1="141.96417" x2="629.72" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_987">
+          <line x1="429.3205" y1="473.7113" x2="429.6917" y2="454.24953" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_986">
+          <line x1="456.9605" y1="445.1955" x2="456.9605" y2="462.96715" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_985">
+          <line x1="484.6005" y1="472.86715" x2="484.9717" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_984">
+          <line x1="512.2405" y1="444.35133" x2="512.2405" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_983">
+          <line x1="539.8805" y1="474.5555" x2="540.2517" y2="455.0937" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_982">
+          <line x1="570.7005" y1="446.0397" x2="570.7005" y2="463.8113" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_981">
+          <line x1="601.5205" y1="472.86715" x2="601.8917" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_980">
+          <line x1="629.1605" y1="444.35133" x2="629.1605" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_988">
+          <line x1="366.04" y1="205.84416" x2="387.14035" y2="206.02432" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_989">
+          <line x1="397.04" y1="236.12417" x2="377.93965" y2="236.28225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_991">
+          <line x1="366.56" y1="265.72417" x2="387.14054" y2="265.94024" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_990">
+          <line x1="394.04" y1="297.32417" x2="374.93965" y2="297.48225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_995">
+          <line x1="367.56" y1="323.70746" x2="384.1407" y2="323.90783" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_994">
+          <line x1="396.04" y1="350.64746" x2="374.9397" y2="350.81083" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_993">
+          <line x1="365.56" y1="378.69075" x2="386.14054" y2="378.9068" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_992">
+          <line x1="395.04" y1="407.18746" x2="375.93965" y2="407.34554" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1378">
+          <line x1="665.5342" y1="204.64416" x2="704.1402" y2="204.89886" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1377">
+          <line x1="710.3468" y1="234.92417" x2="674.1398" y2="234.69445" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1376">
+          <line x1="666.20714" y1="264.52417" x2="701.11745" y2="264.77348" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1375">
+          <line x1="710.48684" y1="296.12417" x2="674.13986" y2="296.3128" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1374">
+          <line x1="667.5013" y1="322.50746" x2="700.5871" y2="322.75376" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1373">
+          <line x1="710.48684" y1="350.63164" x2="674.1379" y2="349.88955" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1372">
+          <line x1="665.2438" y1="377.49074" x2="704.14" y2="377.60306" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1371">
+          <line x1="708.5197" y1="405.63164" x2="674.7633" y2="405.3191" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Graphic_1396">
+          <rect x="397.04" y="419.5437" width="12.96" height="12.96" fill="yellow"/>
+          <rect x="397.04" y="419.5437" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+      </g>
+      <g id="Group_1412">
+        <g id="Graphic_1482">
+          <rect x="769" y="178.38365" width="249.84" height="256.4605" fill="white"/>
+          <rect x="769" y="178.38365" width="249.84" height="256.4605" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Group_1473">
+          <g id="Graphic_1481">
+            <rect x="1013.8" y="198.68417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="1013.8" y="198.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1480">
+            <rect x="1013.8" y="344.32614" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="1013.8" y="344.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1479">
+            <rect x="1013.8" y="228.232" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="1013.8" y="228.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1478">
+            <rect x="1013.8" y="257.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="257.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1477">
+            <rect x="1013.8" y="289.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="289.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1476">
+            <rect x="1013.8" y="316.87548" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="1013.8" y="316.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1475">
+            <rect x="1013.8" y="371.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="371.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1474">
+            <rect x="1013.8" y="399.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="399.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1464">
+          <g id="Graphic_1472">
+            <rect x="762.8" y="199.68417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="762.8" y="199.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1471">
+            <rect x="762.8" y="345.32614" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="762.8" y="345.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1470">
+            <rect x="762.8" y="229.232" width="12.96" height="12.96" fill="#80ff80"/>
+            <rect x="762.8" y="229.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1469">
+            <rect x="762.8" y="258.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="258.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1468">
+            <rect x="762.8" y="290.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="290.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1467">
+            <rect x="762.8" y="317.87548" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="762.8" y="317.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1466">
+            <rect x="762.8" y="372.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="372.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1465">
+            <rect x="762.8" y="400.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="400.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1455">
+          <g id="Graphic_1463">
+            <rect x="989.2921" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="989.2921" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1462">
+            <rect x="843.6502" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="843.6502" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1461">
+            <rect x="959.7443" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="959.7443" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1460">
+            <rect x="930.1965" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="930.1965" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1459">
+            <rect x="898.5515" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="898.5515" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1458">
+            <rect x="871.1008" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="871.1008" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1457">
+            <rect x="816.1995" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="816.1995" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1456">
+            <rect x="788.7489" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="788.7489" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1446">
+          <g id="Graphic_1454">
+            <rect x="989.2921" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="989.2921" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1453">
+            <rect x="843.6502" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="843.6502" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1452">
+            <rect x="959.7443" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="959.7443" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1451">
+            <rect x="930.1965" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="930.1965" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1450">
+            <rect x="898.5515" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="898.5515" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1449">
+            <rect x="871.1008" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="871.1008" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1448">
+            <rect x="816.1995" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="816.1995" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1447">
+            <rect x="788.7489" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="788.7489" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Line_1445">
+          <line x1="795.64" y1="171.32417" x2="796.0112" y2="151.86237" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1444">
+          <line x1="823.28" y1="142.80835" x2="823.28" y2="160.58" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1443">
+          <line x1="850.92" y1="170.48" x2="851.2912" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1442">
+          <line x1="878.56" y1="141.96417" x2="878.56" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1441">
+          <line x1="906.2" y1="172.16835" x2="906.5712" y2="152.70655" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1440">
+          <line x1="937.02" y1="143.65253" x2="937.02" y2="161.42417" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1439">
+          <line x1="967.84" y1="170.48" x2="968.2112" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1438">
+          <line x1="995.48" y1="141.96417" x2="995.48" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1437">
+          <line x1="795.0805" y1="473.7113" x2="795.4517" y2="454.24953" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1436">
+          <line x1="822.7205" y1="445.1955" x2="822.7205" y2="462.96715" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1435">
+          <line x1="850.3605" y1="472.86715" x2="850.7317" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1434">
+          <line x1="878.0005" y1="444.35133" x2="878.0005" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1433">
+          <line x1="905.6405" y1="474.5555" x2="906.0117" y2="455.0937" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1432">
+          <line x1="936.4605" y1="446.0397" x2="936.4605" y2="463.8113" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1431">
+          <line x1="967.2805" y1="472.86715" x2="967.6517" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1430">
+          <line x1="994.9205" y1="444.35133" x2="994.9205" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1429">
+          <line x1="731.8" y1="205.84416" x2="752.90035" y2="206.02432" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1428">
+          <line x1="762.8" y1="236.12417" x2="743.69964" y2="236.28225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1427">
+          <line x1="732.32" y1="265.72417" x2="752.9005" y2="265.94024" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1426">
+          <line x1="759.8" y1="297.32417" x2="740.69964" y2="297.48225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1425">
+          <line x1="733.32" y1="323.70746" x2="749.9007" y2="323.90783" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1424">
+          <line x1="761.8" y1="350.64746" x2="740.6997" y2="350.81083" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1423">
+          <line x1="731.32" y1="378.69075" x2="751.9005" y2="378.9068" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1422">
+          <line x1="760.8" y1="407.18746" x2="741.69964" y2="407.34554" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1421">
+          <line x1="1031.2942" y1="204.64416" x2="1069.9002" y2="204.89886" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1420">
+          <line x1="1076.1068" y1="234.92417" x2="1039.8998" y2="234.69445" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1419">
+          <line x1="1031.9671" y1="264.52417" x2="1066.8774" y2="264.77348" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1418">
+          <line x1="1076.2468" y1="296.12417" x2="1039.8998" y2="296.3128" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1417">
+          <line x1="1033.2613" y1="322.50746" x2="1066.3471" y2="322.75376" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1416">
+          <line x1="1076.2468" y1="350.63164" x2="1039.8979" y2="349.88955" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1415">
+          <line x1="1031.0038" y1="377.49074" x2="1069.9" y2="377.60306" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1414">
+          <line x1="1074.2797" y1="405.63164" x2="1040.5233" y2="405.3191" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Graphic_1413">
+          <rect x="762.8" y="419.5437" width="12.96" height="12.96" fill="yellow"/>
+          <rect x="762.8" y="419.5437" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+      </g>
+    </g>
+    <g id="concat_wire_wires">
+      <title>wires</title>
+      <g id="Line_1503">
+        <line x1="410" y1="206.74365" x2="418.0052" y2="194.33896" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1502">
+        <line x1="410" y1="206.74365" x2="635.1" y2="206.74365" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1501">
+        <line x1="410" y1="206.74365" x2="564.3567" y2="416.60816" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1506">
+        <line x1="778.32" y1="206.74365" x2="786.3252" y2="194.33896" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1505">
+        <line x1="778.32" y1="206.74365" x2="1003.42" y2="206.74365" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1504">
+        <line x1="778.32" y1="206.74365" x2="932.6767" y2="416.60816" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+    </g>
+    <g id="concat_wire_legend">
+      <title>legend</title>
+      <g id="Graphic_1490">
+        <text transform="translate(366.54814 145.5255)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">(a)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1499">
+        <rect x="505.44" y="488.88" width="454.32" height="57.6" fill="white"/>
+        <rect x="505.44" y="488.88" width="454.32" height="57.6" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1498">
+        <rect x="514.1" y="496.6278" width="12.96" height="12.96" fill="#40ff40"/>
+        <rect x="514.1" y="496.6278" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1497">
+        <text transform="translate(538.1717 492.45767)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">Starting routing tracks</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1496">
+        <rect x="725.2653" y="496.58" width="12.96" height="12.96" fill="#ff4040"/>
+        <rect x="725.2653" y="496.58" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1495">
+        <text transform="translate(741.1591 492.45767)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="2.25" y="16">Ending routing tracks </tspan>
+        </text>
+      </g>
+      <g id="Graphic_1494">
+        <rect x="514.1" y="522.5078" width="12.96" height="12.96" fill="#80ffff"/>
+        <rect x="514.1" y="522.5078" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1493">
+        <text transform="translate(532.7875 517.6055)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="2.25" y="16">Passing routing tracks </tspan>
+        </text>
+      </g>
+      <g id="Graphic_1492">
+        <rect x="725.2653" y="523.5078" width="12.96" height="12.96" fill="yellow"/>
+        <rect x="725.2653" y="523.5078" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1491">
+        <text transform="translate(753.9636 518.6055)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">Output pin of blocks</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1500">
+        <text transform="translate(751.7481 145.5255)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">(b)</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/source/manual/arch_lang/figures/opin2all_sides.svg
+++ b/docs/source/manual/arch_lang/figures/opin2all_sides.svg
@@ -1,0 +1,592 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="364.54 140.62 715.76 406.36" width="715.76" height="406.36">
+  <defs>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -3 7 6" markerWidth="7" markerHeight="6" color="black">
+      <g>
+        <path d="M 4.8 0 L 0 -1.8 L 0 1.8 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+  </defs>
+  <g id="opin2all_sides" fill="none" stroke-opacity="1" fill-opacity="1" stroke="none" stroke-dasharray="none">
+    <title>opin2all_sides</title>
+    <g id="opin2all_sides_base">
+      <title>base</title>
+      <g id="Group_1411">
+        <g id="Graphic_362">
+          <rect x="403.24" y="178.38365" width="249.84" height="256.4605" fill="white"/>
+          <rect x="403.24" y="178.38365" width="249.84" height="256.4605" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Group_513">
+          <g id="Graphic_363">
+            <rect x="648.04" y="198.68417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="648.04" y="198.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_368">
+            <rect x="648.04" y="344.32614" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="648.04" y="344.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_367">
+            <rect x="648.04" y="228.232" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="648.04" y="228.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_366">
+            <rect x="648.04" y="257.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="257.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_510">
+            <rect x="648.04" y="289.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="289.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_509">
+            <rect x="648.04" y="316.87548" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="648.04" y="316.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_511">
+            <rect x="648.04" y="371.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="371.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_512">
+            <rect x="648.04" y="399.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="648.04" y="399.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_514">
+          <g id="Graphic_526">
+            <rect x="397.04" y="199.68417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="397.04" y="199.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_523">
+            <rect x="397.04" y="345.32614" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="397.04" y="345.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_522">
+            <rect x="397.04" y="229.232" width="12.96" height="12.96" fill="#80ff80"/>
+            <rect x="397.04" y="229.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_521">
+            <rect x="397.04" y="258.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="258.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_518">
+            <rect x="397.04" y="290.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="290.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_517">
+            <rect x="397.04" y="317.87548" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="397.04" y="317.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_516">
+            <rect x="397.04" y="372.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="372.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_515">
+            <rect x="397.04" y="400.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="397.04" y="400.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_527">
+          <g id="Graphic_539">
+            <rect x="623.53215" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="623.53215" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_536">
+            <rect x="477.8902" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="477.8902" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_535">
+            <rect x="593.9843" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="593.9843" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_534">
+            <rect x="564.4365" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="564.4365" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_531">
+            <rect x="532.7915" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="532.7915" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_530">
+            <rect x="505.34085" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="505.34085" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_529">
+            <rect x="450.4395" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="450.4395" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_528">
+            <rect x="422.98886" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="422.98886" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_540">
+          <g id="Graphic_552">
+            <rect x="623.53215" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="623.53215" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_549">
+            <rect x="477.8902" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="477.8902" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_548">
+            <rect x="593.9843" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="593.9843" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_547">
+            <rect x="564.4365" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="564.4365" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_544">
+            <rect x="532.7915" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="532.7915" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_543">
+            <rect x="505.34085" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="505.34085" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_542">
+            <rect x="450.4395" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="450.4395" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_541">
+            <rect x="422.98886" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="422.98886" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Line_972">
+          <line x1="429.88" y1="171.32417" x2="430.2512" y2="151.86237" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_973">
+          <line x1="457.52" y1="142.80835" x2="457.52" y2="160.58" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_975">
+          <line x1="485.16" y1="170.48" x2="485.5312" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_974">
+          <line x1="512.8" y1="141.96417" x2="512.8" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_979">
+          <line x1="540.44" y1="172.16835" x2="540.8112" y2="152.70655" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_978">
+          <line x1="571.26" y1="143.65253" x2="571.26" y2="161.42417" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_977">
+          <line x1="602.08" y1="170.48" x2="602.4512" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_976">
+          <line x1="629.72" y1="141.96417" x2="629.72" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_987">
+          <line x1="429.3205" y1="473.7113" x2="429.6917" y2="454.24953" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_986">
+          <line x1="456.9605" y1="445.1955" x2="456.9605" y2="462.96715" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_985">
+          <line x1="484.6005" y1="472.86715" x2="484.9717" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_984">
+          <line x1="512.2405" y1="444.35133" x2="512.2405" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_983">
+          <line x1="539.8805" y1="474.5555" x2="540.2517" y2="455.0937" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_982">
+          <line x1="570.7005" y1="446.0397" x2="570.7005" y2="463.8113" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_981">
+          <line x1="601.5205" y1="472.86715" x2="601.8917" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_980">
+          <line x1="629.1605" y1="444.35133" x2="629.1605" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_988">
+          <line x1="366.04" y1="205.84416" x2="387.14035" y2="206.02432" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_989">
+          <line x1="397.04" y1="236.12417" x2="377.93965" y2="236.28225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_991">
+          <line x1="366.56" y1="265.72417" x2="387.14054" y2="265.94024" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_990">
+          <line x1="394.04" y1="297.32417" x2="374.93965" y2="297.48225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_995">
+          <line x1="367.56" y1="323.70746" x2="384.1407" y2="323.90783" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_994">
+          <line x1="396.04" y1="350.64746" x2="374.9397" y2="350.81083" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_993">
+          <line x1="365.56" y1="378.69075" x2="386.14054" y2="378.9068" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_992">
+          <line x1="395.04" y1="407.18746" x2="375.93965" y2="407.34554" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1378">
+          <line x1="665.5342" y1="204.64416" x2="704.1402" y2="204.89886" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1377">
+          <line x1="710.3468" y1="234.92417" x2="674.1398" y2="234.69445" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1376">
+          <line x1="666.20714" y1="264.52417" x2="701.11745" y2="264.77348" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1375">
+          <line x1="710.48684" y1="296.12417" x2="674.13986" y2="296.3128" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1374">
+          <line x1="667.5013" y1="322.50746" x2="700.5871" y2="322.75376" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1373">
+          <line x1="710.48684" y1="350.63164" x2="674.1379" y2="349.88955" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1372">
+          <line x1="665.2438" y1="377.49074" x2="704.14" y2="377.60306" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1371">
+          <line x1="708.5197" y1="405.63164" x2="674.7633" y2="405.3191" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Graphic_1396">
+          <rect x="397.04" y="419.5437" width="12.96" height="12.96" fill="yellow"/>
+          <rect x="397.04" y="419.5437" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+      </g>
+      <g id="Group_1412">
+        <g id="Graphic_1482">
+          <rect x="769" y="178.38365" width="249.84" height="256.4605" fill="white"/>
+          <rect x="769" y="178.38365" width="249.84" height="256.4605" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Group_1473">
+          <g id="Graphic_1481">
+            <rect x="1013.8" y="198.68417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="1013.8" y="198.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1480">
+            <rect x="1013.8" y="344.32614" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="1013.8" y="344.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1479">
+            <rect x="1013.8" y="228.232" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="1013.8" y="228.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1478">
+            <rect x="1013.8" y="257.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="257.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1477">
+            <rect x="1013.8" y="289.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="289.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1476">
+            <rect x="1013.8" y="316.87548" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="1013.8" y="316.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1475">
+            <rect x="1013.8" y="371.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="371.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1474">
+            <rect x="1013.8" y="399.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="1013.8" y="399.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1464">
+          <g id="Graphic_1472">
+            <rect x="762.8" y="199.68417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="762.8" y="199.68417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1471">
+            <rect x="762.8" y="345.32614" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="762.8" y="345.32614" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1470">
+            <rect x="762.8" y="229.232" width="12.96" height="12.96" fill="#80ff80"/>
+            <rect x="762.8" y="229.232" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1469">
+            <rect x="762.8" y="258.77982" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="258.77982" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1468">
+            <rect x="762.8" y="290.4248" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="290.4248" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1467">
+            <rect x="762.8" y="317.87548" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="762.8" y="317.87548" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1466">
+            <rect x="762.8" y="372.7768" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="372.7768" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1465">
+            <rect x="762.8" y="400.22746" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="762.8" y="400.22746" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1455">
+          <g id="Graphic_1463">
+            <rect x="989.2921" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="989.2921" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1462">
+            <rect x="843.6502" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="843.6502" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1461">
+            <rect x="959.7443" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="959.7443" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1460">
+            <rect x="930.1965" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="930.1965" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1459">
+            <rect x="898.5515" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="898.5515" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1458">
+            <rect x="871.1008" y="171.32417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="871.1008" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1457">
+            <rect x="816.1995" y="171.32417" width="12.96" height="12.96" fill="#ff4040"/>
+            <rect x="816.1995" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1456">
+            <rect x="788.7489" y="171.32417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="788.7489" y="171.32417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Group_1446">
+          <g id="Graphic_1454">
+            <rect x="989.2921" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="989.2921" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1453">
+            <rect x="843.6502" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="843.6502" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1452">
+            <rect x="959.7443" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="959.7443" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1451">
+            <rect x="930.1965" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="930.1965" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1450">
+            <rect x="898.5515" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="898.5515" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1449">
+            <rect x="871.1008" y="428.36417" width="12.96" height="12.96" fill="#80ffff"/>
+            <rect x="871.1008" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1448">
+            <rect x="816.1995" y="428.36417" width="12.96" height="12.96" fill="#40ff40"/>
+            <rect x="816.1995" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+          <g id="Graphic_1447">
+            <rect x="788.7489" y="428.36417" width="12.96" height="12.96" fill="red"/>
+            <rect x="788.7489" y="428.36417" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          </g>
+        </g>
+        <g id="Line_1445">
+          <line x1="795.64" y1="171.32417" x2="796.0112" y2="151.86237" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1444">
+          <line x1="823.28" y1="142.80835" x2="823.28" y2="160.58" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1443">
+          <line x1="850.92" y1="170.48" x2="851.2912" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1442">
+          <line x1="878.56" y1="141.96417" x2="878.56" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1441">
+          <line x1="906.2" y1="172.16835" x2="906.5712" y2="152.70655" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1440">
+          <line x1="937.02" y1="143.65253" x2="937.02" y2="161.42417" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1439">
+          <line x1="967.84" y1="170.48" x2="968.2112" y2="151.0182" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1438">
+          <line x1="995.48" y1="141.96417" x2="995.48" y2="159.73582" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1437">
+          <line x1="795.0805" y1="473.7113" x2="795.4517" y2="454.24953" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1436">
+          <line x1="822.7205" y1="445.1955" x2="822.7205" y2="462.96715" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1435">
+          <line x1="850.3605" y1="472.86715" x2="850.7317" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1434">
+          <line x1="878.0005" y1="444.35133" x2="878.0005" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1433">
+          <line x1="905.6405" y1="474.5555" x2="906.0117" y2="455.0937" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1432">
+          <line x1="936.4605" y1="446.0397" x2="936.4605" y2="463.8113" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1431">
+          <line x1="967.2805" y1="472.86715" x2="967.6517" y2="453.40535" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1430">
+          <line x1="994.9205" y1="444.35133" x2="994.9205" y2="462.123" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1429">
+          <line x1="731.8" y1="205.84416" x2="752.90035" y2="206.02432" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1428">
+          <line x1="762.8" y1="236.12417" x2="743.69964" y2="236.28225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1427">
+          <line x1="732.32" y1="265.72417" x2="752.9005" y2="265.94024" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1426">
+          <line x1="759.8" y1="297.32417" x2="740.69964" y2="297.48225" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1425">
+          <line x1="733.32" y1="323.70746" x2="749.9007" y2="323.90783" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1424">
+          <line x1="761.8" y1="350.64746" x2="740.6997" y2="350.81083" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1423">
+          <line x1="731.32" y1="378.69075" x2="751.9005" y2="378.9068" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1422">
+          <line x1="760.8" y1="407.18746" x2="741.69964" y2="407.34554" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1421">
+          <line x1="1031.2942" y1="204.64416" x2="1069.9002" y2="204.89886" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1420">
+          <line x1="1076.1068" y1="234.92417" x2="1039.8998" y2="234.69445" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1419">
+          <line x1="1031.9671" y1="264.52417" x2="1066.8774" y2="264.77348" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1418">
+          <line x1="1076.2468" y1="296.12417" x2="1039.8998" y2="296.3128" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1417">
+          <line x1="1033.2613" y1="322.50746" x2="1066.3471" y2="322.75376" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1416">
+          <line x1="1076.2468" y1="350.63164" x2="1039.8979" y2="349.88955" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1415">
+          <line x1="1031.0038" y1="377.49074" x2="1069.9" y2="377.60306" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Line_1414">
+          <line x1="1074.2797" y1="405.63164" x2="1040.5233" y2="405.3191" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+        <g id="Graphic_1413">
+          <rect x="762.8" y="419.5437" width="12.96" height="12.96" fill="yellow"/>
+          <rect x="762.8" y="419.5437" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        </g>
+      </g>
+    </g>
+    <g id="opin2all_sides_wires">
+      <title>wires</title>
+      <g id="Line_1406">
+        <path d="M 407.3898 426.1812 C 407.3898 426.1812 438.39373 412.8658 438.3898 391 C 438.3874 377.5346 426.6264 364.72587 417.59013 356.8716" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1407">
+        <path d="M 407.3898 426.1812 C 407.3898 426.1812 470.30214 386.4459 470.2982 332 C 470.2953 291.4208 435.344 256.89188 417.54087 241.9359" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1409">
+        <path d="M 776.5 427 C 776.5 427 797.6378 405.5312 796.5046 384 C 795.9039 372.5868 789.1951 364.00094 783.0226 358.4519" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1408">
+        <path d="M 776.5 427 C 776.5 427 820.4932 383.39456 819.36 329 C 818.5508 290.1589 795.004 258.85852 781.6044 244.1343" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1483">
+        <path d="M 776.5 427 C 776.5 427 796.6181 406.30017 810.5 408 C 817.1427 408.8134 820.8628 414.5728 822.9363 420.35843" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1484">
+        <path d="M 776.5 427 C 776.5 427 819.3213 392.30017 865.5 394 C 896.4812 395.1404 919.1997 412.3047 930.7975 423.4788" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1485">
+        <path d="M 776.5 427 C 776.5 427 806.6569 401.59694 875.5 371 C 927.455 347.90887 983.0061 330.05415 1007.1343 322.68376" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1486">
+        <path d="M 776.5 427 C 776.5 427 832.5237 381.3271 902.5 319 C 954.7636 272.44945 996.4549 232.9577 1014.2125 215.94759" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1487">
+        <path d="M 776.5 427 C 776.5 427 844.9537 380.8431 881.5 312 C 907.8248 262.41144 908.6778 217.8486 907.0957 196.80031" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+      <g id="Line_1488">
+        <path d="M 776.5 427 C 776.5 427 841.8201 370.1264 847.5 301 C 851.7266 249.56022 821.4487 209.33536 805.6783 192.119" marker-end="url(#FilledArrow_Marker_2)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      </g>
+    </g>
+    <g id="opin2all_sides_legend">
+      <title>legend</title>
+      <g id="Graphic_1490">
+        <text transform="translate(366.54814 145.5255)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">(a)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1499">
+        <rect x="505.44" y="488.88" width="454.32" height="57.6" fill="white"/>
+        <rect x="505.44" y="488.88" width="454.32" height="57.6" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1498">
+        <rect x="514.1" y="496.6278" width="12.96" height="12.96" fill="#40ff40"/>
+        <rect x="514.1" y="496.6278" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1497">
+        <text transform="translate(538.1717 492.45767)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">Starting routing tracks</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1496">
+        <rect x="725.2653" y="496.58" width="12.96" height="12.96" fill="#ff4040"/>
+        <rect x="725.2653" y="496.58" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1495">
+        <text transform="translate(741.1591 492.45767)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="2.25" y="16">Ending routing tracks </tspan>
+        </text>
+      </g>
+      <g id="Graphic_1494">
+        <rect x="514.1" y="522.5078" width="12.96" height="12.96" fill="#80ffff"/>
+        <rect x="514.1" y="522.5078" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1493">
+        <text transform="translate(532.7875 517.6055)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="2.25" y="16">Passing routing tracks </tspan>
+        </text>
+      </g>
+      <g id="Graphic_1492">
+        <rect x="725.2653" y="523.5078" width="12.96" height="12.96" fill="yellow"/>
+        <rect x="725.2653" y="523.5078" width="12.96" height="12.96" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_1491">
+        <text transform="translate(753.9636 518.6055)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">Output pin of blocks</tspan>
+        </text>
+      </g>
+      <g id="Graphic_1500">
+        <text transform="translate(751.7481 145.5255)" fill="black">
+          <tspan font-family="Times New Roman" font-style="italic" font-weight="bold" font-size="18" fill="black" x="0" y="16">(b)</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -140,6 +140,9 @@ echo -e "Testing through channels in tileable routing";
 run-task fpga_verilog/thru_channel/thru_narrow_tile $@
 run-task fpga_verilog/thru_channel/thru_wide_tile $@
 
+echo -e "Testing wire concatation in tileable routing";
+run-task fpga_verilog/rr_concat_wire $@
+
 echo -e "Testing the generation of preconfigured fabric wrapper for different HDL simulators";
 run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_none $@
 run-task fpga_verilog/verilog_netlist_formats/embed_bitstream_modelsim $@

--- a/openfpga_flow/tasks/fpga_verilog/lut_design/single_mode/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/lut_design/single_mode/config/task.conf
@@ -19,7 +19,7 @@ fpga_flow=vpr_blif
 openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_example_script.openfpga
 openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_N10_40nm_openfpga.xml
 openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
-openfpga_vpr_device_layout=2x2
+openfpga_vpr_device_layout=auto
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml

--- a/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/bus_group_gen.py
+++ b/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/bus_group_gen.py
@@ -1,0 +1,173 @@
+#####################################################################
+# A script to create a bus group file based on an input verilog file
+# The bug group file is an input required by OpenFPGA
+#####################################################################
+import os
+from os.path import dirname, abspath
+import argparse
+import logging
+import subprocess
+import hashlib
+import yaml
+import pyverilog
+from pyverilog.dataflow.dataflow_analyzer import VerilogDataflowAnalyzer
+from xml.dom import minidom
+
+#####################################################################
+# Error codes
+#####################################################################
+error_codes = {
+  "SUCCESS": 0,
+  "MD5_ERROR": 1, 
+  "OPTION_ERROR": 2, 
+  "FILE_ERROR": 3 
+}
+
+#####################################################################
+# Initialize logger 
+#####################################################################
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO);
+
+#####################################################################
+# Generate the string for a Verilog port
+#####################################################################
+def gen_verilog_port_str(port_name, msb, lsb):
+  port_str = str(port_name) + "[" + str(msb) + ":" + str(lsb) + "]"
+  return port_str 
+
+#####################################################################
+# Generate the string for a flatten Verilog port
+#####################################################################
+def gen_flatten_verilog_port_str(port_name, pin_id):
+  port_str = str(port_name) + "_" + str(pin_id) + "_"
+  return port_str 
+
+#####################################################################
+# Parse a verilog file and collect bus port information
+#####################################################################
+def parse_verilog_file_bus_ports(verilog_files, top_module):
+  # Check if verilog file exists
+  verilog_file_list = []
+  for verilog_f in verilog_files:
+    print(verilog_f)
+    verilog_f_abspath = os.path.abspath(verilog_f["name"])
+    if not os.path.exists(verilog_f_abspath):
+      raise IOError("file not found: " + verilog_f_abspath)
+
+    verilog_file_list.append(verilog_f_abspath)
+
+  # Parse verilog file
+  analyzer = VerilogDataflowAnalyzer(verilog_file_list, top_module)
+  analyzer.generate()
+  # Get port information
+  terms = analyzer.getTerms()
+  # Create XML tree
+  xml = minidom.Document()
+  bus_group = xml.createElement("bus_group")
+  xml.appendChild(bus_group)
+  for tk, tv in sorted(terms.items(), key=lambda x: str(x[0])):
+    logging.debug(tv.name)
+    logging.debug(tv.termtype)
+    logging.debug("[" + str(tv.lsb) + ":" + str(tv.msb) + "]")
+  for tk, tv in sorted(terms.items(), key=lambda x: str(x[0])):
+    # Skip ports that do not belong to top module
+    if (top_module != str(tv.name).split(".")[-2]):
+      continue
+    port_name = str(tv.name).split(".")[-1]
+    
+    # Skip minus lsb or msb, which are in don't care set
+    if (("Minus" == str(tv.lsb)) or ("Minus" == str(tv.msb))):
+      continue
+    port_lsb = int(str(tv.lsb))
+    port_msb = int(str(tv.msb))
+    # Only care input and outports 
+    if ((not ("Input" in tv.termtype)) and (not ("Output" in tv.termtype))):
+      continue
+    # Only care bus (msb - lsb > 0)
+    if (abs(port_lsb - port_msb) == 0):
+      continue
+    # Reaching here, this is a bus port we need
+    # Get the second part of the name, which is the port name
+    cur_bus = xml.createElement("bus")
+    cur_bus.setAttribute("name", gen_verilog_port_str(port_name, port_msb, port_lsb)) 
+    # Get if this is little endian or not
+    cur_bus.setAttribute("big_endian", "false")
+    if (port_lsb > port_msb):
+      cur_bus.setAttribute("big_endian", "true")
+    bus_group.appendChild(cur_bus)
+    # Add all the pins
+    for ipin in range(min([port_msb, port_lsb]), max([port_msb, port_lsb]) + 1):
+      cur_pin = xml.createElement("pin")
+      cur_pin.setAttribute('id', str(ipin))
+      cur_pin.setAttribute('name', gen_flatten_verilog_port_str(port_name, ipin))
+      cur_bus.appendChild(cur_pin)
+
+  return xml, bus_group
+
+#####################################################################
+# Generate bus group files with a given task list
+#####################################################################
+def generate_bus_group_files(task_db):
+  # Iterate over all the tasks
+  for verilog_fname in task_db.keys():
+    space_limit = 120
+    log_str = "Parsing verilog file: "
+    top_module_name = task_db[verilog_fname]["top_module"]
+    logging_space = "." * (space_limit - len(log_str) - len(top_module_name))
+    logging.info(log_str + top_module_name) 
+    xml, bus_group_data = parse_verilog_file_bus_ports(task_db[verilog_fname]["source"], top_module_name)
+    logging.info(log_str + top_module_name + logging_space + "Done") 
+    # Write bus ports to an XML file
+    bus_group_frelname = task_db[verilog_fname]["bus_group_file"]
+    bus_group_fname = os.path.abspath(bus_group_frelname)
+    log_str = "Writing bus group file:"
+    logging_space = "." * (space_limit - len(log_str) - len(bus_group_frelname))
+    logging.info(log_str + bus_group_frelname) 
+    xml_str = xml.toprettyxml(indent="\t")
+    with open(bus_group_fname, "w") as bus_group_f:
+      bus_group_f.write(xml_str)
+    logging.info(log_str + bus_group_frelname + logging_space + "Done") 
+
+#####################################################################
+# Read task list from a yaml file
+#####################################################################
+def read_yaml_to_task_database(yaml_filename):
+  task_db = {}
+  with open(yaml_filename, 'r') as stream:
+    try:
+      task_db = yaml.load(stream, Loader=yaml.FullLoader)
+      logging.info("Found " + str(len(task_db)) + " tasks to create symbolic links")
+    except yaml.YAMLError as exc:
+      logging.error(exc)
+      exit(error_codes["FILE_ERROR"]);
+
+  return task_db
+
+#####################################################################
+# Write result database to a yaml file
+#####################################################################
+def write_result_database_to_yaml(result_db, yaml_filename):
+  with open(yaml_filename, 'w') as yaml_file:
+    yaml.dump(result_db, yaml_file, default_flow_style=False)
+
+#####################################################################
+# Main function
+#####################################################################
+if __name__ == '__main__':
+  # Execute when the module is not initialized from an import statement
+
+  # Parse the options and apply sanity checks
+  parser = argparse.ArgumentParser(description='Create bus group files for Verilog inputs')
+  parser.add_argument('--task_list',
+                      required=True,
+                      help='Configuration file in YAML format which contains a list of input Verilog and output bus group files')
+  args = parser.parse_args()
+
+  # Create a database for tasks
+  task_db = {}
+  task_db = read_yaml_to_task_database(args.task_list)
+
+  # Generate links based on the task list in database
+  generate_bus_group_files(task_db)
+  logging.info("Created " + str(len(task_db)) + " bus group files")
+  exit(error_codes["SUCCESS"])

--- a/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/counter8_bus_group_task.yaml
+++ b/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/counter8_bus_group_task.yaml
@@ -1,0 +1,5 @@
+counter8:
+  source:
+    - name: counter_output_verilog.v
+  top_module: counter
+  bus_group_file: bus_group.xml

--- a/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/pin_constraints_reset.xml
+++ b/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/pin_constraints_reset.xml
@@ -1,0 +1,7 @@
+<pin_constraints>
+  <!-- For a given .blif file, we want to assign 
+       - the reset signal to the op_reset[0] port of the FPGA fabric
+    -->
+  <set_io pin="op_reset[0]" net="reset"/>
+</pin_constraints>
+

--- a/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/rr_concat_wire/config/task.conf
@@ -1,0 +1,48 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/auto_bus_group_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_dpram8K_dsp36_fracff_40nm_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+openfpga_verilog_port_mapping=--explicit_port_mapping
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N10_tileableConcatWire_adder_chain_dpram8K_dsp36_fracff_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_8bit_async_reset/counter.v
+
+[SYNTHESIS_PARAM]
+# Yosys script parameters
+bench_yosys_cell_sim_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm_cell_sim.v
+bench_yosys_dff_map_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm_dff_map.v
+bench_yosys_bram_map_rules_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm_bram.txt
+bench_yosys_bram_map_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm_bram_map.v
+bench_yosys_dsp_map_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm_dsp_map.v
+bench_yosys_dsp_map_parameters_common=-D DSP_A_MAXWIDTH=36 -D DSP_B_MAXWIDTH=36 -D DSP_A_MINWIDTH=2 -D DSP_B_MINWIDTH=2 -D DSP_NAME=mult_36x36
+bench_read_verilog_options_common = -nolatches
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
+bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys
+
+bench0_top = counter
+bench0_openfpga_pin_constraints_file=${PATH:TASK_DIR}/config/pin_constraints_reset.xml
+bench0_openfpga_bus_group_file=bus_group.xml
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/vpr_arch/README.md
+++ b/openfpga_flow/vpr_arch/README.md
@@ -5,8 +5,9 @@ Please reveal the following architecture features in the names to help quickly s
   * The keyword 'frac' is to specify if fracturable LUT is used or not.
   * The keyword 'Native' is to specify if fracturable LUT design is a native one (without mode switch) or a standard one (with mode switch).
 - N<le\_size>: Number of logic elements for a CLB. If you have multiple CLB architectures, this should be largest number.
-- tileable<IO>: If the routing architecture is tileable or not. 
+- tileable<IO|ConcatWire>: If the routing architecture is tileable or not. 
   * The keyword 'IO' specifies if the I/O tile is tileable or not
+  * The keyword 'ConcatWire' specifies if the routing wires can be continued in the same direction or not. For example, L4 -> L1
 - fracff<2edge>: Use multi-mode flip-flop model, where reset/set polarity is configurable. When 2edge is specified, clock polarity can be switched between postive edge triggered and negative edge triggered
 - adder\_chain: If hard adder/carry chain is used inside CLBs
 - register\_chain: If shift register chain is used inside CLBs

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
@@ -67,7 +67,7 @@
   </tiles>
   <!-- ODIN II specific config ends -->
   <!-- Physical descriptions begin -->
-  <layout tileable="true" concat_wire="false" concat_pass_wire="false">
+  <layout tileable="true" concat_wire="false" concat_pass_wire="true">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
@@ -67,7 +67,7 @@
   </tiles>
   <!-- ODIN II specific config ends -->
   <!-- Physical descriptions begin -->
-  <layout tileable="true">
+  <layout tileable="true" concat_wire="false" concat_pass_wire="false">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>

--- a/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_40nm.xml
@@ -103,7 +103,7 @@
   </tiles>
   <!-- ODIN II specific config ends -->
   <!-- Physical descriptions begin -->
-  <layout tileable="true">
+  <layout tileable="true" concat_wire="false" concat_pass_wire="true">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>

--- a/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_N10_tileable_40nm.xml
@@ -67,7 +67,7 @@
   </tiles>
   <!-- ODIN II specific config ends -->
   <!-- Physical descriptions begin -->
-  <layout tileable="true">
+  <layout tileable="true" opin2all_sides="true" concat_wire="true" concat_pass_wire="false">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileableConcatWire_adder_chain_dpram8K_dsp36_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileableConcatWire_adder_chain_dpram8K_dsp36_fracff_40nm.xml
@@ -302,7 +302,7 @@
   </tiles>
   <!-- ODIN II specific config ends -->
   <!-- Physical descriptions begin -->
-  <layout tileable="true" through_channel="false" concat_wire="true" concat_pass_wire="false">
+  <layout tileable="true" through_channel="false" opin2all_sides="true" concat_wire="true" concat_pass_wire="false">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileableConcatWire_adder_chain_dpram8K_dsp36_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileableConcatWire_adder_chain_dpram8K_dsp36_fracff_40nm.xml
@@ -1,0 +1,1239 @@
+<?xml version="1.0"?>
+<!-- 
+  Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 6, N = 10, fracturable 6 LUTs (can operate as one 6-LUT or two 5-LUTs with 8 total FLE inputs (2 inputs of which are shared by the 5-LUTs) 
+    with optionally registered outputs
+    Each 5-LUT has an arithemtic mode that converts it to a single-bit adder with both inputs driven by 4-LUTs (both 4-LUTs share all 4 inputs)
+    Carry chain links to vertically adjacent logic blocks
+  - Memory size 32 Kbits, memory aspect ratios vary from a data width of 1 to data width of 64.  
+    Height = 6, found on every (8n+2)th column
+  - Multiplier modes: one 36x36, two 18x18, each 18x18 can also operate as two 9x9.  
+    Height = 4, found on every (8n+6)th column
+  - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
+
+  Details on Modelling:
+
+  The electrical design of the architecture described here is NOT from an 
+  optimized, SPICED architecture.  Instead, we attempt to create a reasonable 
+  architecture file by using an existing commercial FPGA to approximate the area, 
+  delay, and power of the underlying components. This is combined with a reasonable 40 nm 
+  model of wiring and circuit design for low-level routing components, where available.
+  The resulting architecture has delays that roughly match a commercial 40 nm FPGA, but also 
+  has wiring electrical parameters that allow the wire lengths and switch patterns to be 
+  modified and you will still get reasonable delay results for the new architecture.
+  The following describes, in detail, how we obtained the various electrical values for this 
+  architecture.
+
+  Rmin for nmos and pmos, routing buffer sizes, and I/O pad delays are from the ifar 
+  architecture created by Ian Kuon: K06 N10 45nm fc 0.15 area-delay optimized architecture. 
+  (n10k06l04.fc15.area1delay1.cmos45nm.bptm.cmos45nm.xml)      
+  This routing architecture was optimized for 45 nm, and we have scaled it linearly to 40 nm to 
+  match the overall target (a 40 nm FPGA).
+
+  We obtain delay numbers by measuring delays of routing, soft logic blocks, 
+  memories, and multipliers from test circuits on a Stratix IV GX device 
+  (EP4SGX230DF29C2X, i.e. fastest speed grade). For routing, we took the average delay of H4 and V4 
+  wires.  Rmetal and Cmetal values for the routing wires were obtained from work done by Charles 
+  Chiasson. We use a 96 nm half-pitch (corresponding to mid-level metal stack 40 nm routing) and 
+  take the R and C data from the ITRS roadmap.  
+
+  For the general purpose logic block, we assume that the area and delays of the Stratix IV 
+  crossbar is close enough to the crossbar modelled here.  
+  Stratix IV uses 52 inputs and 20 feedback lines, but only a half-populated crossbar, leading to 
+  36:1 multiplexers.  We match these parameters in this architecture.
+
+  For LUTs, we include LUT 
+  delays measured from Stratix IV which is dependant on the input used (ie. some 
+  LUT inputs are faster than others).  The CAD tools at the time of VTR 7 does 
+  not consider differences in LUT input delays.
+
+  Adder delays obtained as approximate values from a Stratix IV EP4SE230F29C3 device.  
+  Delay obtained by compiling a 256 bit adder (registered inputs and outputs, 
+  all pins except clock virtual) then measuring the delays in chip-planner, 
+  sumout delay = 0.271ns to 0.348 ns, intra-block carry delay = 0.011 ns, 
+  inter-block carry delay = 0.327 ns.  Given this data, I will approximate 
+  sumout 0.3 ns, intra-block carry-delay = 0.01 ns, and 
+  inter-block carry-delay = 0.16 ns (since Altera inter-block carry delay has 
+  overhead that we don't have, I'll approximate the delay of a simpler chain at 
+  one half what they have.  This is very rough, anything from 0.01ns to 0.327ns 
+  can be justified).
+
+  Logic block area numbers obtained by scaling overall tile area of a 65nm 
+  Stratix III device, (as given in Wong, Betz and Rose, FPGA 2011) to 40 nm, then subtracting out 
+  routing area at a channel width of 300. We use a channel width of 300 because it can route 
+  all the VTR 6.0 benchmark circuits with an approximately 20% safety margin, and is also close to the
+  total channel width of Stratix IV. Hence this channel width is close to the commercial practice of
+  choosing a width that provides high routability. The architecture can be routed at different channel
+  widths, but we estimate the tile size and hence the physical length of routing wires assuming
+  a channel width of 300.
+
+  Sanity checks employed:
+    1.  We confirmed the routing buffer delay is ~1/3rd of total routing delay at L = 4. This matches 
+        common electrical design.
+
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="frac_lut6">
+      <input_ports>
+        <port name="in"/>
+      </input_ports>
+      <output_ports>
+        <port name="lut4_out"/>
+        <port name="lut5_out"/>
+        <port name="lut6_out"/>
+      </output_ports>
+    </model>
+    <model name="dpram_1024x8">
+      <input_ports>
+        <!-- write address lines -->
+        <port name="waddr" clock="clk"/>
+        <!-- read address lines -->
+        <port name="raddr" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_in" clock="clk"/>
+        <!-- write enable -->
+        <port name="wen" clock="clk"/>
+        <!-- read enable -->
+        <port name="ren" clock="clk"/>
+        <!-- memories are often clocked -->
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data_out" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="mult_36">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Y"/>
+        <port name="B" combinational_sink_ports="Y"/>
+      </input_ports>
+      <output_ports>
+        <port name="Y"/>
+      </output_ports>
+    </model>
+    <!-- A virtual model for flip-flops -->
+    <model name="dff">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffsr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="S" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffr">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffs">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="S" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffrn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="RN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="dffsn">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="SN" clock="C"/>
+        <port name="C" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad</loc>
+          <loc side="top">io.outpad io.inpad</loc>
+          <loc side="right">io.outpad io.inpad</loc>
+          <loc side="bottom">io.outpad io.inpad</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <input name="set" num_pins="1" is_non_clock_global="true"/>
+        <input name="reset" num_pins="1" is_non_clock_global="true"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="set" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">clb.clk clb.reset clb.set</loc>
+          <loc side="top">clb.cin</loc>
+          <loc side="right">clb.O[9:0] clb.I[19:0]</loc>
+          <loc side="bottom">clb.cout clb.O[19:10] clb.I[39:20]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="2" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory"/>
+        </equivalent_sites>
+        <input name="waddr" num_pins="10"/>
+        <input name="raddr" num_pins="10"/>
+        <input name="data_in" num_pins="8"/>
+        <input name="wen" num_pins="1"/>
+        <input name="ren" num_pins="1"/>
+        <output name="data_out" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <!--pinlocations pattern="spread"/-->
+        <pinlocations pattern="custom">
+          <loc side="left">memory.clk</loc>
+          <loc side="top"/>
+          <loc side="right">memory.waddr[4:0] memory.raddr[4:0] memory.data_in[3:0] memory.wen memory.data_out[3:0]</loc>
+          <loc side="bottom">memory.waddr[9:5] memory.raddr[9:5] memory.data_in[7:4] memory.ren memory.data_out[7:4]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="mult_36" height="6" area="396000">
+      <sub_tile name="mult_36">
+        <equivalent_sites>
+          <site pb_type="mult_36" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="36"/>
+        <input name="b" num_pins="36"/>
+        <output name="out" num_pins="72"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <!--  Highly recommand to customize pin location when direct connection is used!!! -->
+        <!-- pinlocations are designed to spread pin on 4 sides evenly -->
+        <pinlocations pattern="custom">
+          <loc side="left">mult_36.b[0:9] mult_36.b[10:35] mult_36.out[36:71]</loc>
+          <loc side="top"/>
+          <loc side="right">mult_36.a[0:9] mult_36.a[10:35] mult_36.out[0:35]</loc>
+          <loc side="bottom"/>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" through_channel="false" concat_wire="true" concat_pass_wire="false">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </auto_layout>
+    <fixed_layout name="3x2" width="5" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+    <fixed_layout name="48x48" width="50" height="50">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+           book area formula. This means the mux transistors are about 5x minimum drive strength.
+           We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+           mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+           the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+           by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+           buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+           I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+           (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+           The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+           2.5x when looking up in Jeff's tables.
+           Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+             With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+    <segment name="L4" freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+           If you need to register the I/O, define clocks in the circuit models
+           These clocks can be handled in back-end
+       -->
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="iopad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
+          </direct>
+          <direct name="inpad" input="iopad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <input name="set" num_pins="1" is_non_clock_global="true"/>
+      <input name="reset" num_pins="1" is_non_clock_global="true"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
+             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+             The outputs of the fracturable logic element can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <input name="set" num_pins="1"/>
+        <input name="reset" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- Physical mode definition begin (physical implementation of the fle) -->
+        <mode name="physical" disable_packing="true">
+          <pb_type name="fabric" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="cin" num_pins="1"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="frac_logic" num_pb="1">
+              <input name="in" num_pins="6"/>
+              <output name="lut4_out" num_pins="4"/>
+              <output name="out" num_pins="2"/>
+              <!-- Define LUT -->
+              <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
+                <input name="in" num_pins="6"/>
+                <output name="lut4_out" num_pins="4"/>
+                <output name="lut5_out" num_pins="2"/>
+                <output name="lut6_out" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="direct1" input="frac_logic.in" output="frac_lut6.in"/>
+                <direct name="direct2" input="frac_lut6.lut4_out" output="frac_logic.lut4_out"/>
+                <direct name="direct3" input="frac_lut6.lut5_out[1]" output="frac_logic.out[1]"/>
+                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                <mux name="mux1" input="frac_lut6.lut6_out frac_lut6.lut5_out[0]" output="frac_logic.out[0]"/>
+              </interconnect>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".subckt dffsr" num_pb="2">
+              <input name="D" num_pins="1" port_class="D"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="C" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="C"/>
+              <T_setup value="66e-12" port="ff.R" clock="C"/>
+              <T_setup value="66e-12" port="ff.S" clock="C"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="C"/>
+            </pb_type>
+            <!-- Define adders -->
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="2">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+              <direct name="direct2" input="frac_logic.out[1:0]" output="ff[1:0].D"/>
+              <direct name="direct3" input="fabric.cin" output="adder[0:0].cin"/>
+              <direct name="direct4" input="adder[0:0].cout" output="adder[1:1].cin"/>
+              <direct name="direct5" input="adder[1:1].cout" output="fabric.cout"/>
+              <direct name="direct6" input="frac_logic.lut4_out[0:0]" output="adder[0:0].a"/>
+              <direct name="direct7" input="frac_logic.lut4_out[1:1]" output="adder[0:0].b"/>
+              <direct name="direct8" input="frac_logic.lut4_out[2:2]" output="adder[1:1].a"/>
+              <direct name="direct9" input="frac_logic.lut4_out[3:3]" output="adder[1:1].b"/>
+              <complete name="direct10" input="fabric.clk" output="ff[1:0].C"/>
+              <complete name="direct11" input="fabric.reset" output="ff[1:0].R"/>
+              <complete name="direct12" input="fabric.set" output="ff[1:0].S"/>
+              <mux name="mux1" input="adder[0].sumout ff[0].Q frac_logic.out[0]" output="fabric.out[0]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
+                <delay_constant max="45e-12" in_port="ff[0].Q" out_port="fabric.out[0]"/>
+              </mux>
+              <mux name="mux2" input="adder[1].sumout ff[1].Q frac_logic.out[1]" output="fabric.out[1]">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
+                <delay_constant max="45e-12" in_port="ff[1].Q" out_port="fabric.out[1]"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct3" input="fabric.out" output="fle.out"/>
+            <direct name="direct4" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct5" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct6" input="fle.reset" output="fabric.reset"/>
+            <direct name="direct7" input="fle.set" output="fabric.set"/>
+          </interconnect>
+        </mode>
+        <!-- Physical mode definition end (physical implementation of the fle) -->
+        <!-- BEGIN fle mode of dual lut5 -->
+        <mode name="n2_lut5">
+          <pb_type name="ble5" num_pb="2">
+            <input name="in" num_pins="5"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Regular LUT mode -->
+            <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="5" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                  we instead take the average of these numbers to get more stable results
+                82e-12
+                173e-12
+                261e-12
+                263e-12
+                398e-12
+                -->
+              <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                235e-12
+                235e-12
+                235e-12
+                235e-12
+                235e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define multi-mode flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffs">
+                <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="S" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffs.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffs.S" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffs.D"/>
+                  <direct name="direct2" input="ff.C" output="dffs.C"/>
+                  <direct name="direct3" input="ff.S" output="dffs.S"/>
+                  <direct name="direct4" input="dffs.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffsn">
+                <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="SN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffsn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffsn.SN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffsn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffsn.C"/>
+                  <direct name="direct3" input="ff.S" output="dffsn.SN"/>
+                  <direct name="direct4" input="dffsn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble5.in" output="lut5.in"/>
+              <direct name="direct2" input="lut5.out" output="ff.D">
+                <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble5.clk" output="ff.C"/>
+              <direct name="direct4" input="ble5.reset" output="ff.R"/>
+              <direct name="direct5" input="ble5.set" output="ff.S"/>
+              <mux name="mux1" input="ff.Q lut5.out" output="ble5.out">
+                <delay_constant max="25e-12" in_port="lut5.out" out_port="ble5.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble5.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="ble5[0:0].in"/>
+            <direct name="direct2" input="fle.in[4:0]" output="ble5[1:1].in"/>
+            <complete name="direct3" input="fle.clk" output="ble5.clk"/>
+            <direct name="direct4" input="ble5.out" output="fle.out"/>
+            <complete name="direct5" input="fle.reset" output="ble5.reset"/>
+            <complete name="direct6" input="fle.set" output="ble5.set"/>
+          </interconnect>
+        </mode>
+        <!-- END fle mode of dual lut5 -->
+        <!-- BEGIN arithmetic mode of dual lut4 + adders -->
+        <mode name="arithmetic">
+          <pb_type name="arithmetic" num_pb="2">
+            <input name="in" num_pins="4"/>
+            <input name="cin" num_pins="1"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Special dual-LUT mode that drives adder only -->
+            <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                  195e-12
+                  195e-12
+                  195e-12
+                  195e-12
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+              <input name="a" num_pins="1"/>
+              <input name="b" num_pins="1"/>
+              <input name="cin" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <output name="sumout" num_pins="1"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.cin" out_port="adder.sumout"/>
+              <delay_constant max="0.3e-9" in_port="adder.a" out_port="adder.cout"/>
+              <delay_constant max="0.3e-9" in_port="adder.b" out_port="adder.cout"/>
+              <delay_constant max="0.01e-9" in_port="adder.cin" out_port="adder.cout"/>
+            </pb_type>
+            <!-- Define multi-mode flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffs">
+                <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="S" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffs.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffs.S" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffs.D"/>
+                  <direct name="direct2" input="ff.C" output="dffs.C"/>
+                  <direct name="direct3" input="ff.S" output="dffs.S"/>
+                  <direct name="direct4" input="dffs.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffsn">
+                <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="SN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffsn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffsn.SN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffsn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffsn.C"/>
+                  <direct name="direct3" input="ff.S" output="dffsn.SN"/>
+                  <direct name="direct4" input="dffsn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="clock" input="arithmetic.clk" output="ff.C"/>
+              <direct name="set" input="arithmetic.set" output="ff.S"/>
+              <direct name="reset" input="arithmetic.reset" output="ff.R"/>
+              <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+              <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+              <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                </direct>
+              <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                </direct>
+              <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+              </direct>
+              <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+              </direct>
+              <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+              </direct>
+              <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                <delay_constant max="25e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[3:0]" output="arithmetic[0:0].in"/>
+            <direct name="direct2" input="fle.in[3:0]" output="arithmetic[1:1].in"/>
+            <direct name="carry_in" input="fle.cin" output="arithmetic[0:0].cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="arithmetic[0:0].cin"/>
+            </direct>
+            <direct name="carry_inter" input="arithmetic[0:0].cout" output="arithmetic[1:1].cin">
+              <pack_pattern name="chain" in_port="arithmetic[0:0].cout" out_port="arithmetic[1:1].cin"/>
+            </direct>
+            <direct name="carry_out" input="arithmetic[1:1].cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="arithmetic.cout" out_port="fle.cout"/>
+            </direct>
+            <complete name="direct3" input="fle.clk" output="arithmetic.clk"/>
+            <complete name="direct4" input="fle.reset" output="arithmetic.reset"/>
+            <complete name="direct5" input="fle.set" output="arithmetic.set"/>
+            <direct name="direct6" input="arithmetic.out" output="fle.out"/>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <input name="set" num_pins="1"/>
+            <input name="reset" num_pins="1"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  398e-12
+                  397e-12
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                </delay_matrix>
+            </pb_type>
+            <!-- Define multi-mode flip-flop -->
+            <pb_type name="ff" num_pb="1">
+              <input name="D" num_pins="1"/>
+              <input name="R" num_pins="1"/>
+              <input name="S" num_pins="1"/>
+              <output name="Q" num_pins="1"/>
+              <clock name="C" num_pins="1"/>
+              <mode name="latch">
+                <pb_type name="latch" blif_model=".latch" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="clk" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="latch.D" clock="clk"/>
+                  <T_clock_to_Q max="124e-12" port="latch.Q" clock="clk"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="latch.D"/>
+                  <direct name="direct2" input="ff.C" output="latch.clk"/>
+                  <direct name="direct3" input="latch.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dff">
+                <pb_type name="dff" blif_model=".subckt dff" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dff.D" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dff.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dff.D"/>
+                  <direct name="direct2" input="ff.C" output="dff.C"/>
+                  <direct name="direct3" input="dff.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffr">
+                <pb_type name="dffr" blif_model=".subckt dffr" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="R" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffr.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffr.R" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffr.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffr.D"/>
+                  <direct name="direct2" input="ff.C" output="dffr.C"/>
+                  <direct name="direct3" input="ff.R" output="dffr.R"/>
+                  <direct name="direct4" input="dffr.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffrn">
+                <pb_type name="dffrn" blif_model=".subckt dffrn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="RN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffrn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffrn.RN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffrn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffrn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffrn.C"/>
+                  <direct name="direct3" input="ff.R" output="dffrn.RN"/>
+                  <direct name="direct4" input="dffrn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffs">
+                <pb_type name="dffs" blif_model=".subckt dffs" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="S" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffs.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffs.S" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffs.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffs.D"/>
+                  <direct name="direct2" input="ff.C" output="dffs.C"/>
+                  <direct name="direct3" input="ff.S" output="dffs.S"/>
+                  <direct name="direct4" input="dffs.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="dffsn">
+                <pb_type name="dffsn" blif_model=".subckt dffsn" num_pb="1">
+                  <input name="D" num_pins="1" port_class="D"/>
+                  <input name="SN" num_pins="1"/>
+                  <output name="Q" num_pins="1" port_class="Q"/>
+                  <clock name="C" num_pins="1" port_class="clock"/>
+                  <T_setup value="66e-12" port="dffsn.D" clock="C"/>
+                  <T_setup value="66e-12" port="dffsn.SN" clock="C"/>
+                  <T_clock_to_Q max="124e-12" port="dffsn.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ff.D" output="dffsn.D"/>
+                  <direct name="direct2" input="ff.C" output="dffsn.C"/>
+                  <direct name="direct3" input="ff.S" output="dffsn.SN"/>
+                  <direct name="direct4" input="dffsn.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.C"/>
+              <direct name="direct4" input="ble6.reset" output="ff.R"/>
+              <direct name="direct5" input="ble6.set" output="ff.S"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[5:0]" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+            <direct name="direct4" input="fle.reset" output="ble6.reset"/>
+            <direct name="direct5" input="fle.set" output="ble6.set"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a 50% depop crossbar built using small full xbars to get sets of logically equivalent pins at inputs of CLB 
+           The delays below come from Stratix IV. the delay through a connection block
+           input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+           delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+           delay within the crossbar is 95 ps. 
+           The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+           Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+           25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+           to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+        </complete>
+        <complete name="resets" input="clb.reset" output="fle[9:0].reset">
+        </complete>
+        <complete name="sets" input="clb.set" output="fle[9:0].set">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+                 By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+                 then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+                 naive specification).
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define 36-bit multiplier begin -->
+    <pb_type name="mult_36">
+      <input name="a" num_pins="36"/>
+      <input name="b" num_pins="36"/>
+      <output name="out" num_pins="72"/>
+      <mode name="mult_36x36">
+        <pb_type name="mult_36x36_slice" num_pb="1">
+          <input name="A_cfg" num_pins="36"/>
+          <input name="B_cfg" num_pins="36"/>
+          <output name="OUT_cfg" num_pins="72"/>
+          <pb_type name="mult_36x36" blif_model=".subckt mult_36" num_pb="1">
+            <input name="A" num_pins="36"/>
+            <input name="B" num_pins="36"/>
+            <output name="Y" num_pins="72"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.A" out_port="mult_36x36.Y"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.B" out_port="mult_36x36.Y"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.A">
+            </direct>
+            <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.B">
+            </direct>
+            <direct name="out2out" input="mult_36x36.Y" output="mult_36x36_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
+		   to a 134 ps delay.
+				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
+              -->
+          <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+    <!-- Define single-mode dual-port memory begin -->
+    <pb_type name="memory">
+      <input name="waddr" num_pins="10"/>
+      <input name="raddr" num_pins="10"/>
+      <input name="data_in" num_pins="8"/>
+      <input name="wen" num_pins="1"/>
+      <input name="ren" num_pins="1"/>
+      <output name="data_out" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify the 1024x8=8Kbit memory block
+           Note: the delay numbers are extracted from VPR flagship XML without modification
+                 Should align to the process technology we using to create the 16K dual-port RAM
+        -->
+      <mode name="mem_1024x8_dp">
+        <pb_type name="mem_1024x8_dp" blif_model=".subckt dpram_1024x8" num_pb="1">
+          <input name="waddr" num_pins="10" port_class="address1"/>
+          <input name="raddr" num_pins="10" port_class="address2"/>
+          <input name="data_in" num_pins="8" port_class="data_in1"/>
+          <input name="wen" num_pins="1" port_class="write_en1"/>
+          <input name="ren" num_pins="1" port_class="write_en2"/>
+          <output name="data_out" num_pins="8" port_class="data_out1"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.waddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.raddr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.data_in" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.wen" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x8_dp.ren" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" port="mem_1024x8_dp.data_out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="waddress" input="memory.waddr" output="mem_1024x8_dp.waddr">
+            <delay_constant max="132e-12" in_port="memory.waddr" out_port="mem_1024x8_dp.waddr"/>
+          </direct>
+          <direct name="raddress" input="memory.raddr" output="mem_1024x8_dp.raddr">
+            <delay_constant max="132e-12" in_port="memory.raddr" out_port="mem_1024x8_dp.raddr"/>
+          </direct>
+          <direct name="data_input" input="memory.data_in" output="mem_1024x8_dp.data_in">
+            <delay_constant max="132e-12" in_port="memory.data_in" out_port="mem_1024x8_dp.data_in"/>
+          </direct>
+          <direct name="writeen" input="memory.wen" output="mem_1024x8_dp.wen">
+            <delay_constant max="132e-12" in_port="memory.wen" out_port="mem_1024x8_dp.wen"/>
+          </direct>
+          <direct name="readen" input="memory.ren" output="mem_1024x8_dp.ren">
+            <delay_constant max="132e-12" in_port="memory.ren" out_port="mem_1024x8_dp.ren"/>
+          </direct>
+          <direct name="dataout" input="mem_1024x8_dp.data_out" output="memory.data_out">
+            <delay_constant max="40e-12" in_port="mem_1024x8_dp.data_out" out_port="memory.data_out"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define single-mode dual-port memory end -->
+  </complexblocklist>
+</architecture>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_40nm.xml
@@ -234,7 +234,7 @@
   </tiles>
   <!-- ODIN II specific config ends -->
   <!-- Physical descriptions begin -->
-  <layout tileable="true" through_channel="false">
+  <layout tileable="true" through_channel="false" concat_pass_wire="true">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_chain_dpram8K_dsp36_fracff_40nm.xml
@@ -302,7 +302,7 @@
   </tiles>
   <!-- ODIN II specific config ends -->
   <!-- Physical descriptions begin -->
-  <layout tileable="true" through_channel="false">
+  <layout tileable="true" through_channel="false" concat_pass_wire="true">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>

--- a/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_40nm.xml
+++ b/openfpga_flow/vpr_arch/k6_frac_N10_tileable_adder_register_scan_chain_depop50_40nm.xml
@@ -146,7 +146,7 @@
   <!-- Apply tileable routing architecture.
        This is strongly recommended if you want to PnR large FPGA fabric
     -->
-  <layout tileable="true">
+  <layout tileable="true" concat_pass_wire="true">
     <auto_layout aspect_ratio="1.0">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <perimeter type="io" priority="100"/>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: #1249 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- As stated in the issue
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Upgrade VTR feature branch to the latest
- [x] Now tileable rr graph supports to allow OPIN to drive the routing tracks in all the sides in switch block. This will enhance the routability and reduce wirelength
- [x] Now tileable rr graph supports to drive the wire in the same direction (for the routing tracks that ends in a switch block). A new option ``concat_wire`` is added to the VPR architecture description.
- [x]  Now tileable rr graph supports to drive the wire in the same direction (for the routing tracks that pass in a switch block). A new option ``concat_pass_wire`` is added to the VPR architecture description.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.

**No impact on the existing architecture, the enhancement is enabled through an option in architecture file. In existing architectures, the bug reported in #1249 remains. Enable the option to remove bug.**
