### PR TITLE
Preserve escaped names

### DIFF
--- a/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_testbench_utils.cpp
@@ -116,6 +116,14 @@ void print_verilog_testbench_fpga_instance(
   fp << std::endl;
 }
 
+std::string escapeNames(const std::string& original) {
+  std::string result = original;
+  if (result.find("$") != std::string::npos) {
+    result = "\\" + result + " ";
+  }
+  return result;
+}
+
 /********************************************************************
  * Instanciate the input benchmark module
  *******************************************************************/
@@ -224,17 +232,18 @@ void print_verilog_testbench_benchmark_instance(
             fp << "~";
           }
 
-          fp << bus_group.pin_name(pin);
+          std::string escapedName = bus_group.pin_name(pin);
 
           /* For clock ports, skip postfix */
           if (clock_port_names.end() == std::find(clock_port_names.begin(),
                                                   clock_port_names.end(),
                                                   port_names[iport])) {
-            fp << input_port_postfix;
+            escapedName += input_port_postfix;
           } else if (include_clock_port_postfix) {
-            fp << input_port_postfix;
+            escapedName += input_port_postfix;
           }
-
+          escapedName = escapeNames(escapedName);
+          fp << escapedName;
           pin_counter++;
         }
         fp << "}";
@@ -249,16 +258,17 @@ void print_verilog_testbench_benchmark_instance(
             pin_constraints.net_default_value(port_names[iport])) {
           fp << "~";
         }
-
-        fp << port_names[iport];
+        std::string escapedName = port_names[iport];
         /* For clock ports, skip postfix */
         if (clock_port_names.end() == std::find(clock_port_names.begin(),
                                                 clock_port_names.end(),
                                                 port_names[iport])) {
-          fp << input_port_postfix;
+          escapedName += input_port_postfix;
         } else if (include_clock_port_postfix) {
-          fp << input_port_postfix;
+          escapedName += input_port_postfix;
         }
+        escapedName = escapeNames(escapedName); 
+        fp << escapedName;
       }
 
       if (true == use_explicit_port_map) {
@@ -286,12 +296,16 @@ void print_verilog_testbench_benchmark_instance(
           if (0 < pin_counter) {
             fp << ", ";
           }
-          fp << bus_group.pin_name(pin) << output_port_postfix;
+          std::string escapedName = bus_group.pin_name(pin) + output_port_postfix;
+          escapedName = escapeNames(escapedName); 
+          fp << escapedName;
           pin_counter++;
         }
         fp << "}";
       } else {
-        fp << port_names[iport] << output_port_postfix;
+        std::string escapedName = port_names[iport] + output_port_postfix;
+        escapedName = escapeNames(escapedName);
+        fp << escapedName;
       }
       if (true == use_explicit_port_map) {
         fp << ")";
@@ -867,7 +881,7 @@ void print_verilog_testbench_random_stimuli(
 
     /* TODO: find the clock inputs will be initialized later */
     if (AtomBlockType::INPAD == atom_ctx.nlist.block_type(atom_blk)) {
-      fp << "\t\t" << block_name + input_port_postfix << " <= 1'b0;"
+      fp << "\t\t" << escapeNames(block_name + input_port_postfix) << " <= 1'b0;"
          << std::endl;
     }
   }
@@ -951,7 +965,7 @@ void print_verilog_testbench_random_stimuli(
 
     /* TODO: find the clock inputs will be initialized later */
     if (AtomBlockType::INPAD == atom_ctx.nlist.block_type(atom_blk)) {
-      fp << "\t\t" << block_name + input_port_postfix << " <= $random;"
+      fp << "\t\t" << escapeNames(block_name + input_port_postfix) << " <= $random;"
          << std::endl;
     }
   }

--- a/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
@@ -533,10 +533,10 @@ std::string generate_verilog_port(
     } else if ((1 == port_info.get_width())) {
       size_str = "[" + std::to_string(port_info.get_lsb()) + "]";
     }
-    verilog_line = port_info.get_name() + size_str;
+    verilog_line = escapeNames(port_info.get_name()) + size_str;
   } else {
     verilog_line = VERILOG_PORT_TYPE_STRING[verilog_port_type];
-    verilog_line += " " + size_str + " " + port_info.get_name();
+    verilog_line += " " + size_str + " " + escapeNames(port_info.get_name());
   }
 
   return verilog_line;

--- a/openfpga/src/fpga_verilog/verilog_writer_utils.h
+++ b/openfpga/src/fpga_verilog/verilog_writer_utils.h
@@ -199,6 +199,8 @@ void print_verilog_netlist_include_header_file(
   const char* subckt_dir, const char* header_file_name,
   const bool& include_time_stamp);
 
+std::string escapeNames(const std::string& name);
+
 } /* end namespace openfpga */
 
 #endif


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
When writing out the Verilog testbench, openfpga writes illegal Verilog of the port identifiers coming from Yosys were originally escaped names, ie \$iopadmap$a .
Yosys creates those escaped names when using the iopad pass.

>
> #### What does this pull request change?
Restore the escaped names if necessary.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ X] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
