### PR TITLE
Use a new version of cancel-previous-flow due to node16 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       docker_repo: ${{ steps.changes.outputs.docker_repo }}
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           
@@ -120,7 +120,7 @@ jobs:
       CXX: ${{ matrix.config.cxx }}
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           
@@ -216,7 +216,7 @@ jobs:
       CXX: ${{ matrix.config.cxx }}
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           
@@ -262,7 +262,7 @@ jobs:
       CXX: ${{ matrix.config.cxx }}
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           
@@ -308,7 +308,7 @@ jobs:
       CXX: ${{ matrix.config.cxx }}
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           
@@ -360,7 +360,7 @@ jobs:
       CXX: ${{ matrix.config.cxx }}
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           
@@ -397,7 +397,7 @@ jobs:
     needs: [linux_build, change_detect]
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           
@@ -450,7 +450,7 @@ jobs:
           - name: tcl_reg_test
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
     
@@ -508,7 +508,7 @@ jobs:
           - name: tcl_reg_test
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Check ccache size
         run: ccache -s
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.config.cc == 'gcc-11'}}
         with:
           name: openfpga
@@ -475,7 +475,7 @@ jobs:
         shell: bash
         run: source openfpga.sh && source openfpga_flow/regression_test_scripts/${{matrix.config.name}}.sh --debug --show_thread_logs
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: failed_${{matrix.config.name}}_regression_log
@@ -524,7 +524,7 @@ jobs:
           unset OPENFPGA_PATH
           source openfpga.sh && source openfpga_flow/regression_test_scripts/${{matrix.config.name}}.sh --debug --show_thread_logs
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: failed_${{matrix.config.name}}_regression_log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,7 +404,7 @@ jobs:
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v4
       - name: Download a built artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: openfpga
       - name: Set up QEMU
@@ -457,7 +457,7 @@ jobs:
       - name: Checkout OpenFPGA repo
         uses: actions/checkout@v4
       - name: Download a built artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: openfpga
       - name: chmod

--- a/.github/workflows/cell_lib_test.yml
+++ b/.github/workflows/cell_lib_test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
           

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -35,7 +35,7 @@ jobs:
             dependency_version: "ubuntu22p04"
     steps:
       - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- Node16 is going to be deprecated soon by the end of June 2024. See details at [link](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
- When looking into our [ci flow warnings](https://github.com/lnis-uofu/OpenFPGA/actions/runs/9649881225),  a large number of warning are related to Node16. 
![image](https://github.com/lnis-uofu/OpenFPGA/assets/11499826/5381111d-ea68-486e-afce-722f172343d4)

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- Use latest release v0.12.1 of the cancel-previous-flow action

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
