### PR TITLE
Fixed a bug where clock network taps cannot identify subtiles

### DIFF
--- a/docs/source/manual/file_formats/clock_network.rst
+++ b/docs/source/manual/file_formats/clock_network.rst
@@ -308,20 +308,25 @@ For example,
   <clock_network name="clk_tree_0" global_port="clk[0:1]">
     <!-- Some clock spines -->
     <taps>
-      <all from_pin="clk[0:0]" to_pin="clb.clk[0:0]"/>
-      <region from_pin="clk[1:1]" to_pin="clb.clk[1:1]" start_x="1" start_y="1" end_x="4" end_y="4" repeat_x="2" repeat_y="2"/>
-      <single from_pin="clk[1:1]" to_pin="clb.clk[1:1]" x="2" y="2"/>
+      <all from_pin="clk[0:0]" to_pin="clb[0:0].clk[0:0]"/>
+      <region from_pin="clk[1:1]" to_pin="clb[1:1].clk[1:1]" start_x="1" start_y="1" end_x="4" end_y="4" repeat_x="2" repeat_y="2"/>
+      <single from_pin="clk[1:1]" to_pin="clb[2:2].clk[1:1]" x="2" y="2"/>
     </taps>
   </clock_network>
 
 where all the clock spines of the clock network ``clk_tree_0`` tap the clock pins ``clk`` of tile ``clb`` in a VPR architecture description file:
 
-.. note:: Use the name of ``subtile`` in the ``to_pin`` when there are a number of subtiles in your tile!
+.. note:: Use the name of ``tile`` in the ``to_pin`` when there are a number of subtiles in your tile! Use the absolute index for the subtile in the tile.
 
 .. code-block:: xml
 
   <tile name="clb">
-   <sub_tile name="clb">
+   <!-- subtile index ranges [0:0] -->
+   <sub_tile name="clbM" capacity="1">
+     <clock name="clk" num_pins="2"/>
+   </sub_tile>
+   <!-- subtile index ranges [1:2] -->
+   <sub_tile name="clbA" capacity="2">
      <clock name="clk" num_pins="2"/>
    </sub_tile>
   </tile>

--- a/openfpga/src/utils/openfpga_physical_tile_utils.cpp
+++ b/openfpga/src/utils/openfpga_physical_tile_utils.cpp
@@ -204,8 +204,7 @@ int find_physical_tile_pin_index(t_physical_tile_type_ptr physical_tile,
       }
       /* Reach here, we get the port we want, return the accumulated index */
       size_t accumulated_pin_idx =
-        acc_pin_index +
-        sub_tile_port.absolute_first_pin_index +
+        acc_pin_index + sub_tile_port.absolute_first_pin_index +
         (sub_tile.num_phy_pins / sub_tile.capacity.total()) *
           (tile_info.get_lsb() - sub_tile.capacity.low) +
         pin_info.get_lsb();

--- a/openfpga/src/utils/openfpga_physical_tile_utils.cpp
+++ b/openfpga/src/utils/openfpga_physical_tile_utils.cpp
@@ -152,6 +152,10 @@ int find_physical_tile_pin_index(t_physical_tile_type_ptr physical_tile,
       pin_name.c_str(), physical_tile->capacity - 1);
     exit(1);
   }
+  /* Bypass unmatched subtiles*/
+  if (tile_info.get_name() != std::string(physical_tile->name)) {
+    return pin_idx;
+  }
   /* precheck: return unfound pin if the subtile index does not match */
   if (tile_info.get_width() != 1) {
     VTR_LOG_ERROR(
@@ -175,9 +179,6 @@ int find_physical_tile_pin_index(t_physical_tile_type_ptr physical_tile,
   /* Spot the subtile by using the index */
   for (const t_sub_tile& sub_tile : physical_tile->sub_tiles) {
     /* Bypass unmatched subtiles*/
-    if (tile_info.get_name() != std::string(sub_tile.name)) {
-      continue;
-    }
     if (!sub_tile.capacity.is_in_range(tile_info.get_lsb())) {
       VTR_LOG_ERROR(
         "Invalid pin name '%s' whose subtile index is out of range, expect "

--- a/openfpga/src/utils/openfpga_physical_tile_utils.cpp
+++ b/openfpga/src/utils/openfpga_physical_tile_utils.cpp
@@ -180,12 +180,7 @@ int find_physical_tile_pin_index(t_physical_tile_type_ptr physical_tile,
   for (const t_sub_tile& sub_tile : physical_tile->sub_tiles) {
     /* Bypass unmatched subtiles*/
     if (!sub_tile.capacity.is_in_range(tile_info.get_lsb())) {
-      VTR_LOG_ERROR(
-        "Invalid pin name '%s' whose subtile index is out of range, expect "
-        "[%lu, "
-        "%lu]\n",
-        pin_name.c_str(), sub_tile.capacity.low, sub_tile.capacity.high);
-      exit(1);
+      continue;
     }
     for (const t_physical_tile_port& sub_tile_port : sub_tile.ports) {
       if (std::string(sub_tile_port.name) != pin_info.get_name()) {

--- a/openfpga/src/utils/openfpga_physical_tile_utils.cpp
+++ b/openfpga/src/utils/openfpga_physical_tile_utils.cpp
@@ -177,9 +177,11 @@ int find_physical_tile_pin_index(t_physical_tile_type_ptr physical_tile,
   }
 
   /* Spot the subtile by using the index */
+  size_t acc_pin_index = 0;
   for (const t_sub_tile& sub_tile : physical_tile->sub_tiles) {
     /* Bypass unmatched subtiles*/
     if (!sub_tile.capacity.is_in_range(tile_info.get_lsb())) {
+      acc_pin_index += sub_tile.num_phy_pins;
       continue;
     }
     for (const t_physical_tile_port& sub_tile_port : sub_tile.ports) {
@@ -202,6 +204,7 @@ int find_physical_tile_pin_index(t_physical_tile_type_ptr physical_tile,
       }
       /* Reach here, we get the port we want, return the accumulated index */
       size_t accumulated_pin_idx =
+        acc_pin_index +
         sub_tile_port.absolute_first_pin_index +
         (sub_tile.num_phy_pins / sub_tile.capacity.total()) *
           (tile_info.get_lsb() - sub_tile.capacity.low) +

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_ClkNtwk_registerable_IoSubtile_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_ClkNtwk_registerable_IoSubtile_cc_openfpga.xml
@@ -188,7 +188,7 @@
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->
-    <pb_type name="fpga_input" physical_mode_name="physical">
+    <pb_type name="fpga_input" physical_mode_name="physical"/>
     <pb_type name="fpga_output" physical_mode_name="physical"/>
     <pb_type name="fpga_input[physical].iopad" circuit_model_name="GPIN"/>
     <pb_type name="fpga_output[physical].iopad" circuit_model_name="GPOUT"/>

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_ClkNtwk_registerable_IoSubtile_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_ClkNtwk_registerable_IoSubtile_cc_openfpga.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0"?>
+<!-- Architecture annotation for OpenFPGA framework
+     This annotation supports the k6_N10_40nm.xml 
+     - General purpose logic block
+       - K = 6, N = 10, I = 40
+       - Single mode
+     - Routing architecture
+       - L = 4, fc_in = 0.15, fc_out = 0.1
+  -->
+<openfpga_architecture>
+  <technology_library>
+    <device_library>
+      <device_model name="logic" type="transistor">
+        <lib type="industry" corner="TOP_TT" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="0.9" pn_ratio="2"/>
+        <pmos name="pch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+        <nmos name="nch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+      </device_model>
+      <device_model name="io" type="transistor">
+        <lib type="academia" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="2.5" pn_ratio="3"/>
+        <pmos name="pch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+        <nmos name="nch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+      </device_model>
+    </device_library>
+    <variation_library>
+      <variation name="logic_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+      <variation name="io_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+    </variation_library>
+  </technology_library>
+  <circuit_library>
+    <circuit_model type="inv_buf" name="INVTX1" prefix="INVTX1" is_default="true">
+      <design_technology type="cmos" topology="inverter" size="1"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="buf4" prefix="buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="2" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="tap_buf4" prefix="tap_buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="3" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="pass_gate" name="TGATE" prefix="TGATE" is_default="true">
+      <design_technology type="cmos" topology="transmission_gate" nmos_size="1" pmos_size="2"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="input" prefix="sel" size="1"/>
+      <port type="input" prefix="selb" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="chan_wire" name="chan_segment" prefix="track_seg" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+    </circuit_model>
+    <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
+    </circuit_model>
+    <circuit_model type="mux" name="mux_tree" prefix="mux_tree" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_tree_tapbuf" prefix="mux_tree_tapbuf" is_default="true" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+      <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="false" default_val="0"/>
+    </circuit_model>
+    <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_inverter exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_buffer exist="true" circuit_model_name="buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="4"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="16"/>
+    </circuit_model>
+    <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ccff" name="DFF" prefix="DFF" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPIN" prefix="GPIN" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
+      <port type="inout" prefix="PAD" lib_name="A" size="1" is_global="true" is_io="true" is_data_io="true"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPOUT" prefix="GPOUT" is_default="false" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
+      <port type="inout" prefix="PAD" lib_name="Y" size="1" is_global="true" is_io="true" is_data_io="true"/>
+      <port type="input" prefix="outpad" lib_name="A" size="1"/>
+    </circuit_model>
+  </circuit_library>
+  <configuration_protocol>
+    <organization type="scan_chain" circuit_model_name="DFF"/>
+  </configuration_protocol>
+  <connection_block>
+    <switch name="ipin_cblock" circuit_model_name="mux_tree_tapbuf"/>
+  </connection_block>
+  <switch_block>
+    <switch name="0" circuit_model_name="mux_tree_tapbuf"/>
+  </switch_block>
+  <routing_segment>
+    <segment name="L1" circuit_model_name="chan_segment"/>
+    <segment name="L4" circuit_model_name="chan_segment"/>
+  </routing_segment>
+  <tile_annotations>
+    <global_port name="clk" is_clock="true" default_val="0" clock_arch_tree_name="clk_tree_2lvl">
+      <tile name="clb" port="clk" x="-1" y="-1"/>
+      <tile name="io_top" port="clk" x="-1" y="-1"/>
+      <tile name="io_right" port="clk" x="-1" y="-1"/>
+      <tile name="io_bottom" port="clk" x="-1" y="-1"/>
+      <tile name="io_left" port="clk" x="-1" y="-1"/>
+    </global_port>
+  </tile_annotations>
+  <pb_type_annotations>
+    <!-- physical pb_type binding in complex block IO -->
+    <pb_type name="fpga_input" physical_mode_name="physical">
+    <pb_type name="fpga_output" physical_mode_name="physical"/>
+    <pb_type name="fpga_input[physical].iopad" circuit_model_name="GPIN"/>
+    <pb_type name="fpga_output[physical].iopad" circuit_model_name="GPOUT"/>
+    <pb_type name="fpga_input[physical].ff" circuit_model_name="DFFSRQ"/>
+    <pb_type name="fpga_output[physical].ff" circuit_model_name="DFFSRQ"/>
+    <pb_type name="fpga_input[inpad].inpad" physical_pb_type_name="fpga_input[physical].iopad"/>
+    <pb_type name="fpga_input[inpad_registered].inpad" physical_pb_type_name="fpga_input[physical].iopad"/>
+    <pb_type name="fpga_input[inpad_registered].ff" physical_pb_type_name="fpga_input[physical].ff"/>
+    <pb_type name="fpga_output[outpad].outpad" physical_pb_type_name="fpga_output[physical].iopad"/>
+    <pb_type name="fpga_output[outpad_registered].outpad" physical_pb_type_name="fpga_output[physical].iopad"/>
+    <pb_type name="fpga_output[outpad_registered].ff" physical_pb_type_name="fpga_output[physical].ff"/>
+    <!-- End physical pb_type binding in complex block IO -->
+    <!-- physical pb_type binding in complex block CLB -->
+    <!-- physical mode will be the default mode if not specified -->
+    <pb_type name="clb">
+      <!-- Binding interconnect to circuit models as their physical implementation, if not defined, we use the default model -->
+      <interconnect name="crossbar" circuit_model_name="mux_tree"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.lut4" circuit_model_name="lut4"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff" circuit_model_name="DFFSRQ"/>
+    <!-- End physical pb_type binding in complex block IO -->
+  </pb_type_annotations>
+</openfpga_architecture>

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -200,6 +200,7 @@ run-task basic_tests/tile_organization/fabric_tile_global_tile_clock_io_subtile 
 run-task basic_tests/tile_organization/fabric_tile_perimeter_cb_global_tile_clock $@
 run-task basic_tests/tile_organization/fabric_tile_perimeter_cb_pb_pin_fixup $@
 run-task basic_tests/tile_organization/fabric_tile_clkntwk_io_subtile $@
+run-task basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile $@
 run-task basic_tests/tile_organization/homo_fabric_tile_preconfig $@
 run-task basic_tests/tile_organization/homo_fabric_tile_2x2_preconfig $@
 run-task basic_tests/tile_organization/homo_fabric_tile_4x4_preconfig $@

--- a/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/clk_arch_1clk_2layer.xml
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/clk_arch_1clk_2layer.xml
@@ -1,0 +1,25 @@
+<clock_networks default_segment="L1" default_tap_switch="ipin_cblock" default_driver_switch="0"> 
+  <clock_network name="clk_tree_2lvl" global_port="clk[0:0]"> 
+    <spine name="spine_lvl0" start_x="0" start_y="1" end_x="2" end_y="1"> 
+      <switch_point tap="rib_lvl1_sw0_upper" x="0" y="1"/> 
+      <switch_point tap="rib_lvl1_sw0_lower" x="0" y="1"/> 
+      <switch_point tap="rib_lvl1_sw1_upper" x="1" y="1"/> 
+      <switch_point tap="rib_lvl1_sw1_lower" x="1" y="1"/> 
+      <switch_point tap="rib_lvl1_sw2_upper" x="2" y="1"/> 
+      <switch_point tap="rib_lvl1_sw2_lower" x="2" y="1"/> 
+    </spine>  
+    <spine name="rib_lvl1_sw0_upper" start_x="0" start_y="2" end_x="0" end_y="2" type="CHANY" direction="INC_DIRECTION"/>
+    <spine name="rib_lvl1_sw0_lower" start_x="0" start_y="1" end_x="0" end_y="1" type="CHANY" direction="DEC_DIRECTION"/>
+    <spine name="rib_lvl1_sw1_upper" start_x="1" start_y="2" end_x="1" end_y="3" type="CHANY" direction="INC_DIRECTION"/>
+    <spine name="rib_lvl1_sw1_lower" start_x="1" start_y="1" end_x="1" end_y="0" type="CHANY" direction="DEC_DIRECTION"/>
+    <spine name="rib_lvl1_sw2_upper" start_x="2" start_y="2" end_x="2" end_y="3" type="CHANY" direction="INC_DIRECTION"/>
+    <spine name="rib_lvl1_sw2_lower" start_x="2" start_y="1" end_x="2" end_y="0" type="CHANY" direction="DEC_DIRECTION"/>
+    <taps>
+      <all from_pin="clk[0:0]" to_pin="clb[0:0].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_top[0:5].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_right[0:2].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_bottom[0:3].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_left[0:3].clk[0:0]"/>
+    </taps>
+  </clock_network>  
+</clock_networks> 

--- a/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/clk_arch_1clk_2layer.xml
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/clk_arch_1clk_2layer.xml
@@ -16,10 +16,10 @@
     <spine name="rib_lvl1_sw2_lower" start_x="2" start_y="1" end_x="2" end_y="0" type="CHANY" direction="DEC_DIRECTION"/>
     <taps>
       <all from_pin="clk[0:0]" to_pin="clb[0:0].clk[0:0]"/>
-      <all from_pin="clk[0:0]" to_pin="io_top[0:5].clk[0:0]"/>
-      <all from_pin="clk[0:0]" to_pin="io_right[0:2].clk[0:0]"/>
-      <all from_pin="clk[0:0]" to_pin="io_bottom[0:3].clk[0:0]"/>
-      <all from_pin="clk[0:0]" to_pin="io_left[0:3].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_top[0:11].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_right[0:5].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_bottom[0:7].clk[0:0]"/>
+      <all from_pin="clk[0:0]" to_pin="io_left[0:7].clk[0:0]"/>
     </taps>
   </clock_network>  
 </clock_networks> 

--- a/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/task.conf
@@ -1,0 +1,42 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/group_tile_clkntwk_preconfig_testbench_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_ClkNtwk_registerable_IoSubtile_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+openfpga_vpr_extra_options=
+openfpga_pb_pin_fixup_command=
+openfpga_vpr_device=2x2
+openfpga_vpr_route_chan_width=40
+openfpga_group_tile_config_file=${PATH:TASK_DIR}/config/tile_config.xml
+openfpga_verilog_testbench_options=--explicit_port_mapping
+openfpga_clock_arch_file=${PATH:TASK_DIR}/config/clk_arch_1clk_2layer.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_PerimeterCb_ClkNtwk_registerable_IoSubtile_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_pipelined/and2_pipelined.v
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = -nolatches
+bench0_top = and2_pipelined
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/tile_config.xml
+++ b/openfpga_flow/tasks/basic_tests/tile_organization/fabric_tile_clkntwk_registerable_io_subtile/config/tile_config.xml
@@ -1,0 +1,1 @@
+<tiles style="top_left"/>

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_PerimeterCb_ClkNtwk_registerable_IoSubtile_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_PerimeterCb_ClkNtwk_registerable_IoSubtile_40nm.xml
@@ -49,7 +49,7 @@
           <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
         </fc>
         <pinlocations pattern="custom">
-          <loc side="left"></loc>
+          <loc side="left"/>
           <loc side="top"/>
           <loc side="right">fpga_input[0:5].clk[0:0]</loc>
           <loc side="bottom">fpga_input[0:5].inpad[0:0]</loc>
@@ -85,8 +85,8 @@
         <pinlocations pattern="custom">
           <loc side="left">fpga_input[0:2].inpad[0:0] fpga_input[0:2].clk[0:0]</loc>
           <loc side="right"/>
-          <loc side="top"></loc>
-          <loc side="bottom"></loc>
+          <loc side="top"/>
+          <loc side="bottom"/>
         </pinlocations>
       </sub_tile>
       <sub_tile name="fpga_output" capacity="3">
@@ -120,7 +120,7 @@
           <loc side="right">fpga_input[0:3].clk[0:0]</loc>
           <loc side="bottom"/>
           <loc side="top">fpga_input[0:3].inpad[0:0]</loc>
-          <loc side="left"></loc>
+          <loc side="left"/>
         </pinlocations>
       </sub_tile>
       <sub_tile name="fpga_output" capacity="4">
@@ -153,8 +153,8 @@
         <pinlocations pattern="custom">
           <loc side="right">fpga_input[0:3].inpad[0:0] fpga_input[0:3].clk[0:0]</loc>
           <loc side="left"/>
-          <loc side="top"></loc>
-          <loc side="bottom"></loc>
+          <loc side="top"/>
+          <loc side="bottom"/>
         </pinlocations>
       </sub_tile>
       <sub_tile name="fpga_output" capacity="4">

--- a/openfpga_flow/vpr_arch/k4_N4_tileable_PerimeterCb_ClkNtwk_registerable_IoSubtile_40nm.xml
+++ b/openfpga_flow/vpr_arch/k4_N4_tileable_PerimeterCb_ClkNtwk_registerable_IoSubtile_40nm.xml
@@ -1,0 +1,506 @@
+<?xml version="1.0"?>
+<!-- 
+  Architecture with no fracturable LUTs
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 4, N = 4
+  - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
+
+  Details on Modelling:
+
+  Based on flagship k6_frac_N10_mem32K_40nm.xml architecture.  This architecture has no fracturable LUTs nor any heterogeneous blocks.
+
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <!-- A virtual model for I/O to be used in the physical mode of io block -->
+    <model name="io_inpad">
+      <output_ports>
+        <port name="inpad"/>
+      </output_ports>
+    </model>
+    <model name="io_outpad">
+      <input_ports>
+        <port name="outpad"/>
+      </input_ports>
+    </model>
+  </models>
+  <tiles>
+    <tile name="io_top" area="0">
+      <sub_tile name="fpga_input" capacity="6">
+        <equivalent_sites>
+          <site pb_type="fpga_input"/>
+        </equivalent_sites>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left"></loc>
+          <loc side="top"/>
+          <loc side="right">fpga_input[0:5].clk[0:0]</loc>
+          <loc side="bottom">fpga_input[0:5].inpad[0:0]</loc>
+        </pinlocations>
+      </sub_tile>
+      <sub_tile name="fpga_output" capacity="6">
+        <equivalent_sites>
+          <site pb_type="fpga_output"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left">fpga_output[0:1].outpad[0:0]</loc>
+          <loc side="top"/>
+          <loc side="right">fpga_output[2:3].outpad fpga_output[0:5].clk[0:0]</loc>
+          <loc side="bottom">fpga_output[4:5].outpad[0:0]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_right" area="0">
+      <sub_tile name="fpga_input" capacity="3">
+        <equivalent_sites>
+          <site pb_type="fpga_input"/>
+        </equivalent_sites>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left">fpga_input[0:2].inpad[0:0] fpga_input[0:2].clk[0:0]</loc>
+          <loc side="right"/>
+          <loc side="top"></loc>
+          <loc side="bottom"></loc>
+        </pinlocations>
+      </sub_tile>
+      <sub_tile name="fpga_output" capacity="3">
+        <equivalent_sites>
+          <site pb_type="fpga_output"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="left">fpga_output[0:0].outpad[0:0] fpga_output[0:2].clk[0:0]</loc>
+          <loc side="right"/>
+          <loc side="top">fpga_output[1:1].outpad[0:0]</loc>
+          <loc side="bottom">fpga_output[2:2].outpad[0:0]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_bottom" area="0">
+      <sub_tile name="fpga_input" capacity="4">
+        <equivalent_sites>
+          <site pb_type="fpga_input"/>
+        </equivalent_sites>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="right">fpga_input[0:3].clk[0:0]</loc>
+          <loc side="bottom"/>
+          <loc side="top">fpga_input[0:3].inpad[0:0]</loc>
+          <loc side="left"></loc>
+        </pinlocations>
+      </sub_tile>
+      <sub_tile name="fpga_output" capacity="4">
+        <equivalent_sites>
+          <site pb_type="fpga_output"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="right">fpga_output[0:1].outpad[0:0] fpga_output[0:3].clk[0:0]</loc>
+          <loc side="bottom"/>
+          <loc side="top">fpga_output[2:2].outpad[0:0]</loc>
+          <loc side="left">fpga_output[3:3].outpad[0:0]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="io_left" area="0">
+      <sub_tile name="fpga_input" capacity="4">
+        <equivalent_sites>
+          <site pb_type="fpga_input"/>
+        </equivalent_sites>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="right">fpga_input[0:3].inpad[0:0] fpga_input[0:3].clk[0:0]</loc>
+          <loc side="left"/>
+          <loc side="top"></loc>
+          <loc side="bottom"></loc>
+        </pinlocations>
+      </sub_tile>
+      <sub_tile name="fpga_output" capacity="4">
+        <equivalent_sites>
+          <site pb_type="fpga_output"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="right">fpga_output[0:1].outpad[0:0] fpga_output[0:3].clk[0:0]</loc>
+          <loc side="left"/>
+          <loc side="top">fpga_output[2:2].outpad[0:0]</loc>
+          <loc side="bottom">fpga_output[3:3].outpad[0:0]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb"/>
+        </equivalent_sites>
+        <input name="I" num_pins="10" equivalent="full"/>
+        <output name="O" num_pins="4" equivalent="none"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.25" out_type="frac" out_val="0.20">
+          <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="custom">
+          <loc side="right">clb.I[0:1] clb.O[0:0]</loc>
+          <loc side="left">clb.I[2:3] clb.O[1:1] clb.clk</loc>
+          <loc side="top">clb.I[4:6] clb.O[2:2]</loc>
+          <loc side="bottom">clb.I[7:9] clb.O[3:3]</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout tileable="true" perimeter_cb="true">
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="90"/>
+      <row type="io_bottom" starty="0" priority="91"/>
+      <col type="io_right" startx="W-1" priority="92"/>
+      <col type="io_left" startx="0" priority="93"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </auto_layout>
+    <fixed_layout name="2x2" width="4" height="4">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <row type="io_top" starty="H-1" priority="90"/>
+      <row type="io_bottom" starty="0" priority="91"/>
+      <col type="io_right" startx="W-1" priority="92"/>
+      <col type="io_left" startx="0" priority="93"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+    </fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	  -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+	       book area formula. This means the mux transistors are about 5x minimum drive strength.
+	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+	       2.5x when looking up in Jeff's tables.
+	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment name="L1" freq="0.900000" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1</sb>
+      <cb type="pattern">1</cb>
+    </segment>
+    <segment name="L4" freq="0.100000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="fpga_input">
+      <output name="inpad" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io_inpad" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="fpga_input.clk" output="ff.clk"/>
+          <!-- Create a selector between registered/combinational I/O -->
+          <direct name="inpad" input="iopad.inpad" output="ff.D"/>
+          <mux name="mux1" input="iopad.inpad ff.Q" output="fpga_input.inpad">
+            <delay_constant max="4.5e-11" in_port="iopad.inpad" out_port="fpga_input.inpad"/>
+            <delay_constant max="4.243e-11" in_port="ff.Q" out_port="fpga_input.inpad"/>
+          </mux>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="fpga_input.inpad">
+            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="fpga_input.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="inpad_registered">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="fpga_input.clk" output="ff.clk"/>
+          <direct name="inpad" input="inpad.inpad" output="ff.D">
+            <pack_pattern name="registered_io" in_port="inpad.inpad" out_port="ff.D"/>
+          </direct>
+          <direct name="ff2inpad" input="ff.Q" output="fpga_input.inpad"/>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <pb_type name="fpga_output">
+      <input name="outpad" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- A mode denotes the physical implementation of an I/O 
+           This mode will be not packable but is mainly used for fabric verilog generation   
+        -->
+      <mode name="physical" disable_packing="true">
+        <pb_type name="iopad" blif_model=".subckt io_outpad" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="fpga_output.clk" output="ff.clk"/>
+          <!-- Create a selector between registered/combinational I/O -->
+          <direct name="outpad-D" input="fpga_output.outpad" output="ff.D"/>
+          <mux name="mux1" input="fpga_output.outpad ff.Q" output="iopad.outpad">
+            <delay_constant max="4.5e-11" in_port="fpga_output.outpad" out_port="iopad.outpad"/>
+            <delay_constant max="4.243e-11" in_port="ff.Q" out_port="iopad.outpad"/>
+          </mux>
+        </interconnect>
+      </mode>
+      <!-- IOs can operate as either inputs or outputs.
+	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+	     -->
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="fpga_output.outpad" output="outpad.outpad"/>
+        </interconnect>
+      </mode>
+      <mode name="outpad_registered">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+          <input name="D" num_pins="1" port_class="D"/>
+          <output name="Q" num_pins="1" port_class="Q"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="66e-12" port="ff.D" clock="clk"/>
+          <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+        </pb_type>
+        <interconnect>
+          <direct name="clk" input="fpga_output.clk" output="ff.clk"/>
+          <direct name="inpad" input="fpga_output.outpad" output="ff.D">
+            <pack_pattern name="registered_io" in_port="fpga_output.outpad" out_port="ff.D"/>
+          </direct>
+          <direct name="ff2outpad" input="ff.Q" output="outpad.outpad"/>
+        </interconnect>
+      </mode>
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="10" equivalent="full"/>
+      <output name="O" num_pins="4" equivalent="none"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe basic logic element.  
+             Each basic logic element has a 4-LUT that can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="4">
+        <input name="in" num_pins="4"/>
+        <output name="out" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <!-- 4-LUT mode definition begin -->
+        <mode name="n1_lut4">
+          <!-- Define 4-LUT mode -->
+          <pb_type name="ble4" num_pb="1">
+            <input name="in" num_pins="4"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <!-- Define LUT -->
+            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="4" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                261e-12
+                261e-12
+                261e-12
+                261e-12
+              </delay_matrix>
+            </pb_type>
+            <!-- Define flip-flop -->
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+              <direct name="direct2" input="lut4.out" output="ff.D">
+                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble4.in"/>
+            <direct name="direct2" input="ble4.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+          </interconnect>
+        </mode>
+        <!-- 6-LUT mode definition end -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+		     The delays below come from Stratix IV. the delay through a connection block
+		     input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+		     delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+		     delay within the crossbar is 95 ps. 
+		     The delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+		     Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+		     25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+		     to get the part that should be marked on the crossbar.	 -->
+        <complete name="crossbar" input="clb.I fle[3:0].out" output="fle[3:0].in">
+          <delay_constant max="95e-12" in_port="clb.I" out_port="fle[3:0].in"/>
+          <delay_constant max="75e-12" in_port="fle[3:0].out" out_port="fle[3:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[3:0].clk">
+        </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+               naive specification).
+          -->
+        <direct name="clbouts1" input="fle[3:0].out" output="clb.O"/>
+      </interconnect>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this general purpose logic block in any unspecified column -->
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+  </complexblocklist>
+</architecture>


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:

- When there are subtiles, it requires users to fill the clock tap in clock network with subtile name. 
![image](https://github.com/user-attachments/assets/0e11aafd-eb4b-4927-aa16-68b75d8e56e2)

However, in practice, the subtiles may share names across tiles. A better way is to use the tile name and subtile index. 
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Now clock tap pin format is changed to <tile_name>_<subtile_index>

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
