### PR TITLE
[lib] now fabric key assistant can cross-check mismatches between reference and input fabric keys

### DIFF
--- a/libs/libfabrickey/test/fabric_key_assistant.cpp
+++ b/libs/libfabrickey/test/fabric_key_assistant.cpp
@@ -34,8 +34,7 @@ static int check_input_and_ref_key_alias_match(
   const openfpga::FabricKey& input_key, const openfpga::FabricKey& ref_key,
   const bool& verbose) {
   size_t num_errors = 0;
-  size_t num_keys_checked = 0;
-  float progress = 0.;
+  size_t num_ref_keys_checked = 0;
   VTR_LOG(
     "Checking key alias matching between reference key and input keys...\n");
   for (openfpga::FabricKeyId key_id : ref_key.keys()) {
@@ -43,7 +42,7 @@ static int check_input_and_ref_key_alias_match(
     std::string curr_alias = ref_key.key_alias(key_id);
     std::vector<openfpga::FabricKeyId> input_found_keys =
       input_key.find_key_by_alias(curr_alias);
-    progress = static_cast<float>(num_keys_checked) /
+    float progress = static_cast<float>(num_ref_keys_checked) /
                static_cast<float>(ref_key.num_keys()) * 100.0;
     VTR_LOGV(verbose, "[%lu%] Checking key alias '%s'\r", size_t(progress),
              curr_alias.c_str());
@@ -61,11 +60,40 @@ static int check_input_and_ref_key_alias_match(
         curr_alias.c_str(), size_t(key_id), input_found_keys.size());
       num_errors++;
     }
-    num_keys_checked++;
+    num_ref_keys_checked++;
   }
   VTR_LOG(
     "Checking key alias matching between reference key and input keys... %s\n",
     num_errors ? "[Fail]" : "[Pass]");
+  /* If failed, provide a detailed diff on the key alias */
+  if (num_errors) {
+    size_t num_input_keys_checked = 0;
+    for (openfpga::FabricKeyId key_id : input_key.keys()) {
+      /* Note that this is slow. May consider to build a map first */
+      std::string curr_alias = input_key.key_alias(key_id);
+      std::vector<openfpga::FabricKeyId> ref_found_keys =
+        ref_key.find_key_by_alias(curr_alias);
+      float progress = static_cast<float>(num_input_keys_checked) /
+                 static_cast<float>(input_key.num_keys()) * 100.0;
+      VTR_LOGV(verbose, "[%lu%] Checking key alias '%s'\r", size_t(progress),
+               curr_alias.c_str());
+      if (ref_found_keys.empty()) {
+        VTR_LOG_ERROR(
+          "Invalid alias '%s' in the input key (id='%lu'), which does not "
+          "exist in the reference key!\n",
+          curr_alias.c_str(), size_t(key_id));
+        num_errors++;
+      }
+      if (ref_found_keys.size() > 1) {
+        VTR_LOG_ERROR(
+          "Invalid alias '%s' in the reference key (id='%lu'), which have been "
+          "found %lu times!\n",
+          curr_alias.c_str(), size_t(key_id), ref_found_keys.size());
+        num_errors++;
+      }
+      num_input_keys_checked++;
+    }
+  }
   return num_errors ? openfpga::CMD_EXEC_FATAL_ERROR
                     : openfpga::CMD_EXEC_SUCCESS;
 }

--- a/libs/libfabrickey/test/fabric_key_assistant.cpp
+++ b/libs/libfabrickey/test/fabric_key_assistant.cpp
@@ -43,7 +43,7 @@ static int check_input_and_ref_key_alias_match(
     std::vector<openfpga::FabricKeyId> input_found_keys =
       input_key.find_key_by_alias(curr_alias);
     float progress = static_cast<float>(num_ref_keys_checked) /
-               static_cast<float>(ref_key.num_keys()) * 100.0;
+                     static_cast<float>(ref_key.num_keys()) * 100.0;
     VTR_LOGV(verbose, "[%lu%] Checking key alias '%s'\r", size_t(progress),
              curr_alias.c_str());
     if (input_found_keys.empty()) {
@@ -74,7 +74,7 @@ static int check_input_and_ref_key_alias_match(
       std::vector<openfpga::FabricKeyId> ref_found_keys =
         ref_key.find_key_by_alias(curr_alias);
       float progress = static_cast<float>(num_input_keys_checked) /
-                 static_cast<float>(input_key.num_keys()) * 100.0;
+                       static_cast<float>(input_key.num_keys()) * 100.0;
       VTR_LOGV(verbose, "[%lu%] Checking key alias '%s'\r", size_t(progress),
                curr_alias.c_str());
       if (ref_found_keys.empty()) {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:

- Fabric key assistant only reports the missing key in the input key against the reference key. However, it is very useful to report the reverse one: the missing key in the reference key against the input key

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- Now when the missing key in the input key is detected, The the missing key in the reference key against the input key will also be reported.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
