### PR TITLE
Issue:1466 - Fix WL ordering in bitstream generation

### DIFF
--- a/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/write_text_fabric_bitstream.cpp
@@ -652,7 +652,7 @@ int write_fabric_bitstream_to_text_file(
         // bitstream
         status = fast_write_memory_bank_flatten_fabric_bitstream_to_text_file(
           fp, apply_fast_configuration, bit_value_to_skip, fabric_bitstream,
-          options.keep_dont_care_bits(), options.wl_decremental_order());
+          options.keep_dont_care_bits(), !options.wl_decremental_order());
 
       } else if (BLWL_PROTOCOL_FLATTEN == config_protocol.bl_protocol_type()) {
         status = write_memory_bank_flatten_fabric_bitstream_to_text_file(


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: [1466](https://github.com/lnis-uofu/OpenFPGA/issues/1466)
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
The option boolean was accidentally reverted (See issue to know which changes cause the reversion) 
>
> #### What does this pull request change?
Revert back the boolean to correct one

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [x] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
