### PR TITLE
Added Verilog Writer API: Enable string version of default nettype and define flags

### DIFF
--- a/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
@@ -30,10 +30,12 @@ namespace openfpga {
  ***********************************************/
 std::string generate_verilog_default_net_type_declaration(
   const e_verilog_default_net_type& default_net_type) {
-  return std::string("`default_nettype ") + std::string(VERILOG_DEFAULT_NET_TYPE_STRING[default_net_type])
+  return std::string("`default_nettype ") +
+         std::string(VERILOG_DEFAULT_NET_TYPE_STRING[default_net_type])
 }
 
-/* Using fstream is not flexible enough. Sometime downstream tool prefer ofstream. So, an API to generate string is developed here. */
+/* Using fstream is not flexible enough. Sometime downstream tool prefer
+ * ofstream. So, an API to generate string is developed here. */
 void print_verilog_default_net_type_declaration(
   std::fstream& fp, const e_verilog_default_net_type& default_net_type) {
   VTR_ASSERT(true == valid_file_stream(fp));
@@ -88,11 +90,12 @@ void print_verilog_include_netlist(std::fstream& fp,
  * Print Verilog codes to define a preprocessing flag
  *******************************************************************/
 std::string generate_verilog_define_flag(const std::string& flag_name,
-                               const int& flag_value) {
+                                         const int& flag_value) {
   return std::string("`define ") + flag_name + std::string(" ") + flag_value;
 }
 
-/* Using fstream is not flexible enough. Sometime downstream tool prefer ofstream. So, an API to generate string is developed here. */
+/* Using fstream is not flexible enough. Sometime downstream tool prefer
+ * ofstream. So, an API to generate string is developed here. */
 void print_verilog_define_flag(std::fstream& fp, const std::string& flag_name,
                                const int& flag_value) {
   VTR_ASSERT(true == valid_file_stream(fp));

--- a/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
+++ b/openfpga/src/fpga_verilog/verilog_writer_utils.cpp
@@ -28,12 +28,18 @@ namespace openfpga {
 /************************************************
  * Generate the declaration for default net type
  ***********************************************/
+std::string generate_verilog_default_net_type_declaration(
+  const e_verilog_default_net_type& default_net_type) {
+  return std::string("`default_nettype ") + std::string(VERILOG_DEFAULT_NET_TYPE_STRING[default_net_type])
+}
+
+/* Using fstream is not flexible enough. Sometime downstream tool prefer ofstream. So, an API to generate string is developed here. */
 void print_verilog_default_net_type_declaration(
   std::fstream& fp, const e_verilog_default_net_type& default_net_type) {
   VTR_ASSERT(true == valid_file_stream(fp));
 
   fp << "//----- Default net type -----" << std::endl;
-  fp << "`default_nettype " << VERILOG_DEFAULT_NET_TYPE_STRING[default_net_type]
+  fp << generate_verilog_default_net_type_declaration(default_net_type)
      << std::endl;
   fp << std::endl;
 }
@@ -81,11 +87,17 @@ void print_verilog_include_netlist(std::fstream& fp,
 /********************************************************************
  * Print Verilog codes to define a preprocessing flag
  *******************************************************************/
+std::string generate_verilog_define_flag(const std::string& flag_name,
+                               const int& flag_value) {
+  return std::string("`define ") + flag_name + std::string(" ") + flag_value;
+}
+
+/* Using fstream is not flexible enough. Sometime downstream tool prefer ofstream. So, an API to generate string is developed here. */
 void print_verilog_define_flag(std::fstream& fp, const std::string& flag_name,
                                const int& flag_value) {
   VTR_ASSERT(true == valid_file_stream(fp));
 
-  fp << "`define " << flag_name << " " << flag_value << std::endl;
+  fp << generate_verilog_define_flag(flag_name, flag_value) << std::endl;
 }
 
 /************************************************

--- a/openfpga/src/fpga_verilog/verilog_writer_utils.h
+++ b/openfpga/src/fpga_verilog/verilog_writer_utils.h
@@ -32,6 +32,8 @@ namespace openfpga {
  * in order to keep a clean header/source file as well maintain a easy way to
  * identify the functions
  */
+std::string generate_verilog_default_net_type_declaration(
+  const e_verilog_default_net_type& default_net_type);
 
 void print_verilog_default_net_type_declaration(
   std::fstream& fp, const e_verilog_default_net_type& default_net_type);
@@ -43,6 +45,8 @@ void print_verilog_file_header(std::fstream& fp, const std::string& usage,
 void print_verilog_include_netlist(std::fstream& fp,
                                    const std::string& netlist_name);
 
+std::string generate_verilog_define_flag(const std::string& flag_name,
+                               const int& flag_value);
 void print_verilog_define_flag(std::fstream& fp, const std::string& flag_name,
                                const int& flag_value);
 

--- a/openfpga/src/fpga_verilog/verilog_writer_utils.h
+++ b/openfpga/src/fpga_verilog/verilog_writer_utils.h
@@ -46,7 +46,7 @@ void print_verilog_include_netlist(std::fstream& fp,
                                    const std::string& netlist_name);
 
 std::string generate_verilog_define_flag(const std::string& flag_name,
-                               const int& flag_value);
+                                         const int& flag_value);
 void print_verilog_define_flag(std::fstream& fp, const std::string& flag_name,
                                const int& flag_value);
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- OpenFPGA is used in commercial tool chains through APIs. In some context, the ``std::ofstream`` is required to write/rewrite Verilog netlists. However, existing API only supports ``std::fstream``.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Added Verilog Writer API: Enable string version of default nettype and define flags. Now developers can freely select any type of ``fstream``. The string version is a general solution.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
