### PR TITLE
Fixed a critical bug in GSB XML writer which causes mismatches against netlist. Fixed typos in documentation

### DIFF
--- a/docs/source/manual/arch_lang/direct_interconnect.rst
+++ b/docs/source/manual/arch_lang/direct_interconnect.rst
@@ -92,7 +92,7 @@ In such scenario, the type ``part_of_cb`` is required.
 .. warning:: Restrictions may be applied when building the direct connections as part of a connection block. 
 
 Direct connections can be inside a tile or across two tiles. Currently, across more than two tiles are not supported!
-:numref:`fig_ecb_allowed_direct_connection`` illustrates the region (in red) where any input pin is allowed to be driven by any output pin.
+:numref:`fig_ecb_allowed_direct_connection` illustrates the region (in red) where any input pin is allowed to be driven by any output pin.
 
 .. _fig_ecb_allowed_direct_connection:
 
@@ -100,7 +100,7 @@ Direct connections can be inside a tile or across two tiles. Currently, across m
 
     Allowed connections inside a tile for enhanced connection block (see the highlighted region)
 
-:numref:`fig_ecb_allowed_direct_connection_inner_tile_example`` shows a few feedback connections which can be built inside connection blocks. Note that feedback connections are fully allowed between any pins on the same side of a programmable block.
+:numref:`fig_ecb_allowed_direct_connection_inner_tile_example` shows a few feedback connections which can be built inside connection blocks. Note that feedback connections are fully allowed between any pins on the same side of a programmable block.
 
 .. _fig_ecb_allowed_direct_connection_inner_tile_example:
 
@@ -118,7 +118,7 @@ For instance, VPR architecture defines feedback connections like:
     <direct name="feedback" from_pin="clb.O_top[1:1]" to_pin="clb.I_top[0:0]" x_offset="0" y_offset="0" z_offset="0"/>
   </directlist>
 
-:numref:`fig_ecb_allowed_direct_connection_inter_tile_example`` shows a few inter-tile connections which can be built inside connection blocks. Note that inter-tile connections are subjected to the restrictions depicted in :numref:`fig_ecb_allowed_direct_connection``
+:numref:`fig_ecb_allowed_direct_connection_inter_tile_example` shows a few inter-tile connections which can be built inside connection blocks. Note that inter-tile connections are subjected to the restrictions depicted in :numref:`fig_ecb_allowed_direct_connection`
 
 .. _fig_ecb_allowed_direct_connection_inter_tile_example:
 
@@ -126,7 +126,7 @@ For instance, VPR architecture defines feedback connections like:
 
     Example of connections across two tiles for enhanced connection block
 
-:numref:`fig_ecb_forbid_direct_connection_example`` illustrates some inner-tile and inter-tile connections which are not allowed. Note that feedback connections across different sides are restricted! 
+:numref:`fig_ecb_forbid_direct_connection_example` illustrates some inner-tile and inter-tile connections which are not allowed. Note that feedback connections across different sides are restricted! 
 
 .. _fig_ecb_forbid_direct_connection_example:
 

--- a/openfpga/src/annotation/write_xml_device_rr_gsb.cpp
+++ b/openfpga/src/annotation/write_xml_device_rr_gsb.cpp
@@ -166,7 +166,7 @@ static void write_rr_gsb_chan_connection_to_xml(
             fp << "\" node_id=\"" << size_t(driver_rr_node) << "\" grid_side=\""
                << grid_side.to_string() << "\" sb_module_pin_name=\""
                << generate_sb_module_grid_port_name(
-                    gsb_side, driver_node_side, vpr_device_grid,
+                    gsb_side, grid_side.get_side(), vpr_device_grid,
                     vpr_device_annotation, rr_graph, driver_rr_node);
           }
           fp << "\"/>" << std::endl;

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
@@ -1,132 +1,132 @@
 <rr_sb x="0" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="201" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="152" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="203" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="154" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="205" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="156" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="207" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="158" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="209" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="160" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="211" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="162" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="213" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="164" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="215" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="166" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="217" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="73" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="73" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="168" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="18" node_id="219" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="21" node_id="170" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="20" node_id="221" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="23" node_id="172" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="22" node_id="223" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="25" node_id="174" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="24" node_id="225" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="150" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANX side="right" index="0" node_id="149" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="25" node_id="226" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="151" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="202" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="153" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="204" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="155" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="206" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="157" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="208" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="159" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="210" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="161" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="212" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="163" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="214" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="165" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="216" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="18" node_id="167" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="218" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="20" node_id="169" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="220" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="22" node_id="171" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="21" node_id="222" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="24" node_id="173" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="23" node_id="224" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
@@ -1,130 +1,130 @@
 <rr_sb x="0" y="1" num_sides="4">
 	<CHANX side="right" index="0" node_id="175" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="22" node_id="223" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="177" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="20" node_id="221" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="179" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="219" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="181" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="217" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="183" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="215" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="185" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="213" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="187" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="211" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="189" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="209" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="191" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="70" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="70" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="207" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="18" node_id="193" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="205" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="20" node_id="195" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="203" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="22" node_id="197" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="201" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="24" node_id="199" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="24" node_id="225" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="202" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="23" node_id="198" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="73" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="73" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="204" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="21" node_id="196" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="206" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="19" node_id="194" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="208" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="192" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="210" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="15" node_id="190" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="212" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="13" node_id="188" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="214" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="11" node_id="186" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="216" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="184" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="218" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="7" node_id="182" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="220" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="5" node_id="180" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="21" node_id="222" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="3" node_id="178" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="23" node_id="224" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="176" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="25" node_id="226" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="25" node_id="200" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
@@ -1,132 +1,132 @@
 <rr_sb x="1" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="227" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="71" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
-		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="71" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="149" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="229" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="24" node_id="173" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="231" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="22" node_id="171" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="233" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="20" node_id="169" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="235" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="167" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="237" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="165" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="239" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="163" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="241" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="161" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="243" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="159" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="18" node_id="245" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="157" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="20" node_id="247" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="155" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="22" node_id="249" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="153" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="24" node_id="251" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="151" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANX side="left" index="1" node_id="150" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="228" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="152" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="25" node_id="252" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="154" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="23" node_id="250" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="156" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="21" node_id="248" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="158" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="246" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="160" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="244" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="162" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="242" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="164" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="240" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="166" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="238" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="168" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="236" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="21" node_id="170" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="234" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="23" node_id="172" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="232" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="25" node_id="174" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="230" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_1x1/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
@@ -1,130 +1,130 @@
 <rr_sb x="1" y="1" num_sides="4">
 	<CHANY side="bottom" index="1" node_id="228" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="177" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="230" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="179" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="232" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="181" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="234" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="183" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="236" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="185" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="238" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="187" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="240" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="189" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="242" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="191" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="244" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="71" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="71" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="193" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="246" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="20" node_id="195" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="21" node_id="248" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="22" node_id="197" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="23" node_id="250" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="24" node_id="199" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="25" node_id="252" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="175" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANX side="left" index="1" node_id="176" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="24" node_id="251" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="178" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="0" node_id="227" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="180" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="2" node_id="229" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="182" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="4" node_id="231" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="184" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="6" node_id="233" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="186" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="8" node_id="235" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="188" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="10" node_id="237" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="190" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="12" node_id="239" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="192" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="14" node_id="241" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="70" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="70" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="194" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="16" node_id="243" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="21" node_id="196" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="18" node_id="245" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="23" node_id="198" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="20" node_id="247" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="25" node_id="200" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="22" node_id="249" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
@@ -1,38 +1,38 @@
 <rr_sb x="0" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="1038" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="144" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="144" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="851" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="1040" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="145" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="145" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="853" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="1042" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="146" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="146" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="855" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="1044" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="147" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="147" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="857" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1046" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="148" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="148" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="859" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="1048" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="149" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="149" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="861" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="1050" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="150" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="150" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="863" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="1052" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="7" node_id="151" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="151" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="865" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1054" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="8" node_id="169" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="169" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="867" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="18" node_id="1056" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chany_top_out">
@@ -40,39 +40,39 @@
 	</CHANY>
 	<CHANX side="right" index="0" node_id="848" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="1057" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="168" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="168" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="850" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1039" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="852" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1041" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="854" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="1043" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="856" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="1045" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="858" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="1047" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="860" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="1049" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="862" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="1051" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="864" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="1053" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="18" node_id="866" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="1055" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="0" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="1058" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="292" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="295" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="298" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="292" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="295" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="298" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="889" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="895" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="901" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1042" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1060" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="293" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="296" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="299" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="293" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="296" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="299" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="891" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="897" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="903" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -39,9 +39,9 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1050" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1062" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="294" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="297" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="317" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="294" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="297" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="317" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="887" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="893" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="899" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -53,12 +53,12 @@
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1054" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANX side="right" index="0" node_id="886" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="316" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="316" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="888" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1041" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="1059" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="166" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="166" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="890" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1043" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -102,9 +102,9 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="889" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="895" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="901" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="169" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="146" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="149" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="169" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="146" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="149" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1041" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1041" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -122,9 +122,9 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="893" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="899" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="905" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="144" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="147" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="150" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="144" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="147" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="150" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="1049" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="1049" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -141,9 +141,9 @@
 		<driver_node type="CHANX" side="right" index="5" node_id="891" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="897" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="903" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="145" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="148" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="151" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="145" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="148" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="151" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="1057" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="1057" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__2_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="0" y="2" num_sides="4">
 	<CHANY side="top" index="0" node_id="1064" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="440" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="443" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="446" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="440" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="443" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="446" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="927" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="933" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="939" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1040" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1066" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="441" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="444" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="447" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="441" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="444" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="447" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="929" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="935" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="941" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -39,9 +39,9 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1048" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1068" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="442" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="445" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="465" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="442" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="445" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="465" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="925" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="931" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="937" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -53,12 +53,12 @@
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1062" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANX side="right" index="0" node_id="924" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="464" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="464" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="926" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1043" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="1065" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="314" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="314" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="928" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1045" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -102,9 +102,9 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="927" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="933" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="939" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="317" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="294" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="297" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="317" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="294" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="297" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1043" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1043" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -122,9 +122,9 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="931" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="937" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="943" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="292" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="295" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="298" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="292" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="295" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="298" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="1051" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="1051" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -141,9 +141,9 @@
 		<driver_node type="CHANX" side="right" index="5" node_id="929" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="935" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="941" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="293" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="296" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="299" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="293" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="296" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="299" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="1063" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="1063" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__3_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__3_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="0" y="3" num_sides="4">
 	<CHANY side="top" index="0" node_id="1070" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="588" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="591" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="594" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="588" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="591" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="594" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="965" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="971" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="977" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1038" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1072" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="589" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="592" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="595" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="589" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="592" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="595" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="967" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="973" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="979" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -39,9 +39,9 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1046" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1074" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="590" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="593" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="613" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="590" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="593" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="613" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="963" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="969" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="975" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -53,12 +53,12 @@
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1068" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANX side="right" index="0" node_id="962" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="612" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="612" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="964" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1045" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="1071" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="462" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="462" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="966" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1059" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -102,9 +102,9 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="965" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="971" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="977" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="465" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="442" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="445" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="465" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="442" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="445" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1045" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1045" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -122,9 +122,9 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="969" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="975" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="981" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="440" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="443" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="446" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="440" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="443" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="446" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="1053" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="1053" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -141,9 +141,9 @@
 		<driver_node type="CHANX" side="right" index="5" node_id="967" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="973" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="979" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="441" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="444" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="447" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="441" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="444" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="447" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="1069" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="1069" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__4_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_0__4_.xml
@@ -1,38 +1,38 @@
 <rr_sb x="0" y="4" num_sides="4">
 	<CHANX side="right" index="0" node_id="1000" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="736" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="736" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1074" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="1002" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="737" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="737" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1046" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="1004" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="738" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="738" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1060" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="1006" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="3" node_id="739" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="739" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1066" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="1008" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="4" node_id="740" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="740" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1072" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="1010" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="5" node_id="741" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="741" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1038" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="1012" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="6" node_id="742" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="742" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1058" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="1014" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="7" node_id="743" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="743" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1064" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="1016" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="8" node_id="610" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="610" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1070" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="18" node_id="1018" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_right_out">
@@ -40,39 +40,39 @@
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="1045" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="1017" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="613" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="613" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1059" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="15" node_id="1015" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="588" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="588" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="1065" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="13" node_id="1013" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="589" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="589" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="1071" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="11" node_id="1011" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="590" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="590" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="1053" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="1009" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="591" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="591" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="1061" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="7" node_id="1007" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="592" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="592" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="1067" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="5" node_id="1005" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="593" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="593" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="1073" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="3" node_id="1003" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="594" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="594" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="1069" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="1001" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="595" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="595" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="1075" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="19" node_id="1019" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
@@ -1,13 +1,13 @@
 <rr_sb x="1" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="1076" segment_id="0" segment_name="L4" mux_size="5" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="167" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="167" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="853" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="871" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="848" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="854" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="1078" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="190" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="190" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="855" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="873" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
@@ -45,9 +45,9 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1081" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="1087" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1093" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="189" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="50" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="53" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="189" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="50" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="53" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="848" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="856" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="864" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -66,9 +66,9 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1083" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1089" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1095" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="48" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="51" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="54" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="48" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="51" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="54" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="850" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="858" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -85,9 +85,9 @@
 		<driver_node type="CHANY" side="top" index="3" node_id="1079" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1085" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="15" node_id="1091" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="49" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="52" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="55" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="49" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="52" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="55" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="852" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="860" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -102,9 +102,9 @@
 		<driver_node type="CHANX" side="right" index="1" node_id="851" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="859" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="867" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="168" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="168" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="851" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="851" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -121,9 +121,9 @@
 		<driver_node type="CHANY" side="top" index="17" node_id="1093" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="853" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="861" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="859" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="859" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -140,9 +140,9 @@
 		<driver_node type="CHANY" side="top" index="15" node_id="1091" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="855" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="863" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="867" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="867" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="1" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="1096" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="315" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="315" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="891" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="899" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="909" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1080" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1098" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="338" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="338" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="893" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="901" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="911" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1083" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1091" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1101" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="337" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="337" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1078" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1086" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1090" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1097" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1087" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1095" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="187" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="187" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1076" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1082" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1084" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="891" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="899" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="909" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="190" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="190" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="888" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="896" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="900" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="907" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="897" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="905" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="167" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="167" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="890" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="898" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="904" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1080" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1088" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1094" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="316" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="316" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="889" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="889" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1082" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1084" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1092" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="166" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="166" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="897" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="897" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__2_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="1" y="2" num_sides="4">
 	<CHANY side="top" index="0" node_id="1102" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="463" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="463" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="929" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="937" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="947" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1078" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1104" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="486" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="486" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="931" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="939" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="949" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1097" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1099" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1107" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="485" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="485" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1076" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1084" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1088" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1103" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1089" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1101" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="335" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="335" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1096" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1080" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1098" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="929" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="937" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="947" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="338" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="338" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="926" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="934" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="938" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="945" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="935" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="943" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="315" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="315" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="928" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="936" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="942" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1078" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1086" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1092" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="464" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="464" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="927" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="927" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1080" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1098" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1100" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="314" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="314" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="935" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="935" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__3_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__3_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="1" y="3" num_sides="4">
 	<CHANY side="top" index="0" node_id="1108" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="611" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="611" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="967" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="975" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="985" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1076" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1110" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="634" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="634" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="969" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="977" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="987" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1103" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1105" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1113" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="633" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="633" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1096" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1098" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1086" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1109" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1091" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1107" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="483" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="483" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1102" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1078" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1104" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="967" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="975" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="985" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="486" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="486" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="964" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="972" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="976" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="983" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="973" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="981" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="463" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="463" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="966" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="974" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="980" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1076" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1084" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1100" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="612" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="612" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="965" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="965" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1078" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1104" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1106" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="462" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="462" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="973" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="973" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__4_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_1__4_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="1" y="4" num_sides="4">
 	<CHANX side="right" index="0" node_id="1020" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="768" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="771" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="774" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="768" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="771" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="774" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1102" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1110" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1084" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANX" side="left" index="4" node_id="1004" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="1022" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="769" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="772" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="775" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="769" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="772" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="775" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1108" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1076" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1098" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -40,9 +40,9 @@
 		<driver_node type="CHANX" side="left" index="12" node_id="1012" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="1024" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="770" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="773" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="631" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="770" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="773" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="631" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1096" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1104" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1112" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -53,12 +53,12 @@
 		<driver_node type="CHANX" side="left" index="16" node_id="1016" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="1083" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="634" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="634" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="1002" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="1014" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1097" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="611" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="611" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="1004" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="1018" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
@@ -101,9 +101,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1096" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1104" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1112" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="736" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="739" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="742" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="736" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="739" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="742" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="1003" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="1003" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -121,9 +121,9 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1076" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1098" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1106" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="737" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="740" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="743" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="737" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="740" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="743" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="1011" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="1011" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -140,9 +140,9 @@
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1102" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1110" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1084" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="738" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="741" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="610" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="738" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="741" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="610" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="1019" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="1019" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__0_.xml
@@ -1,13 +1,13 @@
 <rr_sb x="2" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="1114" segment_id="0" segment_name="L4" mux_size="5" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="188" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="188" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="855" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="877" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="868" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="852" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="1116" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="211" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="211" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="869" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="879" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
@@ -45,9 +45,9 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1119" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="1125" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1131" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="210" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="82" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="85" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="210" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="82" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="85" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="868" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="870" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="872" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -66,9 +66,9 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1121" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1127" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1133" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="80" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="83" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="86" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="80" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="83" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="86" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="848" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="856" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -85,9 +85,9 @@
 		<driver_node type="CHANY" side="top" index="3" node_id="1117" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1123" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="15" node_id="1129" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="81" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="84" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="87" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="81" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="84" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="87" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="850" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="858" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -102,9 +102,9 @@
 		<driver_node type="CHANX" side="right" index="1" node_id="853" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="861" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="873" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="189" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="50" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="53" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="189" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="50" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="53" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="853" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="853" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -121,9 +121,9 @@
 		<driver_node type="CHANY" side="top" index="17" node_id="1131" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="855" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="863" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="48" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="51" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="54" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="48" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="51" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="54" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="861" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="861" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -140,9 +140,9 @@
 		<driver_node type="CHANY" side="top" index="15" node_id="1129" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="869" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="871" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="49" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="52" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="55" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="49" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="52" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="55" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="873" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="873" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__1_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="2" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="1134" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="336" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="336" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="893" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="901" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="915" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1118" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1136" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="359" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="359" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="907" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="909" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="917" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1121" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1129" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1139" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="358" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="358" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1116" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1124" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1128" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1135" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1125" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1133" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="208" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="208" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1114" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1120" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1122" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="893" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="901" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="915" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="211" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="211" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="886" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="894" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="898" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="913" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="899" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="911" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="188" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="188" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="888" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="896" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="902" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1118" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1126" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1132" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="337" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="337" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="891" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="891" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1120" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1122" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1130" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="187" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="187" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="899" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="899" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__2_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="2" y="2" num_sides="4">
 	<CHANY side="top" index="0" node_id="1140" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="484" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="484" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="931" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="939" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="953" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1116" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1142" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="507" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="507" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="945" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="947" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="955" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1135" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1137" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1145" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="506" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="506" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1114" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1122" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1126" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1141" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1127" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1139" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="356" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="356" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1134" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1118" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1136" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="931" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="939" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="953" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="359" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="359" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="924" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="932" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="936" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="951" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="937" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="949" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="336" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="336" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="926" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="934" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="940" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1116" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1124" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1130" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="485" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="485" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="929" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="929" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1118" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1136" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1138" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="335" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="335" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="937" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="937" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__3_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__3_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="2" y="3" num_sides="4">
 	<CHANY side="top" index="0" node_id="1146" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="632" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="632" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="969" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="977" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="991" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1114" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1148" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="655" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="655" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="983" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="985" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="993" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1141" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1143" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1151" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="654" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="654" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1134" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1136" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1124" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1147" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1129" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1145" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="504" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="504" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1140" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1116" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1142" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="969" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="977" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="991" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="507" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="507" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="962" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="970" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="974" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="989" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="975" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="987" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="484" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="484" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="964" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="972" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="978" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1114" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1122" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1138" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="633" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="633" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="967" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="967" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1116" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1142" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1144" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="483" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="483" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="975" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="975" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__4_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_2__4_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="2" y="4" num_sides="4">
 	<CHANX side="right" index="0" node_id="1026" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="800" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="803" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="806" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="800" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="803" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="806" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1140" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1148" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1122" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANX" side="left" index="4" node_id="1002" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="1028" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="801" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="804" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="807" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="801" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="804" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="807" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1146" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1114" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1136" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -40,9 +40,9 @@
 		<driver_node type="CHANX" side="left" index="12" node_id="1010" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="1030" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="802" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="805" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="652" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="802" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="805" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="652" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1134" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1142" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1150" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -53,12 +53,12 @@
 		<driver_node type="CHANX" side="left" index="16" node_id="1024" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="1121" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="655" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="655" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="1000" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="1012" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1135" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="632" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="632" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="1002" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="1016" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
@@ -101,9 +101,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1134" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1142" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1150" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="768" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="771" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="774" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="768" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="771" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="774" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="1005" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="1005" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -121,9 +121,9 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1114" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1136" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1144" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="769" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="772" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="775" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="769" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="772" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="775" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="1013" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="1013" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -140,9 +140,9 @@
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1140" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1148" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1122" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="770" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="773" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="631" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="770" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="773" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="631" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="1025" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="1025" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__0_.xml
@@ -1,13 +1,13 @@
 <rr_sb x="3" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="1152" segment_id="0" segment_name="L4" mux_size="5" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="209" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="209" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="869" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="883" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="874" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="850" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="1154" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="232" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="232" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="875" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="885" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
@@ -45,9 +45,9 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1157" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="1163" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1169" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="231" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="114" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="117" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="231" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="114" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="117" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="874" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="876" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="878" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -66,9 +66,9 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1159" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1165" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1171" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="112" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="115" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="118" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="112" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="115" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="118" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="868" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="870" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -85,9 +85,9 @@
 		<driver_node type="CHANY" side="top" index="3" node_id="1155" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1161" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="15" node_id="1167" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="113" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="116" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="119" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="113" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="116" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="119" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="848" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="856" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -102,9 +102,9 @@
 		<driver_node type="CHANX" side="right" index="1" node_id="855" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="863" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="879" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="210" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="82" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="85" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="210" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="82" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="85" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="855" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="855" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -121,9 +121,9 @@
 		<driver_node type="CHANY" side="top" index="17" node_id="1169" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="869" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="871" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="80" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="83" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="86" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="80" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="83" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="86" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="863" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="863" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -140,9 +140,9 @@
 		<driver_node type="CHANY" side="top" index="15" node_id="1167" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="875" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="877" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="81" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="84" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="87" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="81" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="84" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="87" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="879" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="879" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__1_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="3" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="1172" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="357" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="357" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="907" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="909" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="921" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1156" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1174" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="380" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="380" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="913" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="915" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="923" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1159" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1167" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1177" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="379" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="379" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1154" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1162" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1166" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1173" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1163" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1171" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="229" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="229" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1152" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1158" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1160" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="907" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="909" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="921" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="232" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="232" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="906" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="908" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="896" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="919" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="901" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="917" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="209" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="209" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="886" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="894" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="910" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1156" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1164" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1170" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="358" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="358" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="893" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="893" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1158" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1160" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1168" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="208" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="208" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="901" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="901" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__2_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="3" y="2" num_sides="4">
 	<CHANY side="top" index="0" node_id="1178" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="505" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="505" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="945" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="947" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="959" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1154" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1180" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="528" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="528" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="951" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="953" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="961" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1173" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1175" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1183" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="527" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="527" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1152" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1160" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1164" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1179" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1165" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1177" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="377" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="377" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1172" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1156" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1174" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="945" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="947" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="959" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="380" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="380" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="944" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="946" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="934" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="957" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="939" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="955" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="357" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="357" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="924" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="932" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="948" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1154" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1162" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1168" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="506" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="506" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="931" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="931" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1156" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1174" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1176" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="356" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="356" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="939" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="939" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__3_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__3_.xml
@@ -1,6 +1,6 @@
 <rr_sb x="3" y="3" num_sides="4">
 	<CHANY side="top" index="0" node_id="1184" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="653" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="653" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="983" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="985" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="997" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -22,7 +22,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1152" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1186" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="676" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="676" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="989" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="991" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="999" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -59,7 +59,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="1179" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1181" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="1189" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="675" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="675" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1172" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1174" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1162" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -81,7 +81,7 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="1185" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1167" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1183" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="525" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="525" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1178" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1154" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1180" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -118,7 +118,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="983" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="985" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="997" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="528" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="528" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="982" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="984" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="972" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -139,7 +139,7 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="995" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="977" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="993" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="505" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="505" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="962" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="970" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="986" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -178,7 +178,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1152" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1160" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1176" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="654" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="654" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="969" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="969" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -199,7 +199,7 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1154" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1180" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1182" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="504" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="504" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="977" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="977" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__4_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_3__4_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="3" y="4" num_sides="4">
 	<CHANX side="right" index="0" node_id="1032" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="832" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="835" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="838" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="832" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="835" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="838" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1178" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1186" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1160" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANX" side="left" index="4" node_id="1000" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="1034" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="833" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="836" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="839" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="833" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="836" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="839" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1184" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1152" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1174" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -40,9 +40,9 @@
 		<driver_node type="CHANX" side="left" index="12" node_id="1008" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="1036" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="834" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="837" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="673" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="834" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="837" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="673" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1172" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1180" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1188" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -53,12 +53,12 @@
 		<driver_node type="CHANX" side="left" index="16" node_id="1030" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="1159" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="676" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="676" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="1020" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="1010" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1173" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="653" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="653" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="1000" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="1024" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
@@ -101,9 +101,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1172" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1180" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1188" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="800" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="803" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="806" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="800" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="803" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="806" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="1007" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="1007" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -121,9 +121,9 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1152" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1174" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1182" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="801" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="804" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="807" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="801" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="804" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="807" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="1015" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="1015" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -140,9 +140,9 @@
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1178" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1186" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1160" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="802" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="805" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="652" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="802" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="805" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="652" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="1031" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="1031" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__0_.xml
@@ -1,38 +1,38 @@
 <rr_sb x="4" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="1190" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="230" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="230" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="880" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="1192" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="260" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="260" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="878" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="1194" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="261" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="261" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="884" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="1196" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="262" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="262" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="856" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1198" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="263" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="263" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="870" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="1200" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="264" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="264" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="876" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="1202" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="265" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="265" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="882" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="1204" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="7" node_id="266" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="266" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="848" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1206" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="8" node_id="267" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="267" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="868" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="18" node_id="1208" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chany_top_out">
@@ -40,39 +40,39 @@
 	</CHANY>
 	<CHANX side="left" index="1" node_id="855" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1191" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="231" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="231" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="869" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="1209" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="112" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="112" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="875" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="1207" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="113" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="113" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="881" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="1205" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="114" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="114" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="863" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="1203" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="115" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="115" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="871" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="1201" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="116" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="116" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="877" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="1199" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="117" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="117" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="883" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="1197" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="118" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="118" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="879" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="1195" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="119" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="119" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="885" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1193" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__1_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="4" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="1210" segment_id="0" segment_name="L4" mux_size="10" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="378" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="410" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="413" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="378" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="410" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="413" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1190" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1198" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1206" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -21,9 +21,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1194" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1212" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="408" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="411" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="414" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="408" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="411" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="414" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1192" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1200" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="906" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -40,9 +40,9 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1202" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1214" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="409" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="412" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="415" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="409" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="412" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="415" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1194" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1202" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="912" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -56,9 +56,9 @@
 		<driver_node type="CHANY" side="top" index="1" node_id="1193" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1201" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1209" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="260" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="263" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="266" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="260" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="263" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="266" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="912" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="920" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="894" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -75,9 +75,9 @@
 	<CHANY side="bottom" index="9" node_id="1199" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1195" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="1203" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="261" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="264" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="267" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="261" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="264" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="267" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="906" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="914" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="922" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -94,9 +94,9 @@
 	<CHANY side="bottom" index="17" node_id="1207" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="1197" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1205" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="262" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="265" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="230" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="262" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="265" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="230" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="918" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="886" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="908" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -108,12 +108,12 @@
 	<CHANX side="left" index="1" node_id="893" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1193" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="1211" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="379" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="379" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="907" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1190" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1196" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="229" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="229" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="913" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1192" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__2_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="4" y="2" num_sides="4">
 	<CHANY side="top" index="0" node_id="1216" segment_id="0" segment_name="L4" mux_size="10" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="526" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="558" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="561" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="526" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="558" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="561" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1210" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1212" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1214" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -21,9 +21,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1192" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1218" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="556" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="559" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="562" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="556" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="559" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="562" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1190" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1198" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="944" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -40,9 +40,9 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1200" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1220" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="557" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="560" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="563" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="557" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="560" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="563" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1192" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1200" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="950" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -56,9 +56,9 @@
 		<driver_node type="CHANY" side="top" index="1" node_id="1195" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1203" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1215" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="408" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="411" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="414" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="408" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="411" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="414" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="950" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="958" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="932" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -75,9 +75,9 @@
 	<CHANY side="bottom" index="9" node_id="1201" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1197" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="1205" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="409" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="412" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="415" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="409" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="412" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="415" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="944" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="952" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="960" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -94,9 +94,9 @@
 	<CHANY side="bottom" index="17" node_id="1209" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="1211" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1213" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="410" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="413" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="378" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="410" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="413" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="378" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="956" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="924" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="946" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -108,12 +108,12 @@
 	<CHANX side="left" index="1" node_id="931" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1195" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="1217" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="527" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="527" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="945" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1210" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1194" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="377" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="377" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="951" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1190" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__3_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__3_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="4" y="3" num_sides="4">
 	<CHANY side="top" index="0" node_id="1222" segment_id="0" segment_name="L4" mux_size="10" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="674" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="706" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="709" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="674" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="706" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="709" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1216" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1218" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1220" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -21,9 +21,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1190" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="1224" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="704" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="707" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="710" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="704" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="707" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="710" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1210" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1212" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="982" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -40,9 +40,9 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1198" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="1226" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="705" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="708" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="711" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="705" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="708" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="711" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1190" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1198" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="988" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -56,9 +56,9 @@
 		<driver_node type="CHANY" side="top" index="1" node_id="1197" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="1205" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="1221" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="556" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="559" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="562" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="556" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="559" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="562" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="988" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="996" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="970" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -75,9 +75,9 @@
 	<CHANY side="bottom" index="9" node_id="1203" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="1211" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="1213" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="557" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="560" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="563" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="557" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="560" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="563" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="982" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="990" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="998" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -94,9 +94,9 @@
 	<CHANY side="bottom" index="17" node_id="1215" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="1217" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="1219" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="558" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="561" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="526" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="558" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="561" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="526" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="994" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="962" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="984" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -108,12 +108,12 @@
 	<CHANX side="left" index="1" node_id="969" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="1197" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="1223" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="675" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="675" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="983" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1216" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1192" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="525" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="525" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="989" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1210" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__4_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/device_4x4/golden_outputs_no_time_stamp/gsb_xml/sb_4__4_.xml
@@ -1,38 +1,38 @@
 <rr_sb x="4" y="4" num_sides="4">
 	<CHANY side="bottom" index="1" node_id="1197" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="704" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="704" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="1026" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="1211" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="705" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="705" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="1020" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="1217" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="2" node_id="706" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="706" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="1000" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="1223" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="3" node_id="707" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="707" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="1034" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="1205" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="4" node_id="708" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="708" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="1028" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="1213" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="5" node_id="709" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="709" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="1022" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="1219" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="6" node_id="710" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="710" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="1008" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="1225" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="7" node_id="711" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="711" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="1036" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="1221" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="8" node_id="674" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="674" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="1030" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="1227" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chany_bottom_out">
@@ -40,39 +40,39 @@
 	</CHANY>
 	<CHANX side="left" index="1" node_id="1007" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="18" node_id="1220" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="832" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="832" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="1021" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="0" node_id="1222" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="833" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="833" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="1027" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="2" node_id="1216" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="834" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="834" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="1033" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="4" node_id="1210" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="835" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="835" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="1015" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="6" node_id="1190" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="836" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="836" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="1023" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="8" node_id="1224" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="837" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="837" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="1029" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="10" node_id="1218" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="838" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="838" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="1035" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="12" node_id="1212" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="839" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="839" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="1031" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="14" node_id="1198" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="673" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="673" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="1037" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="16" node_id="1226" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
@@ -1,132 +1,132 @@
 <rr_sb x="0" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="201" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="152" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="203" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="154" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="205" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="156" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="207" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="158" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="209" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="160" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="211" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="162" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="213" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="164" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="215" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="49" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="55" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="166" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="217" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="73" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="50" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="73" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="168" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="18" node_id="219" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="51" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="21" node_id="170" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="20" node_id="221" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="52" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="23" node_id="172" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="22" node_id="223" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="53" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="25" node_id="174" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="24" node_id="225" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="48" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="54" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="150" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANX side="right" index="0" node_id="149" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="25" node_id="226" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="151" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="202" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="153" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="204" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="155" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="206" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="157" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="208" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="159" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="210" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="161" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="212" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="163" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="214" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="165" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="216" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="18" node_id="167" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="218" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="20" node_id="169" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="220" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="22" node_id="171" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="21" node_id="222" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="24" node_id="173" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="23" node_id="224" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
@@ -1,130 +1,130 @@
 <rr_sb x="0" y="1" num_sides="4">
 	<CHANX side="right" index="0" node_id="175" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="22" node_id="223" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="177" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="20" node_id="221" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="179" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="219" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="181" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="217" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="183" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="215" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="185" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="213" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="187" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="211" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="189" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="209" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="191" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="70" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="70" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="207" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="18" node_id="193" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="205" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="20" node_id="195" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="203" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="22" node_id="197" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="201" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="24" node_id="199" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="24" node_id="225" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="202" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="23" node_id="198" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="73" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="73" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="204" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="21" node_id="196" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="206" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="19" node_id="194" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="208" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="192" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="210" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="15" node_id="190" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="212" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="13" node_id="188" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="214" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="11" node_id="186" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="216" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="184" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="48" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="54" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="218" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="7" node_id="182" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="49" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="55" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="220" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="5" node_id="180" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="50" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="21" node_id="222" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="3" node_id="178" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="51" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="23" node_id="224" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="176" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="52" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="25" node_id="226" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="25" node_id="200" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="53" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
@@ -1,132 +1,132 @@
 <rr_sb x="1" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="227" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="71" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
-		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="71" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="149" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="229" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="24" node_id="173" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="231" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="22" node_id="171" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="233" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="20" node_id="169" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="235" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="167" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="237" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="165" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="239" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="163" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="241" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="101" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="107" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="161" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="243" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="102" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="108" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="159" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="18" node_id="245" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="103" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="157" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="20" node_id="247" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="104" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="155" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="22" node_id="249" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="105" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="153" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="24" node_id="251" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="106" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="151" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANX side="left" index="1" node_id="150" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="228" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="152" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="25" node_id="252" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="154" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="23" node_id="250" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="156" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="21" node_id="248" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="158" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="246" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="160" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="244" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="162" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="242" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="164" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="240" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="166" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="238" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="168" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="236" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="21" node_id="170" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="234" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="23" node_id="172" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="232" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="25" node_id="174" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="230" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="72" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/dump_waveform/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
@@ -1,130 +1,130 @@
 <rr_sb x="1" y="1" num_sides="4">
 	<CHANY side="bottom" index="1" node_id="228" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="177" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="230" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="179" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="232" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="181" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="234" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="183" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="236" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="185" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="238" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="187" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="240" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="189" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="242" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="102" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="108" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="191" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="244" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="71" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="103" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="71" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="193" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="246" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="104" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="20" node_id="195" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="21" node_id="248" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="105" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="22" node_id="197" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="23" node_id="250" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="106" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="24" node_id="199" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="25" node_id="252" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="101" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="107" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="175" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANX side="left" index="1" node_id="176" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="24" node_id="251" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="178" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="0" node_id="227" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="180" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="2" node_id="229" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="182" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="4" node_id="231" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="184" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="6" node_id="233" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="186" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="8" node_id="235" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="188" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="10" node_id="237" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="190" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="12" node_id="239" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="134" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="140" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="192" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="14" node_id="241" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="70" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="135" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="70" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_O_2_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="194" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="16" node_id="243" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="136" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="21" node_id="196" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="18" node_id="245" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="137" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="23" node_id="198" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="20" node_id="247" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="138" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="25" node_id="200" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="22" node_id="249" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="133" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="139" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_0__0_.xml
@@ -1,34 +1,34 @@
 <rr_sb x="0" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="474" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="80" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="80" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="399" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="476" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="81" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="81" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="401" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="478" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="82" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="82" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="403" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="480" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="83" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="83" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="405" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="482" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="84" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="84" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="407" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="484" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="85" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="85" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="409" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="486" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="86" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="86" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="411" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="488" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="7" node_id="87" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="87" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="413" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="490" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chany_top_out">
@@ -39,44 +39,44 @@
 	</CHANY>
 	<CHANX side="right" index="0" node_id="396" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="493" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="112" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
-		<driver_node type="OPIN" side="right" index="10" node_id="22" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="112" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="right" index="10" node_id="22" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="398" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="475" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="113" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
-		<driver_node type="OPIN" side="right" index="11" node_id="23" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="113" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="right" index="11" node_id="23" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="400" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="477" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="114" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="114" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="402" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="479" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="115" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="115" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="404" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="481" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="16" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="16" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="406" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="483" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="17" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="17" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="408" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="485" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="18" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="18" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="410" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="487" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="19" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="19" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="412" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="489" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="20" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="20" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="right" index="18" node_id="414" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="491" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="9" node_id="21" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="9" node_id="21" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_0__1_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="0" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="494" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="214" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="217" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="220" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="214" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="217" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="220" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="425" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="431" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="437" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="478" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="496" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="215" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="218" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="221" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="215" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="218" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="221" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="427" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="433" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="439" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -39,8 +39,8 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="486" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="498" segment_id="0" segment_name="L4" mux_size="8" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="216" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="219" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="216" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="219" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="423" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="429" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="435" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -53,25 +53,25 @@
 	</CHANY>
 	<CHANX side="right" index="0" node_id="422" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="477" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="246" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="246" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="474" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="424" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="479" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="495" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="247" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="247" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="476" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="426" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="481" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="15" node_id="497" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="248" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="248" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="478" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="428" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_right_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="485" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="499" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="249" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="249" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="482" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="430" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
@@ -103,9 +103,9 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="425" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="431" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="437" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="80" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="83" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="86" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="80" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="83" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="86" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="477" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="477" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -123,9 +123,9 @@
 		<driver_node type="CHANX" side="right" index="7" node_id="429" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="435" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="441" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="81" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="84" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="87" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="81" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="84" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="87" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="485" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="485" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
@@ -142,8 +142,8 @@
 		<driver_node type="CHANX" side="right" index="5" node_id="427" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="433" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="439" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="82" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="85" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="82" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="85" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="493" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="493" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_0__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_0__2_.xml
@@ -1,34 +1,34 @@
 <rr_sb x="0" y="2" num_sides="4">
 	<CHANX side="right" index="0" node_id="448" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="348" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="348" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="498" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="2" node_id="450" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="349" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="349" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="486" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="4" node_id="452" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="350" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="350" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="484" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="6" node_id="454" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="3" node_id="351" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="351" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="482" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="456" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="4" node_id="352" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="352" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="496" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="10" node_id="458" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="5" node_id="353" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="353" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="478" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="12" node_id="460" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="6" node_id="354" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="354" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="476" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="14" node_id="462" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="7" node_id="355" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="355" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="474" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="464" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_right_out">
@@ -39,35 +39,35 @@
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="477" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="465" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="214" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="214" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="479" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="15" node_id="463" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="215" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="215" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="481" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="13" node_id="461" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="216" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="216" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="495" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="11" node_id="459" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="217" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="217" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="485" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="457" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="218" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="218" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="487" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="7" node_id="455" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="219" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="219" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="489" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="5" node_id="453" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="220" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="220" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="497" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="3" node_id="451" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="221" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="221" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="493" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="449" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_1__0_.xml
@@ -1,24 +1,24 @@
 <rr_sb x="1" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="500" segment_id="0" segment_name="L4" mux_size="5" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="108" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="108" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="399" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="419" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="396" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="402" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="502" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="109" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="109" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="401" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="421" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="398" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="504" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="110" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="110" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="403" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="400" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="506" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="111" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="111" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="407" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="404" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
@@ -48,10 +48,10 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="505" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="511" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="517" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="147" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="150" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="50" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="9" node_id="53" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="147" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="150" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="50" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="9" node_id="53" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="396" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="404" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="412" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -70,10 +70,10 @@
 		<driver_node type="CHANY" side="top" index="7" node_id="507" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="513" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="519" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="148" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="48" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="51" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="10" node_id="54" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="148" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="48" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="51" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="10" node_id="54" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="398" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="406" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -90,10 +90,10 @@
 		<driver_node type="CHANY" side="top" index="3" node_id="503" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="509" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="15" node_id="515" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="149" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="49" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="8" node_id="52" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="11" node_id="55" grid_side="top" sb_module_pin_name="right_left_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="149" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="49" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="8" node_id="52" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="11" node_id="55" grid_side="top" sb_module_pin_name="right_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="400" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="408" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
@@ -108,10 +108,10 @@
 		<driver_node type="CHANX" side="right" index="1" node_id="399" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="407" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="415" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="112" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="115" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="18" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="9" node_id="21" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="112" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="115" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="18" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="9" node_id="21" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="399" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="399" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -128,10 +128,10 @@
 		<driver_node type="CHANY" side="top" index="17" node_id="517" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="401" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="409" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="113" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="16" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="19" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="10" node_id="22" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="113" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="16" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="19" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="10" node_id="22" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="407" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="407" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -148,10 +148,10 @@
 		<driver_node type="CHANY" side="top" index="15" node_id="515" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="403" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="411" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="114" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="17" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="20" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="11" node_id="23" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="114" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="17" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="20" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="11" node_id="23" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="415" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="415" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_1__1_.xml
@@ -1,7 +1,7 @@
 <rr_sb x="1" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="520" segment_id="0" segment_name="L4" mux_size="13" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="242" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="245" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="242" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="245" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="right" index="1" node_id="425" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="9" node_id="433" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="445" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -24,7 +24,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="504" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="522" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="243" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="243" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="right" index="3" node_id="427" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="435" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="447" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -44,7 +44,7 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="512" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="524" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="244" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="244" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANX" side="right" index="5" node_id="429" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="443" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="437" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -62,8 +62,8 @@
 		<driver_node type="CHANY" side="top" index="9" node_id="511" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="519" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="19" node_id="525" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="0" node_id="281" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="284" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="281" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="284" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="500" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="508" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="514" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -85,7 +85,7 @@
 		<driver_node type="CHANY" side="top" index="3" node_id="505" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="521" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="513" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="1" node_id="282" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="282" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="502" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="506" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="510" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -105,7 +105,7 @@
 		<driver_node type="CHANY" side="top" index="5" node_id="507" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="515" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="15" node_id="523" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="right" index="2" node_id="283" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="283" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="504" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="512" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="518" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -123,8 +123,8 @@
 		<driver_node type="CHANX" side="right" index="9" node_id="433" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="15" node_id="445" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="17" node_id="441" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="108" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="111" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="108" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="111" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="422" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="430" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="436" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -145,7 +145,7 @@
 		<driver_node type="CHANX" side="right" index="3" node_id="427" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="7" node_id="443" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="11" node_id="435" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="109" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="109" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="424" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="432" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="440" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -165,7 +165,7 @@
 		<driver_node type="CHANX" side="right" index="5" node_id="429" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="13" node_id="437" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
 		<driver_node type="CHANX" side="right" index="19" node_id="447" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="110" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="110" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="426" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="428" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="434" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -185,8 +185,8 @@
 		<driver_node type="CHANY" side="bottom" index="8" node_id="508" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="516" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="518" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="246" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="249" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="246" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="249" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="425" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="425" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -206,7 +206,7 @@
 		<driver_node type="CHANY" side="bottom" index="2" node_id="502" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="506" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="510" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="247" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="247" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="433" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="433" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -226,7 +226,7 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="504" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="512" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="514" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="248" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="248" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="441" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="441" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_1__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_1__2_.xml
@@ -1,8 +1,8 @@
 <rr_sb x="1" y="2" num_sides="4">
 	<CHANX side="right" index="0" node_id="468" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="0" node_id="380" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="3" node_id="383" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="6" node_id="386" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="0" node_id="380" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="3" node_id="383" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="6" node_id="386" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="500" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="522" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="512" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -20,9 +20,9 @@
 		<driver_node type="CHANX" side="left" index="4" node_id="452" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="8" node_id="470" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="1" node_id="381" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="4" node_id="384" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="7" node_id="387" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="1" node_id="381" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="4" node_id="384" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="7" node_id="387" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="520" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="504" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="510" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -40,8 +40,8 @@
 		<driver_node type="CHANX" side="left" index="12" node_id="460" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANX>
 	<CHANX side="right" index="16" node_id="472" segment_id="0" segment_name="L4" mux_size="7" sb_module_pin_name="chanx_right_out">
-		<driver_node type="OPIN" side="right" index="2" node_id="382" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="right" index="5" node_id="385" grid_side="bottom" sb_module_pin_name="right_left_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="2" node_id="382" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="right" index="5" node_id="385" grid_side="bottom" sb_module_pin_name="right_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="502" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="508" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="524" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -53,24 +53,24 @@
 	</CHANX>
 	<CHANY side="bottom" index="1" node_id="503" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="451" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="242" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="242" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="448" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="462" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="505" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="3" node_id="453" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="243" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="243" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="450" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="466" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="507" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="5" node_id="455" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="244" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="244" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="452" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="521" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="459" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="245" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="245" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="456" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="511" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
@@ -102,9 +102,9 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="502" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="508" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="524" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="348" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="351" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="354" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="348" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="351" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="354" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="451" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="1" node_id="451" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -122,9 +122,9 @@
 		<driver_node type="CHANY" side="bottom" index="6" node_id="504" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="510" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="516" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="349" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="352" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="355" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="349" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="352" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="355" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="459" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="9" node_id="459" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>
@@ -141,8 +141,8 @@
 		<driver_node type="CHANY" side="bottom" index="2" node_id="500" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="522" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="512" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="350" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="353" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="350" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="353" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="467" segment_id="0" segment_name="L4" mux_size="0" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANX" side="right" index="17" node_id="467" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_right_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_2__0_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_2__0_.xml
@@ -1,86 +1,86 @@
 <rr_sb x="2" y="0" num_sides="4">
 	<CHANY side="top" index="0" node_id="526" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="143" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="top" index="10" node_id="188" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="143" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="top" index="10" node_id="188" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="416" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="2" node_id="528" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="144" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
-		<driver_node type="OPIN" side="top" index="11" node_id="189" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="144" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="11" node_id="189" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="412" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="4" node_id="530" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="145" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="145" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="420" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="6" node_id="532" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="3" node_id="146" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="146" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="408" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="534" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="4" node_id="182" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="182" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="406" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="10" node_id="536" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="5" node_id="183" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="183" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="404" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="12" node_id="538" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="6" node_id="184" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="184" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="418" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="14" node_id="540" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="7" node_id="185" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="185" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="400" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="542" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="8" node_id="186" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="186" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="398" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="top" index="18" node_id="544" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="9" node_id="187" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="9" node_id="187" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="396" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANX side="left" index="1" node_id="399" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="1" node_id="527" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="147" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
-		<driver_node type="OPIN" side="left" index="10" node_id="54" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="147" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="left" index="10" node_id="54" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="401" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="19" node_id="545" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="148" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
-		<driver_node type="OPIN" side="left" index="11" node_id="55" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="148" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="left" index="11" node_id="55" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="403" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="17" node_id="543" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="149" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="149" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="417" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="15" node_id="541" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="150" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="150" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="407" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="13" node_id="539" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="48" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="48" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="409" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="537" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="49" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="49" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="411" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="535" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="50" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="50" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="419" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="7" node_id="533" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="51" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="51" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="415" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="531" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="8" node_id="52" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="8" node_id="52" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="19" node_id="421" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="529" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="left" index="9" node_id="53" grid_side="top" sb_module_pin_name="left_right_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="9" node_id="53" grid_side="top" sb_module_pin_name="left_bottom_grid_top_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 </rr_sb>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_2__1_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_2__1_.xml
@@ -1,9 +1,9 @@
 <rr_sb x="2" y="1" num_sides="4">
 	<CHANY side="top" index="0" node_id="546" segment_id="0" segment_name="L4" mux_size="11" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="0" node_id="277" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="top" index="3" node_id="280" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
-		<driver_node type="OPIN" side="top" index="6" node_id="318" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="9" node_id="321" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="0" node_id="277" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="top" index="3" node_id="280" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="top" index="6" node_id="318" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="9" node_id="321" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="526" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="534" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="16" node_id="542" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
@@ -22,10 +22,10 @@
 		<driver_node type="CHANY" side="bottom" index="4" node_id="530" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="8" node_id="548" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="1" node_id="278" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
-		<driver_node type="OPIN" side="top" index="4" node_id="316" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="7" node_id="319" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="10" node_id="322" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="1" node_id="278" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="top" index="4" node_id="316" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="7" node_id="319" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="10" node_id="322" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="528" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="10" node_id="536" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="424" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -42,10 +42,10 @@
 		<driver_node type="CHANY" side="bottom" index="12" node_id="538" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 	</CHANY>
 	<CHANY side="top" index="16" node_id="550" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_top_out">
-		<driver_node type="OPIN" side="top" index="2" node_id="279" grid_side="right" sb_module_pin_name="top_bottom_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
-		<driver_node type="OPIN" side="top" index="5" node_id="317" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="8" node_id="320" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="top" index="11" node_id="323" grid_side="left" sb_module_pin_name="top_bottom_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="2" node_id="279" grid_side="right" sb_module_pin_name="top_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="top" index="5" node_id="317" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="8" node_id="320" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="top" index="11" node_id="323" grid_side="left" sb_module_pin_name="top_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="530" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="12" node_id="538" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="422" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -59,10 +59,10 @@
 		<driver_node type="CHANY" side="top" index="1" node_id="529" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="9" node_id="537" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="17" node_id="545" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="0" node_id="182" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="3" node_id="185" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="6" node_id="188" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="9" node_id="144" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="182" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="185" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="188" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="9" node_id="144" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="422" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="444" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="434" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -79,10 +79,10 @@
 	<CHANY side="bottom" index="9" node_id="535" segment_id="0" segment_name="L4" mux_size="9" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="531" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="11" node_id="539" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="1" node_id="183" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="4" node_id="186" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="7" node_id="189" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="10" node_id="145" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="183" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="186" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="189" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="10" node_id="145" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="424" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="430" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="446" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -99,10 +99,10 @@
 	<CHANY side="bottom" index="17" node_id="543" segment_id="0" segment_name="L4" mux_size="10" sb_module_pin_name="chany_bottom_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="533" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="13" node_id="541" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
-		<driver_node type="OPIN" side="bottom" index="2" node_id="184" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="5" node_id="187" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="8" node_id="143" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
-		<driver_node type="OPIN" side="bottom" index="11" node_id="146" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="184" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="187" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="143" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="bottom" index="11" node_id="146" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="442" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="426" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="432" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
@@ -115,25 +115,25 @@
 		<driver_node type="CHANY" side="top" index="1" node_id="529" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="top" index="7" node_id="547" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="bottom" index="0" node_id="526" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="281" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="281" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_4_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="427" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="3" node_id="531" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="bottom" index="2" node_id="528" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="6" node_id="532" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="282" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="282" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_5_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="429" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="5" node_id="533" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="bottom" index="4" node_id="530" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="14" node_id="540" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="283" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="283" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_6_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="443" segment_id="0" segment_name="L4" mux_size="4" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="9" node_id="537" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>
 		<driver_node type="CHANY" side="bottom" index="8" node_id="534" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
 		<driver_node type="CHANY" side="bottom" index="18" node_id="544" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="284" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="284" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_O_7_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="433" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="top" index="11" node_id="539" segment_id="0" segment_name="L4" sb_module_pin_name="chany_top_in"/>

--- a/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_2__2_.xml
+++ b/openfpga_flow/tasks/basic_tests/no_time_stamp/no_cout_in_gsb/golden_outputs_no_time_stamp/gsb_xml/sb_2__2_.xml
@@ -1,77 +1,77 @@
 <rr_sb x="2" y="2" num_sides="4">
 	<CHANY side="bottom" index="1" node_id="529" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="0" node_id="316" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="10" node_id="279" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
+		<driver_node type="OPIN" side="bottom" index="0" node_id="316" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="10" node_id="279" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_2_"/>
 		<driver_node type="CHANX" side="left" index="2" node_id="448" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="3" node_id="531" segment_id="0" segment_name="L4" mux_size="3" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="1" node_id="317" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
-		<driver_node type="OPIN" side="bottom" index="11" node_id="280" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
+		<driver_node type="OPIN" side="bottom" index="1" node_id="317" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="11" node_id="280" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_3_"/>
 		<driver_node type="CHANX" side="left" index="4" node_id="450" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="5" node_id="533" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="2" node_id="318" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="2" node_id="318" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_2__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="6" node_id="452" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="7" node_id="547" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="3" node_id="319" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="3" node_id="319" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_3__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="8" node_id="470" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="9" node_id="537" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="4" node_id="320" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="4" node_id="320" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_4__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="10" node_id="456" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="11" node_id="539" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="5" node_id="321" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="5" node_id="321" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_5__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="12" node_id="458" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="13" node_id="541" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="6" node_id="322" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="6" node_id="322" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_6__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="14" node_id="460" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="15" node_id="549" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="7" node_id="323" grid_side="left" sb_module_pin_name="bottom_top_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="bottom" index="7" node_id="323" grid_side="left" sb_module_pin_name="bottom_right_grid_left_width_0_height_0_subtile_7__pin_inpad_0_"/>
 		<driver_node type="CHANX" side="left" index="16" node_id="472" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="17" node_id="545" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="8" node_id="277" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
+		<driver_node type="OPIN" side="bottom" index="8" node_id="277" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_0_"/>
 		<driver_node type="CHANX" side="left" index="18" node_id="464" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANY side="bottom" index="19" node_id="551" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chany_bottom_out">
-		<driver_node type="OPIN" side="bottom" index="9" node_id="278" grid_side="right" sb_module_pin_name="bottom_top_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
+		<driver_node type="OPIN" side="bottom" index="9" node_id="278" grid_side="right" sb_module_pin_name="bottom_left_grid_right_width_0_height_0_subtile_0__pin_O_1_"/>
 		<driver_node type="CHANX" side="left" index="0" node_id="468" segment_id="0" segment_name="L4" sb_module_pin_name="chanx_left_in"/>
 	</CHANY>
 	<CHANX side="left" index="1" node_id="451" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="18" node_id="542" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="0" node_id="380" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="0" node_id="380" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_0__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="3" node_id="453" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="0" node_id="546" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="1" node_id="381" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="1" node_id="381" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_1__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="5" node_id="455" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="2" node_id="526" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="2" node_id="382" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="2" node_id="382" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_2__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="7" node_id="469" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="4" node_id="528" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="3" node_id="383" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="3" node_id="383" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_3__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="9" node_id="459" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="6" node_id="530" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="4" node_id="384" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="4" node_id="384" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_4__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="11" node_id="461" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="8" node_id="548" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="5" node_id="385" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="5" node_id="385" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_5__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="13" node_id="463" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="10" node_id="534" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="6" node_id="386" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="6" node_id="386" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_6__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="15" node_id="471" segment_id="0" segment_name="L4" mux_size="2" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="12" node_id="536" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>
-		<driver_node type="OPIN" side="left" index="7" node_id="387" grid_side="bottom" sb_module_pin_name="left_right_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
+		<driver_node type="OPIN" side="left" index="7" node_id="387" grid_side="bottom" sb_module_pin_name="left_top_grid_bottom_width_0_height_0_subtile_7__pin_inpad_0_"/>
 	</CHANX>
 	<CHANX side="left" index="17" node_id="467" segment_id="0" segment_name="L4" mux_size="1" sb_module_pin_name="chanx_left_out">
 		<driver_node type="CHANY" side="bottom" index="14" node_id="538" segment_id="0" segment_name="L4" sb_module_pin_name="chany_bottom_in"/>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- See pin name mismatches between the GSB output files and the netlists. Note that this only happens to OPIN. The OPIN names appear in the GSB XML do not match the pin names of Switch block in Verilog netlists.
- Verilog netlists are golden. Correct the bug in GSB writer.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- Fixed a critical bug in GSB XML writer which causes mismatches against netlist.
- Updated golden copies.
- Fixed typos in documentation

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
