### PR TITLE
A new option '--map_global_net_to_msb' for command 'pb_pin_fixup'

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_commands/setup_commands.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_commands/setup_commands.rst
@@ -235,6 +235,10 @@ pb_pin_fixup
   .. warning:: This feature has been integrated into VPR to provide accurate timing analysis results at post-routing stage. However, this command provides a light fix-up (not as thorough as the one in VPR) but bring more flexibility in support some architecture without local routing. Suggest to enable it when your architecture does not have local routing for *Look-Up Tables* (LUTs) but you want to enable logic equivalent for input pins of LUTs
 
   .. warning:: This command may be deprecated in future
+
+  .. option:: --map_global_net_to_msb
+
+    If specified, any global net including clock, reset etc, will be mapped to a best-fit Most Significant Bit (MSB) of input ports of programmable blocks. If not specified, a best-fit Least Significant Bit (LSB) will be the default choice. For example, when ``--clock_modeling ideal`` is selected when running VPR, global nets will not be routed and their pin mapping on programmable blocks may be revoked by other nets due to optimization. Therefore, this command will restore the pin mapping for the global nets and pick a spare pin on programmable blocks. This option is to set a preference when mapping the global nets to spare pins.
   
   .. option:: --verbose
 

--- a/openfpga/src/base/openfpga_pb_pin_fixup.cpp
+++ b/openfpga/src/base/openfpga_pb_pin_fixup.cpp
@@ -81,7 +81,7 @@ static int update_cluster_pin_global_net_with_post_routing_results(
     size_t cand_pin_start = pb_type_pin - pb_graph_pin->pin_number;
     size_t cand_pin_end = cand_pin_start + pb_graph_pin->port->num_pins;
     std::vector<size_t> cand_pins(pb_graph_pin->port->num_pins);
-    std::itoa(cand_pins.begin(), cand_pins.end(), cand_pin_start);
+    std::iota(cand_pins.begin(), cand_pins.end(), cand_pin_start);
     if (map_gnet2msb) {
       std::reverse(cand_pins.begin(), cand_pins.end());
     }

--- a/openfpga/src/base/openfpga_pb_pin_fixup.cpp
+++ b/openfpga/src/base/openfpga_pb_pin_fixup.cpp
@@ -79,7 +79,6 @@ static int update_cluster_pin_global_net_with_post_routing_results(
       "during routing optimization\n",
       clustering_ctx.clb_nlist.net_name(global_net_id).c_str());
     size_t cand_pin_start = pb_type_pin - pb_graph_pin->pin_number;
-    size_t cand_pin_end = cand_pin_start + pb_graph_pin->port->num_pins;
     std::vector<size_t> cand_pins(pb_graph_pin->port->num_pins);
     std::iota(cand_pins.begin(), cand_pins.end(), cand_pin_start);
     if (map_gnet2msb) {
@@ -363,7 +362,7 @@ int update_pb_pin_with_post_routing_results(
   int status = CMD_EXEC_SUCCESS;
   size_t num_fixup = 0;
   /* Confirm options */
-  VTR_LOGV(verbose && map_gnet2msb, "User choose to map global net to the best fit MSB of input port\n")
+  VTR_LOGV(verbose && map_gnet2msb, "User choose to map global net to the best fit MSB of input port\n");
   /* Ensure a clean start: remove all the remapping results from VTR's
    * post-routing clustering result sync-up */
   vpr_clustering_annotation.clear_net_remapping();

--- a/openfpga/src/base/openfpga_pb_pin_fixup.cpp
+++ b/openfpga/src/base/openfpga_pb_pin_fixup.cpp
@@ -32,10 +32,8 @@ namespace openfpga {
 static int update_cluster_pin_global_net_with_post_routing_results(
   const ClusteringContext& clustering_ctx,
   VprClusteringAnnotation& clustering_annotation, const ClusterBlockId& blk_id,
-  t_logical_block_type_ptr logical_block,
-  const bool& map_gnet2msb,
-  size_t& num_fixup,
-  const bool& verbose) {
+  t_logical_block_type_ptr logical_block, const bool& map_gnet2msb,
+  size_t& num_fixup, const bool& verbose) {
   /* Reassign global nets to unused pins in the same port where they were mapped
    * NO optimization is done here!!! First find first fit
    */
@@ -144,8 +142,7 @@ static int update_cluster_pin_with_post_routing_results(
   VprClusteringAnnotation& vpr_clustering_annotation, const size_t& layer,
   const vtr::Point<size_t>& grid_coord, const ClusterBlockId& blk_id,
   const e_side& border_side, const size_t& z, const bool& perimeter_cb,
-  const bool& map_gnet2msb,
-  size_t& num_fixup, const bool& verbose) {
+  const bool& map_gnet2msb, size_t& num_fixup, const bool& verbose) {
   int status = CMD_EXEC_SUCCESS;
   /* Handle each pin */
   auto logical_block = clustering_ctx.clb_nlist.block_type(blk_id);
@@ -343,8 +340,8 @@ static int update_cluster_pin_with_post_routing_results(
   }
   /* 2nd round of fixup: focus on global nets */
   status = update_cluster_pin_global_net_with_post_routing_results(
-    clustering_ctx, vpr_clustering_annotation, blk_id, logical_block, map_gnet2msb, num_fixup,
-    verbose);
+    clustering_ctx, vpr_clustering_annotation, blk_id, logical_block,
+    map_gnet2msb, num_fixup, verbose);
   return status;
 }
 
@@ -357,12 +354,12 @@ int update_pb_pin_with_post_routing_results(
   const PlacementContext& placement_ctx,
   const VprRoutingAnnotation& vpr_routing_annotation,
   VprClusteringAnnotation& vpr_clustering_annotation, const bool& perimeter_cb,
-  const bool& map_gnet2msb,
-  const bool& verbose) {
+  const bool& map_gnet2msb, const bool& verbose) {
   int status = CMD_EXEC_SUCCESS;
   size_t num_fixup = 0;
   /* Confirm options */
-  VTR_LOGV(verbose && map_gnet2msb, "User choose to map global net to the best fit MSB of input port\n");
+  VTR_LOGV(verbose && map_gnet2msb,
+           "User choose to map global net to the best fit MSB of input port\n");
   /* Ensure a clean start: remove all the remapping results from VTR's
    * post-routing clustering result sync-up */
   vpr_clustering_annotation.clear_net_remapping();

--- a/openfpga/src/base/openfpga_pb_pin_fixup.cpp
+++ b/openfpga/src/base/openfpga_pb_pin_fixup.cpp
@@ -32,7 +32,9 @@ namespace openfpga {
 static int update_cluster_pin_global_net_with_post_routing_results(
   const ClusteringContext& clustering_ctx,
   VprClusteringAnnotation& clustering_annotation, const ClusterBlockId& blk_id,
-  t_logical_block_type_ptr logical_block, size_t& num_fixup,
+  t_logical_block_type_ptr logical_block,
+  const bool& map_gnet2msb,
+  size_t& num_fixup,
   const bool& verbose) {
   /* Reassign global nets to unused pins in the same port where they were mapped
    * NO optimization is done here!!! First find first fit
@@ -78,9 +80,13 @@ static int update_cluster_pin_global_net_with_post_routing_results(
       clustering_ctx.clb_nlist.net_name(global_net_id).c_str());
     size_t cand_pin_start = pb_type_pin - pb_graph_pin->pin_number;
     size_t cand_pin_end = cand_pin_start + pb_graph_pin->port->num_pins;
+    std::vector<size_t> cand_pins(pb_graph_pin->port->num_pins);
+    std::itoa(cand_pins.begin(), cand_pins.end(), cand_pin_start);
+    if (map_gnet2msb) {
+      std::reverse(cand_pins.begin(), cand_pins.end());
+    }
     bool found_cand = false;
-    for (size_t cand_pin = cand_pin_start; cand_pin < cand_pin_end;
-         ++cand_pin) {
+    for (size_t cand_pin : cand_pins) {
       ClusterNetId cand_pin_net_id =
         clustering_ctx.clb_nlist.block_net(blk_id, cand_pin);
       const t_pb_graph_pin* cand_pb_graph_pin =
@@ -139,6 +145,7 @@ static int update_cluster_pin_with_post_routing_results(
   VprClusteringAnnotation& vpr_clustering_annotation, const size_t& layer,
   const vtr::Point<size_t>& grid_coord, const ClusterBlockId& blk_id,
   const e_side& border_side, const size_t& z, const bool& perimeter_cb,
+  const bool& map_gnet2msb,
   size_t& num_fixup, const bool& verbose) {
   int status = CMD_EXEC_SUCCESS;
   /* Handle each pin */
@@ -337,7 +344,7 @@ static int update_cluster_pin_with_post_routing_results(
   }
   /* 2nd round of fixup: focus on global nets */
   status = update_cluster_pin_global_net_with_post_routing_results(
-    clustering_ctx, vpr_clustering_annotation, blk_id, logical_block, num_fixup,
+    clustering_ctx, vpr_clustering_annotation, blk_id, logical_block, map_gnet2msb, num_fixup,
     verbose);
   return status;
 }
@@ -351,9 +358,12 @@ int update_pb_pin_with_post_routing_results(
   const PlacementContext& placement_ctx,
   const VprRoutingAnnotation& vpr_routing_annotation,
   VprClusteringAnnotation& vpr_clustering_annotation, const bool& perimeter_cb,
+  const bool& map_gnet2msb,
   const bool& verbose) {
   int status = CMD_EXEC_SUCCESS;
   size_t num_fixup = 0;
+  /* Confirm options */
+  VTR_LOGV(verbose && map_gnet2msb, "User choose to map global net to the best fit MSB of input port\n")
   /* Ensure a clean start: remove all the remapping results from VTR's
    * post-routing clustering result sync-up */
   vpr_clustering_annotation.clear_net_remapping();
@@ -384,7 +394,7 @@ int update_pb_pin_with_post_routing_results(
           device_ctx, clustering_ctx, vpr_routing_annotation,
           vpr_clustering_annotation, layer, grid_coord, cluster_blk_id,
           NUM_SIDES, placement_ctx.block_locs[cluster_blk_id].loc.sub_tile,
-          perimeter_cb, num_fixup, verbose);
+          perimeter_cb, map_gnet2msb, num_fixup, verbose);
         if (status != CMD_EXEC_SUCCESS) {
           return CMD_EXEC_FATAL_ERROR;
         }
@@ -419,7 +429,7 @@ int update_pb_pin_with_post_routing_results(
           device_ctx, clustering_ctx, vpr_routing_annotation,
           vpr_clustering_annotation, layer, io_coord, cluster_blk_id, io_side,
           placement_ctx.block_locs[cluster_blk_id].loc.sub_tile, perimeter_cb,
-          num_fixup, verbose);
+          map_gnet2msb, num_fixup, verbose);
         if (status != CMD_EXEC_SUCCESS) {
           return CMD_EXEC_FATAL_ERROR;
         }

--- a/openfpga/src/base/openfpga_pb_pin_fixup.h
+++ b/openfpga/src/base/openfpga_pb_pin_fixup.h
@@ -19,6 +19,7 @@ int update_pb_pin_with_post_routing_results(
   const PlacementContext& placement_ctx,
   const VprRoutingAnnotation& vpr_routing_annotation,
   VprClusteringAnnotation& vpr_clustering_annotation, const bool& perimeter_cb,
+  const bool& map_gnet2msb,
   const bool& verbose);
 
 } /* end namespace openfpga */

--- a/openfpga/src/base/openfpga_pb_pin_fixup.h
+++ b/openfpga/src/base/openfpga_pb_pin_fixup.h
@@ -19,8 +19,7 @@ int update_pb_pin_with_post_routing_results(
   const PlacementContext& placement_ctx,
   const VprRoutingAnnotation& vpr_routing_annotation,
   VprClusteringAnnotation& vpr_clustering_annotation, const bool& perimeter_cb,
-  const bool& map_gnet2msb,
-  const bool& verbose);
+  const bool& map_gnet2msb, const bool& verbose);
 
 } /* end namespace openfpga */
 

--- a/openfpga/src/base/openfpga_pb_pin_fixup_template.h
+++ b/openfpga/src/base/openfpga_pb_pin_fixup_template.h
@@ -35,6 +35,7 @@ int pb_pin_fixup_template(T& openfpga_context, const Command& cmd,
   vtr::ScopedStartFinishTimer timer(
     "Fix up pb pin mapping results after routing optimization");
 
+  CommandOptionId opt_map_gnet2msb = cmd.option("map_global_net_to_msb");
   CommandOptionId opt_verbose = cmd.option("verbose");
 
   /* Apply fix-up to each grid */
@@ -43,6 +44,7 @@ int pb_pin_fixup_template(T& openfpga_context, const Command& cmd,
     openfpga_context.vpr_routing_annotation(),
     openfpga_context.mutable_vpr_clustering_annotation(),
     g_vpr_ctx.device().arch->perimeter_cb,
+    cmd_context.option_enable(cmd, opt_map_gnet2msb),
     cmd_context.option_enable(cmd, opt_verbose));
 }
 

--- a/openfpga/src/base/openfpga_setup_command_template.h
+++ b/openfpga/src/base/openfpga_setup_command_template.h
@@ -324,6 +324,8 @@ ShellCommandId add_pb_pin_fixup_command_template(
   const std::vector<ShellCommandId>& dependent_cmds, const bool& hidden) {
   Command shell_cmd("pb_pin_fixup");
 
+  /* Add an option '--map_global_net_to_msb' */
+  shell_cmd.add_option("map_global_net_to_msb", false, "If specified, any global net including clock, reset etc, will be mapped to a best-fit Most Significant Bit (MSB) of input ports of programmable blocks. If not specified, a best-fit Least Significant Bit (LSB) will be the default choice");
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Show verbose outputs");
 

--- a/openfpga/src/base/openfpga_setup_command_template.h
+++ b/openfpga/src/base/openfpga_setup_command_template.h
@@ -325,7 +325,12 @@ ShellCommandId add_pb_pin_fixup_command_template(
   Command shell_cmd("pb_pin_fixup");
 
   /* Add an option '--map_global_net_to_msb' */
-  shell_cmd.add_option("map_global_net_to_msb", false, "If specified, any global net including clock, reset etc, will be mapped to a best-fit Most Significant Bit (MSB) of input ports of programmable blocks. If not specified, a best-fit Least Significant Bit (LSB) will be the default choice");
+  shell_cmd.add_option(
+    "map_global_net_to_msb", false,
+    "If specified, any global net including clock, reset etc, will be mapped "
+    "to a best-fit Most Significant Bit (MSB) of input ports of programmable "
+    "blocks. If not specified, a best-fit Least Significant Bit (LSB) will be "
+    "the default choice");
   /* Add an option '--verbose' */
   shell_cmd.add_option("verbose", false, "Show verbose outputs");
 

--- a/openfpga_flow/openfpga_shell_scripts/example_clkntwk_pb_pin_fixup_no_ace_script.openfpga
+++ b/openfpga_flow/openfpga_shell_scripts/example_clkntwk_pb_pin_fixup_no_ace_script.openfpga
@@ -22,7 +22,7 @@ append_clock_rr_graph
 # to debug use --verbose options
 link_openfpga_arch --sort_gsb_chan_node_in_edges
 
-pb_pin_fixup --verbose
+pb_pin_fixup ${OPENFPGA_PB_PIN_FIXUP_OPTIONS}
 
 # Route clock based on clock network definition
 route_clock_rr_graph ${OPENFPGA_ROUTE_CLOCK_OPTIONS} --pin_constraints_file ${OPENFPGA_PIN_CONSTRAINTS_FILE}

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -250,6 +250,7 @@ run-task basic_tests/clock_network/homo_1clock_1reset_3layer_2entry_disable_unus
 run-task basic_tests/clock_network/homo_1clock_1reset_2layer_y_entry $@
 run-task basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut $@
 run-task basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup $@
+run-task basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb $@
 run-task basic_tests/clock_network/homo_1clock_1reset_2layer_syntax $@
 run-task basic_tests/clock_network/homo_1clock_1reset_2layer_disable_unused_spines $@
 run-task basic_tests/clock_network/homo_1clock_1reset_2layer_internal_driver $@

--- a/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/clk_arch_1clk_1rst_2layer.xml
+++ b/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/clk_arch_1clk_1rst_2layer.xml
@@ -1,0 +1,34 @@
+<clock_networks default_segment="L1" default_tap_switch="ipin_cblock" default_driver_switch="0"> 
+  <clock_network name="clk_tree_2lvl" global_port="op_clk[0:0]"> 
+    <spine name="clk_spine_lvl0" start_x="1" start_y="1" end_x="2" end_y="1"> 
+      <switch_point tap="clk_rib_lvl1_sw0_upper" x="1" y="1"/> 
+      <switch_point tap="clk_rib_lvl1_sw0_lower" x="1" y="1"/> 
+      <switch_point tap="clk_rib_lvl1_sw1_upper" x="2" y="1"/> 
+      <switch_point tap="clk_rib_lvl1_sw1_lower" x="2" y="1"/> 
+    </spine>  
+    <spine name="clk_rib_lvl1_sw0_upper" start_x="1" start_y="2" end_x="1" end_y="2" type="CHANY" direction="INC_DIRECTION"/>
+    <spine name="clk_rib_lvl1_sw0_lower" start_x="1" start_y="1" end_x="1" end_y="1" type="CHANY" direction="DEC_DIRECTION"/>
+    <spine name="clk_rib_lvl1_sw1_upper" start_x="2" start_y="2" end_x="2" end_y="2" type="CHANY" direction="INC_DIRECTION"/>
+    <spine name="clk_rib_lvl1_sw1_lower" start_x="2" start_y="1" end_x="2" end_y="1" type="CHANY" direction="DEC_DIRECTION"/>
+    <taps>
+      <all from_pin="op_clk[0:0]" to_pin="clb[0:0].clk[0:0]"/>
+      <all from_pin="op_clk[0:0]" to_pin="clb[0:0].I[0:11]"/>
+    </taps>
+  </clock_network>  
+  <clock_network name="rst_tree_2lvl" global_port="op_reset[0:0]"> 
+    <spine name="rst_spine_lvl0" start_x="1" start_y="1" end_x="2" end_y="1"> 
+      <switch_point tap="rst_rib_lvl1_sw0_upper" x="1" y="1"/> 
+      <switch_point tap="rst_rib_lvl1_sw0_lower" x="1" y="1"/> 
+      <switch_point tap="rst_rib_lvl1_sw1_upper" x="2" y="1"/> 
+      <switch_point tap="rst_rib_lvl1_sw1_lower" x="2" y="1"/> 
+    </spine>  
+    <spine name="rst_rib_lvl1_sw0_upper" start_x="1" start_y="2" end_x="1" end_y="2" type="CHANY" direction="INC_DIRECTION"/>
+    <spine name="rst_rib_lvl1_sw0_lower" start_x="1" start_y="1" end_x="1" end_y="1" type="CHANY" direction="DEC_DIRECTION"/>
+    <spine name="rst_rib_lvl1_sw1_upper" start_x="2" start_y="2" end_x="2" end_y="2" type="CHANY" direction="INC_DIRECTION"/>
+    <spine name="rst_rib_lvl1_sw1_lower" start_x="2" start_y="1" end_x="2" end_y="1" type="CHANY" direction="DEC_DIRECTION"/>
+    <taps>
+      <all from_pin="op_reset[0:0]" to_pin="clb[0:0].reset[0:0]"/>
+      <all from_pin="op_reset[0:0]" to_pin="clb[0:0].I[0:11]"/>
+    </taps>
+  </clock_network>  
+</clock_networks> 

--- a/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/pin_constraints_clk.xml
+++ b/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/pin_constraints_clk.xml
@@ -1,0 +1,8 @@
+<pin_constraints>
+  <!-- For a given .blif file, we want to assign 
+       - the reset signal to the op_reset[0] port of the FPGA fabric
+    -->
+  <set_io pin="op_reset[0]" net="OPEN"/>
+  <set_io pin="op_clk[0]" net="clk"/>
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/pin_constraints_rst.xml
+++ b/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/pin_constraints_rst.xml
@@ -1,0 +1,8 @@
+<pin_constraints>
+  <!-- For a given .blif file, we want to assign 
+       - the reset signal to the op_reset[0] port of the FPGA fabric
+    -->
+  <set_io pin="op_reset[0]" net="rst"/>
+  <set_io pin="op_clk[0]" net="clk"/>
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/pin_constraints_rst_and_clk.xml
+++ b/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/pin_constraints_rst_and_clk.xml
@@ -1,0 +1,8 @@
+<pin_constraints>
+  <!-- For a given .blif file, we want to assign 
+       - the reset signal to the op_reset[0] port of the FPGA fabric
+    -->
+  <set_io pin="op_reset[0]" net="rst"/>
+  <set_io pin="op_clk[0]" net="clk"/>
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/repack_pin_constraints.xml
+++ b/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/repack_pin_constraints.xml
@@ -1,0 +1,4 @@
+<repack_design_constraints>
+  <!-- Intended to be dummy -->
+</repack_design_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/clock_network/homo_1clock_1reset_2layer_on_lut_pb_pin_fixup_msb/config/task.conf
@@ -25,7 +25,7 @@ openfpga_vpr_route_chan_width=32
 openfpga_clock_arch_file=${PATH:TASK_DIR}/config/clk_arch_1clk_1rst_2layer.xml
 openfpga_verilog_testbench_port_mapping=--explicit_port_mapping
 openfpga_route_clock_options=
-openfpga_pb_pin_fixup_options=--verbose
+openfpga_pb_pin_fixup_options=--map_global_net_to_msb --verbose
 
 [ARCHITECTURES]
 arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff_40nm.xml


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:

- When ``--clock_modeling ideal`` is selected when running VPR, global nets will not be routed and their pin mapping on programmable blocks may be revoked by other nets due to optimization. Therefore, this command will restore the pin mapping for the global nets and pick a spare pin on programmable blocks. 
- Currently, when selecting the proper pin for mapping, the first found spare *Least Significant Bit* (LSB) will be applied. However, we see limitations that some LSB pins may not be accessible to programmable global network. Therefore, MSB should also be considered as an option.


>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- Added a new option ``--map_global_net_to_msb`` for command ``pb_pin_fixup``
- Added a new testcase to validate the new feature
- Update documentation for the new option

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
