### PR TITLE
Fix quicklogic tests by removing integrated quicklogic plugins code in yosys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,9 @@ if (OPENFPGA_WITH_YOSYS)
     else ()
         # run makefile provided, we pass-on the options to the local make file 
         add_custom_target(
-            yosys ALL 
+            yosys ALL
+            # add step to remove the 'built-in' quicklogic plugins code in yosys
+            COMMAND rm -rf techlibs/quicklogic
             COMMAND $(MAKE) config-gcc
             COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys


### PR DESCRIPTION

> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
Quicklogic tests fail because of the recent update in yosys which integrates the quicklogic plugins code into yosys itself, which then conflicts, because the same pass names used in the quicklogic plugins are also defined in yosys
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Currently, when we build yosys, the techlibs are automatically built.
With recent change in yosys, this includes the quicklogic techlibs which contain the integrated quicklogic plugins code.

> #### What does this pull request change?
This PR adds a step in the yosys build process in CMakeLists.txt to first delete the quicklogic techlibs from yosys sources.
This ensures that the yosys built will not contain the integrated quicklogic plugins code, and we can continue to use the combination of yosys so built + yosys-plugins separately built (which does contain the quicklogic plugins code as well)

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts
> - [x] Build Steps (CMakeLists.txt)

> ### Impact of the pull request
This PR moves OpenFPGA back to previous status, i.e. yosys build as before, and separate yosys-plugins build which contains the quicklogic plugin.
In the future, when the yosys upstream code is always guaranteed to contain up-to-date quicklogic plugins code, the quicklogic plugin may be removed from yosys-plugins, and will require a revisit at that time.

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
