### PR TITLE
Fixed the bug where last stage MUX standard cell may be disconnected from MUX inputs

### DIFF
--- a/openfpga/src/fabric/build_mux_modules.cpp
+++ b/openfpga/src/fabric/build_mux_modules.cpp
@@ -676,15 +676,17 @@ static void build_cmos_mux_module_mux2_multiplexing_structure(
       size_t input_node_level = mux_graph.node_level(input_nodes[node_id]);
       size_t input_node_index_at_level =
         mux_graph.node_index_at_level(input_nodes[node_id]);
-      /* For a single-level MUX, which is only module between the inputs and outputs, should handle it in a special way */
-      if (true == mux_graph.is_node_input(input_nodes[node_id]) && true == mux_graph.is_node_output(node)) {
+      /* For a single-level MUX, which is only module between the inputs and
+       * outputs, should handle it in a special way */
+      if (true == mux_graph.is_node_input(input_nodes[node_id]) &&
+          true == mux_graph.is_node_output(node)) {
         MuxInputId input_id = mux_graph.input_id(input_nodes[node_id]);
         module_manager.add_module_net_sink(
           mux_module, mux_module_input_nets[input_id],
           curr_stage_std_cell_module_id, std_cell_instance_id,
           last_stage_std_cell_module_inputs[node_id],
           last_stage_std_cell_module_input_ports[node_id].get_lsb());
-      /* For inputs of mux, the net id is reserved */
+        /* For inputs of mux, the net id is reserved */
       } else if (true == mux_graph.is_node_input(input_nodes[node_id])) {
         /* Get node input id */
         MuxInputId input_id = mux_graph.input_id(input_nodes[node_id]);

--- a/openfpga/src/fabric/build_mux_modules.cpp
+++ b/openfpga/src/fabric/build_mux_modules.cpp
@@ -689,7 +689,7 @@ static void build_cmos_mux_module_mux2_multiplexing_structure(
         module_manager.add_module_net_sink(
           mux_module,
           module_nets_by_level[input_node_level][input_node_index_at_level],
-          last_stage_std_cell_module_id, std_cell_instance_id,
+          curr_stage_std_cell_module_id, std_cell_instance_id,
           last_stage_std_cell_module_inputs[node_id],
           last_stage_std_cell_module_input_ports[node_id].get_lsb());
       } else {

--- a/openfpga/src/fabric/build_mux_modules.cpp
+++ b/openfpga/src/fabric/build_mux_modules.cpp
@@ -676,8 +676,16 @@ static void build_cmos_mux_module_mux2_multiplexing_structure(
       size_t input_node_level = mux_graph.node_level(input_nodes[node_id]);
       size_t input_node_index_at_level =
         mux_graph.node_index_at_level(input_nodes[node_id]);
+      /* For a single-level MUX, which is only module between the inputs and outputs, should handle it in a special way */
+      if (true == mux_graph.is_node_input(input_nodes[node_id]) && true == mux_graph.is_node_output(node)) {
+        MuxInputId input_id = mux_graph.input_id(input_nodes[node_id]);
+        module_manager.add_module_net_sink(
+          mux_module, mux_module_input_nets[input_id], std_cell_module_id,
+          curr_stage_std_cell_module_id, std_cell_instance_id,
+          last_stage_std_cell_module_inputs[node_id],
+          last_stage_std_cell_module_input_ports[node_id].get_lsb());
       /* For inputs of mux, the net id is reserved */
-      if (true == mux_graph.is_node_input(input_nodes[node_id])) {
+      } else if (true == mux_graph.is_node_input(input_nodes[node_id])) {
         /* Get node input id */
         MuxInputId input_id = mux_graph.input_id(input_nodes[node_id]);
         module_manager.add_module_net_sink(

--- a/openfpga/src/fabric/build_mux_modules.cpp
+++ b/openfpga/src/fabric/build_mux_modules.cpp
@@ -680,7 +680,7 @@ static void build_cmos_mux_module_mux2_multiplexing_structure(
       if (true == mux_graph.is_node_input(input_nodes[node_id]) && true == mux_graph.is_node_output(node)) {
         MuxInputId input_id = mux_graph.input_id(input_nodes[node_id]);
         module_manager.add_module_net_sink(
-          mux_module, mux_module_input_nets[input_id], std_cell_module_id,
+          mux_module, mux_module_input_nets[input_id],
           curr_stage_std_cell_module_id, std_cell_instance_id,
           last_stage_std_cell_module_inputs[node_id],
           last_stage_std_cell_module_input_ports[node_id].get_lsb());

--- a/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/fpga_verilog_reg_test.sh
@@ -85,6 +85,7 @@ run-task fpga_verilog/mux_design/tree_structure $@
 echo -e "Testing Verilog generation with routing multiplexers implemented by standard cell MUX2";
 run-task fpga_verilog/mux_design/stdcell_mux2 $@
 run-task fpga_verilog/mux_design/stdcell_mux2_last_stage $@
+run-task fpga_verilog/mux_design/stdcell_mux2_last_stage_size2 $@
 
 echo -e "Testing Verilog generation with routing multiplexers implemented by local encoders";
 run-task fpga_verilog/mux_design/local_encoder $@

--- a/openfpga_flow/tasks/fpga_verilog/mux_design/stdcell_mux2_last_stage_size2/config/task.conf
+++ b/openfpga_flow/tasks/fpga_verilog/mux_design/stdcell_mux2_last_stage_size2/config/task.conf
@@ -1,0 +1,39 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_route_chan_width_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k6_frac_N8_stdcell_laststage_mux_40nm_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=2x2
+openfpga_vpr_route_chan_width=20
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k6_frac_N8_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_act = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.act
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+bench0_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- When the last stage of a MUX circuit model is defined to be different, a bug may arise when
  
  - The last stage MUX is also driven by an input of the MUX. This happens to some single-level MUX or special MUX tree

For example
```
// ----- Verilog module for sb_mux_size2 -----
module sb_mux_size2(in,
                    sram,
                    sram_inv,
                    out);
//----- INPUT PORTS -----
input [0:1] in;
//----- INPUT PORTS -----
input [0:1] sram;
//----- INPUT PORTS -----
input [0:1] sram_inv;
//----- OUTPUT PORTS -----
output [0:0] out;

//----- BEGIN Registered ports -----
//----- END Registered ports -----



// ----- BEGIN Local short connections -----
// ----- END Local short connections -----
// ----- BEGIN Local output short connections -----
// ----- END Local output short connections -----

	const0 const0_0_ (
		.const0(const0_0_const0));

	SB_MUX2_WRAPPER mux_l1_in_0_ (
		.in1_i(in[0]),
		.in0_i(const0_0_const0),
		.sel_i(sram[0]),
		.out_o(SB_MUX2_WRAPPER_0_out_o));

	SB_LS_MUX2_WRAPPER mux_l2_in_0_ (
		.in1_i(SB_MUX2_WRAPPER_0_out_o),
		.in0_i(mux_l2_in_0__undriven_in0_i),
		.sel_i(sram[1]),
		.out_o(out));

endmodule
// ----- END Verilog module for sb_mux_size2 -----
```

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- Fixed the bug.

```
// ----- Verilog module for sb_mux_size2 -----
module sb_mux_size2(in,
                    sram,
                    sram_inv,
                    out);
//----- INPUT PORTS -----
input [0:1] in;
//----- INPUT PORTS -----
input [0:1] sram;
//----- INPUT PORTS -----
input [0:1] sram_inv;
//----- OUTPUT PORTS -----
output [0:0] out;

//----- BEGIN Registered ports -----
//----- END Registered ports -----



// ----- BEGIN Local short connections -----
// ----- END Local short connections -----
// ----- BEGIN Local output short connections -----
// ----- END Local output short connections -----

	const0 const0_0_ (
		.const0(const0_0_const0));

	SB_MUX2_WRAPPER mux_l1_in_0_ (
		.in1_i(in[0]),
		.in0_i(in[1]),
		.sel_i(sram[0]),
		.out_o(SB_MUX2_WRAPPER_0_out_o));

	SB_LS_MUX2_WRAPPER mux_l2_in_0_ (
		.in1_i(SB_MUX2_WRAPPER_0_out_o),
		.in0_i(const0_0_const0),
		.sel_i(sram[1]),
		.out_o(out));

endmodule
// ----- END Verilog module for sb_mux_size2 -----
```

After the patch, 

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [x] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
