### PR TITLE
Support HEX and BIN format with little/big endian for mode bits in architecture description

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,51 +284,52 @@ jobs:
           git config --global --add safe.directory '*'
           make all BUILD_TYPE=$BUILD_TYPE 
 
-  ubuntu_support:
-    needs: change_detect
-    if: ${{ fromJSON(needs.change_detect.outputs.source_modified) }}
-    name: ${{ matrix.config.name }}
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - name: "Build (GCC-11 on Ubuntu 20.04)"
-            cc: gcc-11
-            cxx: g++-11
-            dependency_version: "ubuntu20p04"
-          - name: "Build (Clang-10 on Ubuntu 20.04)"
-            cc: clang-10
-            cxx: clang++-10
-            dependency_version: "ubuntu20p04"
-    # Define the steps to run the build job
-    env:
-      CC: ${{ matrix.config.cc }}
-      CXX: ${{ matrix.config.cxx }}
-    steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
-          
-      - name: Checkout OpenFPGA repo
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: sudo bash ./.github/workflows/install_dependencies_build_${{ matrix.config.dependency_version }}.sh
-      
-      - name: Dump tool versions
-        run: |
-          cmake --version
-          ${CC} --version
-          ${CXX} --version
-
-      - uses: hendrikmuhs/ccache-action@v1
-
-      - name: Build
-        shell: bash
-        run: |
-          make all BUILD_TYPE=$BUILD_TYPE 
+# TODO: Support 24.04
+#  ubuntu_support:
+#    needs: change_detect
+#    if: ${{ fromJSON(needs.change_detect.outputs.source_modified) }}
+#    name: ${{ matrix.config.name }}
+#    runs-on: ubuntu-20.04
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        config:
+#          - name: "Build (GCC-11 on Ubuntu 20.04)"
+#            cc: gcc-11
+#            cxx: g++-11
+#            dependency_version: "ubuntu20p04"
+#          - name: "Build (Clang-10 on Ubuntu 20.04)"
+#            cc: clang-10
+#            cxx: clang++-10
+#            dependency_version: "ubuntu20p04"
+#    # Define the steps to run the build job
+#    env:
+#      CC: ${{ matrix.config.cc }}
+#      CXX: ${{ matrix.config.cxx }}
+#    steps:
+#      - name: Cancel previous
+#        uses: styfle/cancel-workflow-action@0.12.1
+#        with:
+#          access_token: ${{ github.token }}
+#          
+#      - name: Checkout OpenFPGA repo
+#        uses: actions/checkout@v4
+#
+#      - name: Install dependencies
+#        run: sudo bash ./.github/workflows/install_dependencies_build_${{ matrix.config.dependency_version }}.sh
+#      
+#      - name: Dump tool versions
+#        run: |
+#          cmake --version
+#          ${CC} --version
+#          ${CXX} --version
+#
+#      - uses: hendrikmuhs/ccache-action@v1
+#
+#      - name: Build
+#        shell: bash
+#        run: |
+#          make all BUILD_TYPE=$BUILD_TYPE 
 
   debug_build:
     needs: change_detect

--- a/docs/source/manual/arch_lang/annotate_vpr_arch.rst
+++ b/docs/source/manual/arch_lang/annotate_vpr_arch.rst
@@ -248,7 +248,7 @@ The ``circuit_model_name`` should match the given name of a ``circuit_model`` de
 
   - ``circuit_model_name="<string>"`` Specify a circuit model to implement a ``pb_type`` in VPR architecture. The ``circuit_model_name`` is mandatory for every primitive``pb_type`` in a physical_mode ``pb_type``.
 
-  - ``mode_bits="<int>"`` Specify the configuration bits for the ``circuit_model`` when operating at an operating mode. The length of ``mode_bits`` should match the ``port`` size defined in ``circuit_model``. The ``mode_bits`` should be derived from circuit designs while users are responsible for its correctness. FPGA-Bitstreamm will add the ``mode_bits`` during bitstream generation.
+  - ``mode_bits="<string>"`` Specify the configuration bits for the ``circuit_model`` when operating at an operating mode. The length of ``mode_bits`` should match the ``port`` size defined in ``circuit_model``. The ``mode_bits`` should be derived from circuit designs while users are responsible for its correctness. FPGA-Bitstreamm will add the ``mode_bits`` during bitstream generation. **Note that mode bits are default in big-endian format**. User can provide in binary format (e.g., ``00011111``) or HEX format (e.g., ``8h'1F``) 
 
   - ``physical_pb_type_index_factor="<float>"`` aims to align the indices for ``pb_type`` between operating and physical modes, especially when an operating mode contains multiple ``pb_type`` (``num_pb``>1) that are linked to the same physical ``pb_type``. When ``physical_pb_type_name`` is larger than 1, the  index of ``pb_type`` will be multipled by the given factor. 
 

--- a/docs/source/manual/arch_lang/annotate_vpr_arch.rst
+++ b/docs/source/manual/arch_lang/annotate_vpr_arch.rst
@@ -248,7 +248,7 @@ The ``circuit_model_name`` should match the given name of a ``circuit_model`` de
 
   - ``circuit_model_name="<string>"`` Specify a circuit model to implement a ``pb_type`` in VPR architecture. The ``circuit_model_name`` is mandatory for every primitive``pb_type`` in a physical_mode ``pb_type``.
 
-  - ``mode_bits="<string>"`` Specify the configuration bits for the ``circuit_model`` when operating at an operating mode. The length of ``mode_bits`` should match the ``port`` size defined in ``circuit_model``. The ``mode_bits`` should be derived from circuit designs while users are responsible for its correctness. FPGA-Bitstreamm will add the ``mode_bits`` during bitstream generation. **Note that mode bits are default in big-endian format**. User can provide in binary format (e.g., ``00011111``) or HEX format (e.g., ``8h'1F``) 
+  - ``mode_bits="<string>"`` Specify the configuration bits for the ``circuit_model`` when operating at an operating mode. The length of ``mode_bits`` should match the ``port`` size defined in ``circuit_model``. The ``mode_bits`` should be derived from circuit designs while users are responsible for its correctness. FPGA-Bitstream will add the ``mode_bits`` during bitstream generation. See details in :ref:`file_formats_bitstream_setting_mode_bit` about the format 
 
   - ``physical_pb_type_index_factor="<float>"`` aims to align the indices for ``pb_type`` between operating and physical modes, especially when an operating mode contains multiple ``pb_type`` (``num_pb``>1) that are linked to the same physical ``pb_type``. When ``physical_pb_type_name`` is larger than 1, the  index of ``pb_type`` will be multipled by the given factor. 
 

--- a/docs/source/manual/file_formats/bitstream_setting.rst
+++ b/docs/source/manual/file_formats/bitstream_setting.rst
@@ -77,9 +77,17 @@ The following syntax are applicable to the XML definition tagged by ``default_mo
 
   .. note:: Bitstream setting has a higher priority than the ``mode_bits`` definition in the OpenFPGA architecture description!
 
+  In binary format: 
+
   .. code-block:: xml
 
     mode_bits="0100"
+
+  In hexadecimal format: 
+
+  .. code-block:: xml
+
+    mode_bits="4h'4"
 
 
 Interconnection-related Settings

--- a/docs/source/manual/file_formats/bitstream_setting.rst
+++ b/docs/source/manual/file_formats/bitstream_setting.rst
@@ -56,6 +56,9 @@ The following syntax are applicable to the XML definition tagged by ``pb_type`` 
 
   Specify the offset to be applied when overloading the bitstream to a target. For example, a LUT may have a 16-bit bitstream. When ``offset=1``, bitstream overloading will skip the first bit and start from the second bit of the 16-bit bitstream.
 
+
+.. _file_formats_bitstream_setting_mode_bit:
+
 Default Mode Bits-related Settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -77,17 +80,38 @@ The following syntax are applicable to the XML definition tagged by ``default_mo
 
   .. note:: Bitstream setting has a higher priority than the ``mode_bits`` definition in the OpenFPGA architecture description!
 
-  In binary format: 
+  .. note:: Mode bits are default in big-endian format!
+
+  In binary format with a few available options: 
 
   .. code-block:: xml
 
-    mode_bits="0100"
+    <!-- The following are equivalent in functionality -->
+    <!-- BIN in big endian defined implicitedly -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="010011"/>
+    <!-- BIN in big endian -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6B'010011"/>
+    <!-- BIN in big endian with splitter -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6B'01_0011"/>
+    <!-- BIN in little endian -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6b'110010"/>
+    <!-- BIN in little endian with splitter -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6b'11_0010"/>
 
-  In hexadecimal format: 
+  In hexadecimal format with a few available options: 
 
   .. code-block:: xml
 
-    mode_bits="4h'4"
+    <!-- The following are equivalent in functionality -->
+    <!-- HEX in big endian -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6H'13/>
+    <!-- HEX in big endian with splitter -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6H'1_3/>
+    <!-- HEX in little endian -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6h'32/>
+    <!-- HEX in little endian with splitter -->
+    <default_mode_bits name="clb.fle[arithmetic].soft_adder.adder_lut4" mode_bits="6h'3_2/>
+ 
 
 
 Interconnection-related Settings

--- a/docs/source/tutorials/getting_started/compile.rst
+++ b/docs/source/tutorials/getting_started/compile.rst
@@ -12,7 +12,7 @@ How to Compile
 Supported Operating Systems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-OpenFPGA is continously tested with Ubuntu 22.04 and partially on Ubuntu 20.04 
+OpenFPGA is continously tested with Ubuntu 22.04
 It might work with earlier versions and other distributions.
 
 In addition to continous integration, our community users have tested OpenFPGA on their local machines using the following operating systems:
@@ -22,6 +22,7 @@ In addition to continous integration, our community users have tested OpenFPGA o
 - CentOS 9
 - Ubuntu 18.04
 - Ubuntu 21.04
+- Ubuntu 20.04 
 
 Build Steps
 ~~~~~~~~~~~

--- a/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
+++ b/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
@@ -24,6 +24,7 @@
 std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
                                     const pugiutil::loc_data& loc_data,
                                     const std::string& mode_bit_str) {
+  /* Return if the input is empty */
   openfpga::BitsParser bits_parser(mode_bit_str);
   if (!bits_parser.valid()) {
     archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),

--- a/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
+++ b/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
@@ -15,12 +15,13 @@
 /* Headers from libarchfpga */
 #include "arch_error.h"
 #include "read_xml_openfpga_arch_utils.h"
+#include "openfpga_bit_parser.h"
 
 /********************************************************************
  * Parse mode_bits: convert from string to array of digits
  * We only allow the bit to either '0' or '1'
  *******************************************************************/
-std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
+static std::vector<size_t> parse_mode_bits_bin_format(pugi::xml_node& xml_mode_bits,
                                     const pugiutil::loc_data& loc_data,
                                     const std::string& mode_bit_str) {
   std::vector<size_t> mode_bits;
@@ -37,6 +38,45 @@ std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
                      bit_char, mode_bit_str.c_str());
     }
   }
+  return mode_bits;
+}
 
+/********************************************************************
+ * Parse mode_bits: convert from string to array of digits
+ * We only allow the bit to either '0' or '1'
+ *******************************************************************/
+std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
+                                    const pugiutil::loc_data& loc_data,
+                                    const std::string& mode_bit_str) {
+  openfpga::BitsParser bit_parser(mode_bit_str);
+  if (!bit_parser.status())
+    archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
+                   "Invalid format of mode bit '%s'! Expect to be binary or HEX format. For example, 1100 or 4b'1100 or 4h'A\n",
+                   mode_bit_str.c_str());
+  }
+  return bit_parser.data();
+}
+
+  /* Check the head, if starts with an apostrophy, consider the format. Otherwise, following binary format as default */
+  std::string format_delim = "'";
+  openfpga::StringToken str_tok(mode_bit_str);
+  std::vector<std::string> tokens = str_tok.split(format_delim); 
+  if (tokens.size() == 1) {
+    /* Binary format */
+    return parse_mode_bits_bin_format(xml_mode_bits, loc_data, mode_bit_str);
+  } else if (tokens.size() > 2) {
+    /* Invalid format, error out ! */
+    archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
+                   "Invalid format of mode bit '%s'! Expect to be binary or HEX format. For example, 1100 or 4b'1100 or 4h'A\n",
+                   mode_bit_str.c_str());
+  } else {
+    VTR_ASSERT_SAFE(tokens.size() == 2);
+    /* Parse the format */
+    std::string bin_format = "b";
+    std::string bin_format = "b";
+    std::string fmt_type = tokens[0].back();
+    if (fmt_type == std::string("b")) 
+  }
+  
   return mode_bits;
 }

--- a/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
+++ b/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
@@ -26,10 +26,10 @@ std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
                                     const pugiutil::loc_data& loc_data,
                                     const std::string& mode_bit_str) {
   openfpga::BitsParser bits_parser(mode_bit_str);
-  if (!bit_parser.valid())
+  if (!bits_parser.valid())
     archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
                    "Invalid format of mode bit '%s'!\n",
                    mode_bit_str.c_str());
   }
-  return bit_parser.result();
+  return bits_parser.result();
 }

--- a/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
+++ b/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
@@ -17,7 +17,6 @@
 #include "read_xml_openfpga_arch_utils.h"
 #include "openfpga_bits_parser.h"
 
-
 /********************************************************************
  * Parse mode_bits: convert from string to array of digits
  * We only allow the bit to either '0' or '1'

--- a/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
+++ b/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
@@ -26,7 +26,7 @@ std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
                                     const pugiutil::loc_data& loc_data,
                                     const std::string& mode_bit_str) {
   openfpga::BitsParser bits_parser(mode_bit_str);
-  if (!bits_parser.valid())
+  if (!bits_parser.valid()) {
     archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
                    "Invalid format of mode bit '%s'!\n",
                    mode_bit_str.c_str());

--- a/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
+++ b/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
@@ -14,8 +14,8 @@
 
 /* Headers from libarchfpga */
 #include "arch_error.h"
-#include "read_xml_openfpga_arch_utils.h"
 #include "openfpga_bits_parser.h"
+#include "read_xml_openfpga_arch_utils.h"
 
 /********************************************************************
  * Parse mode_bits: convert from string to array of digits
@@ -28,8 +28,7 @@ std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
   openfpga::BitsParser bits_parser(mode_bit_str);
   if (!bits_parser.valid()) {
     archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
-                   "Invalid format of mode bit '%s'!\n",
-                   mode_bit_str.c_str());
+                   "Invalid format of mode bit '%s'!\n", mode_bit_str.c_str());
   }
   return bits_parser.result();
 }

--- a/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
+++ b/libs/libarchopenfpga/src/read_xml_openfpga_arch_utils.cpp
@@ -15,31 +15,8 @@
 /* Headers from libarchfpga */
 #include "arch_error.h"
 #include "read_xml_openfpga_arch_utils.h"
-#include "openfpga_bit_parser.h"
+#include "openfpga_bits_parser.h"
 
-/********************************************************************
- * Parse mode_bits: convert from string to array of digits
- * We only allow the bit to either '0' or '1'
- *******************************************************************/
-static std::vector<size_t> parse_mode_bits_bin_format(pugi::xml_node& xml_mode_bits,
-                                    const pugiutil::loc_data& loc_data,
-                                    const std::string& mode_bit_str) {
-  std::vector<size_t> mode_bits;
-
-  for (const char& bit_char : mode_bit_str) {
-    if ('0' == bit_char) {
-      mode_bits.push_back(0);
-    } else if ('1' == bit_char) {
-      mode_bits.push_back(1);
-    } else {
-      archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
-                     "Unexpected '%c' character found in the mode bit '%s'! "
-                     "Only allow either '0' or '1'\n",
-                     bit_char, mode_bit_str.c_str());
-    }
-  }
-  return mode_bits;
-}
 
 /********************************************************************
  * Parse mode_bits: convert from string to array of digits
@@ -48,35 +25,11 @@ static std::vector<size_t> parse_mode_bits_bin_format(pugi::xml_node& xml_mode_b
 std::vector<size_t> parse_mode_bits(pugi::xml_node& xml_mode_bits,
                                     const pugiutil::loc_data& loc_data,
                                     const std::string& mode_bit_str) {
-  openfpga::BitsParser bit_parser(mode_bit_str);
-  if (!bit_parser.status())
+  openfpga::BitsParser bits_parser(mode_bit_str);
+  if (!bit_parser.valid())
     archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
-                   "Invalid format of mode bit '%s'! Expect to be binary or HEX format. For example, 1100 or 4b'1100 or 4h'A\n",
+                   "Invalid format of mode bit '%s'!\n",
                    mode_bit_str.c_str());
   }
-  return bit_parser.data();
-}
-
-  /* Check the head, if starts with an apostrophy, consider the format. Otherwise, following binary format as default */
-  std::string format_delim = "'";
-  openfpga::StringToken str_tok(mode_bit_str);
-  std::vector<std::string> tokens = str_tok.split(format_delim); 
-  if (tokens.size() == 1) {
-    /* Binary format */
-    return parse_mode_bits_bin_format(xml_mode_bits, loc_data, mode_bit_str);
-  } else if (tokens.size() > 2) {
-    /* Invalid format, error out ! */
-    archfpga_throw(loc_data.filename_c_str(), loc_data.line(xml_mode_bits),
-                   "Invalid format of mode bit '%s'! Expect to be binary or HEX format. For example, 1100 or 4b'1100 or 4h'A\n",
-                   mode_bit_str.c_str());
-  } else {
-    VTR_ASSERT_SAFE(tokens.size() == 2);
-    /* Parse the format */
-    std::string bin_format = "b";
-    std::string bin_format = "b";
-    std::string fmt_type = tokens[0].back();
-    if (fmt_type == std::string("b")) 
-  }
-  
-  return mode_bits;
+  return bit_parser.result();
 }

--- a/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
+++ b/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
@@ -118,6 +118,20 @@ void BitsParser::parse_hex_format(const std::string& bits_str, const bool& littl
     }
     bin_str += bin_segment;
   }
+  /* Remove the redundant bits due to length definition */
+  if (expected_len > bin_str.size()) {
+    VTR_LOG_ERROR("Invalid length '%lu' of bits '%s' which is larger than its data size '%lu'!\n", expected_len, bits_str.c_str(), data_.c_str(), bin_str.size());
+    valid_ = false; 
+    return;
+  }
+  if (expected_len <= bin_str.size() - 4) {
+    VTR_LOG_ERROR("Invalid length '%lu' of bits '%s' which is much smaller than its data size '%lu'! This may cause data loss! Please double check\n", expected_len, bits_str.c_str(), data_.c_str(), bin_str.size());
+    valid_ = false; 
+    return;
+  }
+  if (expected_len < bin_str.size()) {
+    bin_str.erase(0, bin_str.size() - expected_len); 
+  }
   parse_bin_format(bin_str, little_endian, expected_len);
 }
 

--- a/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
+++ b/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
@@ -29,7 +29,6 @@ BitsParser::BitsParser(const std::string& data) {
   hex_format_be_code_ = 'H';
   hex_format_le_code_ = 'h';
   set_data(data);
-  valid_ = false;
 }
 
 /************************************************************************
@@ -140,10 +139,17 @@ void BitsParser::parse_hex_format(const std::string& bits_str, const bool& littl
 /* Parse the data */
 void BitsParser::parse() {
   valid_ = true;
+  if (data_.empty()) {
+    result_.clear();
+    return; /* Nothing to do */
+  }
   /* Create a tokenizer */
   StringToken tokenizer(data_);
   std::vector<std::string> tokens = tokenizer.split(delim_); 
-  if (tokens.size() == 1) {
+  if (tokens.size() == 0) {
+    /* Binary format */
+    parse_bin_format(data_, false, -1);
+  } else if (tokens.size() == 1) {
     /* Binary format */
     parse_bin_format(tokens[0], false, -1);
   } else if (tokens.size() > 2) {

--- a/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
+++ b/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
@@ -40,6 +40,8 @@ std::string BitsParser::data() const { return data_; }
 
 bool BitsParser::valid() const { return valid_; }
 
+std::vector<size_t> BitsParser::result() const { return result_; }
+
 /************************************************************************
  * Public Mutators
  ***********************************************************************/

--- a/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
+++ b/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
@@ -1,0 +1,176 @@
+/************************************************************************
+ * Member functions for Port parsers
+ ***********************************************************************/
+#include "openfpga_bits_parser.h"
+
+#include <cstring>
+#include <algorithm>
+#include <cctype>
+
+#include "arch_error.h"
+#include "openfpga_tokenizer.h"
+#include "vtr_assert.h"
+
+/* namespace openfpga begins */
+namespace openfpga {
+
+/************************************************************************
+ * Member functions for BitsParser class
+ ***********************************************************************/
+
+/************************************************************************
+ * Constructors
+ ***********************************************************************/
+BitsParser::BitsParser(const std::string& data) {
+  delim = ''';
+  splitter = '_';
+  bin_format_be_code = 'B';
+  bin_format_le_code = 'b';
+  hex_format_be_code = 'H';
+  hex_format_le_code = 'h';
+  set_data(data);
+  valid_ = false;
+}
+
+/************************************************************************
+ * Public Accessors
+ ***********************************************************************/
+/* Get the data string */
+std::string BitsParser::data() const { return data_; }
+
+bool BitsParser::valid() const { return valid_; }
+
+/************************************************************************
+ * Public Mutators
+ ***********************************************************************/
+void BitsParser::set_data(const std::string& data) {
+  data_ = data;
+  parse();
+  return;
+}
+
+/************************************************************************
+ * Internal Mutators
+ ***********************************************************************/
+void BitsParser::parse_bin_format(const std::string& bits_str, const bool& little_endian, const int& expected_len) {
+  valid_ = true;
+  /* Remove all the splitter */
+  std::string bits_str_pure = bits_str;
+  bits_str_pure.erase(std::remove(bits_str_pure.begin(), bits_str_pure.end(), splitter_), bits_str_pure.end());
+  for (const char& bit_char : bits_str_pure) {
+    if ('0' == bit_char) {
+      result_.push_back(0);
+    } else if ('1' == bit_char) {
+      result_.push_back(1);
+    } else {
+      VTR_LOG_ERROR("Unexpected '%c' character found in the bits '%s'! "
+                    "Only allow either '0' or '1'\n",
+                    bit_char, bits_str.c_str());
+      valid_ = false;
+    }
+  }
+  if (little_endian) {
+    std::reverse(result_.begin(), result_.end());
+  }
+  /* Check expected len, -1 indicate to skip the check */
+  if (expected_len == -1) {
+    return;
+  }
+  if (expected_len != result_.size()) {
+    VTR_LOG_ERROR("Actual length '%lu' of bits '%s' does not match its definition '%d'\n",
+                  results_size(), bits_str.c_str(), expected_len);
+    valid_ = false;
+  } 
+}
+
+void BitsParser::parse_hex_format(const std::string& bits_str, const bool& little_endian, const int& expected_len) {
+  valid_ = true;
+  /* Remove all the splitter */
+  std::string bits_str_pure = bits_str;
+  bits_str_pure.erase(std::remove(bits_str_pure.begin(), bits_str_pure.end(), splitter_), bits_str_pure.end());
+
+  std::string bin_str;
+  /* XT: Since the size could be large, std::stoul may cause overflow! Use a simple but effective way */
+  for (const char& hex_char : bits_str_pure) {
+    std::string bin_segment;
+    switch (std::tolower(hex_char)) {
+        case '0': bin_segment = "0000"; break;
+        case '1': bin_segment = "0001"; break;
+        case '2': bin_segment = "0010"; break;
+        case '3': bin_segment = "0011"; break;
+        case '4': bin_segment = "0100"; break;
+        case '5': bin_segment = "0101"; break;
+        case '6': bin_segment = "0110"; break;
+        case '7': bin_segment = "0111"; break;
+        case '8': bin_segment = "1000"; break;
+        case '9': bin_segment = "1001"; break;
+        case 'a': bin_segment = "1010"; break;
+        case 'b': bin_segment = "1011"; break;
+        case 'c': bin_segment = "1100"; break;
+        case 'd': bin_segment = "1101"; break;
+        case 'e': bin_segment = "1110"; break;
+        case 'f': bin_segment = "1111"; break;
+        default: {
+          VTR_LOG_ERROR("Invalid hexadecimal number '%s' of '%s'! Found unexpected character '%c'\n", bits_str.c_str(), data_.c_str(), hex_char);
+          valid_ = false; 
+          return;
+        }
+    }
+    bin_str += bin_segment;
+  }
+  parse_bin_format(bin_str, little_endian, expected_len);
+}
+
+/* Parse the data */
+void BitsParser::parse() {
+  valid_ = true;
+  /* Create a tokenizer */
+  StringToken tokenizer(data_);
+  std::vector<std::string> tokens = tokenizer.split(delim_); 
+  if (tokens.size() == 1) {
+    /* Binary format */
+    parse_bin_format(tokens[0], false, -1);
+  } else if (tokens.size() > 2) {
+    /* Invalid format, error out ! */
+    valid_ = false;
+  } else {
+    VTR_ASSERT_SAFE(tokens.size() == 2);
+    /* Find expected length */
+    std::string bit_len_def = tokens[0];
+    bit_len_def.pop_back();
+    if (bit_len_def.empty()) {
+      valid_ = false;
+      VTR_LOG_ERROR("Invalid format definition '%s' of '%s'. Expect a number before the format type!\n", tokens[0].c_str(), data_.c_str());
+      return;
+    }
+    if (!std::all_of(bit_len_def.begin(). bit_len_def.end(), std::isdigit)) {
+      valid_ = false;
+      VTR_LOG_ERROR("Invalid format definition '%s' of '%s'. Expect a valid decimal number before the format type!\n", tokens[0].c_str(), data_.c_str());
+      return;
+    }
+    int expected_bit_len = std::stoi(bit_len_def);
+    /* Parse on expected format */
+    switch (tokens[0].back()) {
+      case bin_format_be_code:
+        parse_bin_format(tokens[1], false, expected_bit_len);
+        break;
+      case bin_format_le_code:
+        parse_bin_format(tokens[1], true, expected_bit_len);
+        break;
+      case hex_format_be_code:
+        parse_hex_format(tokens[1], false, expected_bit_len);
+        break;
+      case hex_format_le_code:
+        parse_hex_format(tokens[1], true, expected_bit_len);
+        break;
+      default: {
+        VTR_LOG_ERROR("Invalid format definition '%c' of '%s'. Expect to be [ %c | %c | %c | %c ]!\n", 
+                      tokens[0].back(), data_.c_str(), bin_format_be_code_, bin_format_le_code_, hex_format_be_code_, hex_format_le_code_);
+        valid_ = false;
+        break;
+      }
+    }
+  }
+}
+
+}  // namespace openfpga

--- a/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
+++ b/libs/libopenfpgautil/src/openfpga_bits_parser.cpp
@@ -3,9 +3,9 @@
  ***********************************************************************/
 #include "openfpga_bits_parser.h"
 
-#include <cstring>
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 
 #include "openfpga_tokenizer.h"
 #include "vtr_assert.h"
@@ -53,20 +53,25 @@ void BitsParser::set_data(const std::string& data) {
 /************************************************************************
  * Internal Mutators
  ***********************************************************************/
-void BitsParser::parse_bin_format(const std::string& bits_str, const bool& little_endian, const int& expected_len) {
+void BitsParser::parse_bin_format(const std::string& bits_str,
+                                  const bool& little_endian,
+                                  const int& expected_len) {
   valid_ = true;
   /* Remove all the splitter */
   std::string bits_str_pure = bits_str;
-  bits_str_pure.erase(std::remove(bits_str_pure.begin(), bits_str_pure.end(), splitter_), bits_str_pure.end());
+  bits_str_pure.erase(
+    std::remove(bits_str_pure.begin(), bits_str_pure.end(), splitter_),
+    bits_str_pure.end());
   for (const char& bit_char : bits_str_pure) {
     if ('0' == bit_char) {
       result_.push_back(0);
     } else if ('1' == bit_char) {
       result_.push_back(1);
     } else {
-      VTR_LOG_ERROR("Unexpected '%c' character found in the bits '%s'! "
-                    "Only allow either '0' or '1'\n",
-                    bit_char, bits_str.c_str());
+      VTR_LOG_ERROR(
+        "Unexpected '%c' character found in the bits '%s'! "
+        "Only allow either '0' or '1'\n",
+        bit_char, bits_str.c_str());
       valid_ = false;
     }
   }
@@ -78,60 +83,107 @@ void BitsParser::parse_bin_format(const std::string& bits_str, const bool& littl
     return;
   }
   if (expected_len != (int)(result_.size())) {
-    VTR_LOG_ERROR("Actual length '%lu' of bits '%s' does not match its definition '%d'\n",
-                  result_.size(), bits_str.c_str(), expected_len);
+    VTR_LOG_ERROR(
+      "Actual length '%lu' of bits '%s' does not match its definition '%d'\n",
+      result_.size(), bits_str.c_str(), expected_len);
     valid_ = false;
-  } 
+  }
 }
 
-void BitsParser::parse_hex_format(const std::string& bits_str, const bool& little_endian, const int& expected_len) {
+void BitsParser::parse_hex_format(const std::string& bits_str,
+                                  const bool& little_endian,
+                                  const int& expected_len) {
   valid_ = true;
   /* Remove all the splitter */
   std::string bits_str_pure = bits_str;
-  bits_str_pure.erase(std::remove(bits_str_pure.begin(), bits_str_pure.end(), splitter_), bits_str_pure.end());
+  bits_str_pure.erase(
+    std::remove(bits_str_pure.begin(), bits_str_pure.end(), splitter_),
+    bits_str_pure.end());
 
   std::string bin_str;
-  /* XT: Since the size could be large, std::stoul may cause overflow! Use a simple but effective way */
+  /* XT: Since the size could be large, std::stoul may cause overflow! Use a
+   * simple but effective way */
   for (const char& hex_char : bits_str_pure) {
     std::string bin_segment;
     switch (std::tolower(hex_char)) {
-        case '0': bin_segment = "0000"; break;
-        case '1': bin_segment = "0001"; break;
-        case '2': bin_segment = "0010"; break;
-        case '3': bin_segment = "0011"; break;
-        case '4': bin_segment = "0100"; break;
-        case '5': bin_segment = "0101"; break;
-        case '6': bin_segment = "0110"; break;
-        case '7': bin_segment = "0111"; break;
-        case '8': bin_segment = "1000"; break;
-        case '9': bin_segment = "1001"; break;
-        case 'a': bin_segment = "1010"; break;
-        case 'b': bin_segment = "1011"; break;
-        case 'c': bin_segment = "1100"; break;
-        case 'd': bin_segment = "1101"; break;
-        case 'e': bin_segment = "1110"; break;
-        case 'f': bin_segment = "1111"; break;
-        default: {
-          VTR_LOG_ERROR("Invalid hexadecimal number '%s' of '%s'! Found unexpected character '%c'\n", bits_str.c_str(), data_.c_str(), hex_char);
-          valid_ = false; 
-          return;
-        }
+      case '0':
+        bin_segment = "0000";
+        break;
+      case '1':
+        bin_segment = "0001";
+        break;
+      case '2':
+        bin_segment = "0010";
+        break;
+      case '3':
+        bin_segment = "0011";
+        break;
+      case '4':
+        bin_segment = "0100";
+        break;
+      case '5':
+        bin_segment = "0101";
+        break;
+      case '6':
+        bin_segment = "0110";
+        break;
+      case '7':
+        bin_segment = "0111";
+        break;
+      case '8':
+        bin_segment = "1000";
+        break;
+      case '9':
+        bin_segment = "1001";
+        break;
+      case 'a':
+        bin_segment = "1010";
+        break;
+      case 'b':
+        bin_segment = "1011";
+        break;
+      case 'c':
+        bin_segment = "1100";
+        break;
+      case 'd':
+        bin_segment = "1101";
+        break;
+      case 'e':
+        bin_segment = "1110";
+        break;
+      case 'f':
+        bin_segment = "1111";
+        break;
+      default: {
+        VTR_LOG_ERROR(
+          "Invalid hexadecimal number '%s' of '%s'! Found unexpected character "
+          "'%c'\n",
+          bits_str.c_str(), data_.c_str(), hex_char);
+        valid_ = false;
+        return;
+      }
     }
     bin_str += bin_segment;
   }
   /* Remove the redundant bits due to length definition */
   if (expected_len > (int)(bin_str.size())) {
-    VTR_LOG_ERROR("Invalid length '%lu' of bits '%s' which is larger than its data size '%lu'!\n", expected_len, bits_str.c_str(), data_.c_str(), bin_str.size());
-    valid_ = false; 
+    VTR_LOG_ERROR(
+      "Invalid length '%lu' of bits '%s' which is larger than its data size "
+      "'%lu'!\n",
+      expected_len, bits_str.c_str(), data_.c_str(), bin_str.size());
+    valid_ = false;
     return;
   }
   if (expected_len <= (int)(bin_str.size() - 4)) {
-    VTR_LOG_ERROR("Invalid length '%lu' of bits '%s' which is much smaller than its data size '%lu'! This may cause data loss! Please double check\n", expected_len, bits_str.c_str(), data_.c_str(), bin_str.size());
-    valid_ = false; 
+    VTR_LOG_ERROR(
+      "Invalid length '%lu' of bits '%s' which is much smaller than its data "
+      "size '%lu'! This may cause data loss! Please double check\n",
+      expected_len, bits_str.c_str(), data_.c_str(), bin_str.size());
+    valid_ = false;
     return;
   }
   if (expected_len < (int)(bin_str.size())) {
-    bin_str.erase(0, bin_str.size() - expected_len); 
+    bin_str.erase(0, bin_str.size() - expected_len);
   }
   parse_bin_format(bin_str, little_endian, expected_len);
 }
@@ -145,7 +197,7 @@ void BitsParser::parse() {
   }
   /* Create a tokenizer */
   StringToken tokenizer(data_);
-  std::vector<std::string> tokens = tokenizer.split(delim_); 
+  std::vector<std::string> tokens = tokenizer.split(delim_);
   if (tokens.size() == 0) {
     /* Binary format */
     parse_bin_format(data_, false, -1);
@@ -162,12 +214,18 @@ void BitsParser::parse() {
     bit_len_def.pop_back();
     if (bit_len_def.empty()) {
       valid_ = false;
-      VTR_LOG_ERROR("Invalid format definition '%s' of '%s'. Expect a number before the format type!\n", tokens[0].c_str(), data_.c_str());
+      VTR_LOG_ERROR(
+        "Invalid format definition '%s' of '%s'. Expect a number before the "
+        "format type!\n",
+        tokens[0].c_str(), data_.c_str());
       return;
     }
     if (!std::all_of(bit_len_def.begin(), bit_len_def.end(), ::isdigit)) {
       valid_ = false;
-      VTR_LOG_ERROR("Invalid format definition '%s' of '%s'. Expect a valid decimal number before the format type!\n", tokens[0].c_str(), data_.c_str());
+      VTR_LOG_ERROR(
+        "Invalid format definition '%s' of '%s'. Expect a valid decimal number "
+        "before the format type!\n",
+        tokens[0].c_str(), data_.c_str());
       return;
     }
     int expected_bit_len = std::stoi(bit_len_def);
@@ -176,13 +234,16 @@ void BitsParser::parse() {
       parse_bin_format(tokens[1], false, expected_bit_len);
     } else if (tokens[0].back() == bin_format_le_code_) {
       parse_bin_format(tokens[1], true, expected_bit_len);
-    } else if (tokens[0].back() ==  hex_format_be_code_) {
+    } else if (tokens[0].back() == hex_format_be_code_) {
       parse_hex_format(tokens[1], false, expected_bit_len);
-    } else if (tokens[0].back() ==  hex_format_le_code_) {
+    } else if (tokens[0].back() == hex_format_le_code_) {
       parse_hex_format(tokens[1], true, expected_bit_len);
     } else {
-      VTR_LOG_ERROR("Invalid format definition '%c' of '%s'. Expect to be [ %c | %c | %c | %c ]!\n", 
-                    tokens[0].back(), data_.c_str(), bin_format_be_code_, bin_format_le_code_, hex_format_be_code_, hex_format_le_code_);
+      VTR_LOG_ERROR(
+        "Invalid format definition '%c' of '%s'. Expect to be [ %c | %c | %c | "
+        "%c ]!\n",
+        tokens[0].back(), data_.c_str(), bin_format_be_code_,
+        bin_format_le_code_, hex_format_be_code_, hex_format_le_code_);
       valid_ = false;
     }
   }

--- a/libs/libopenfpgautil/src/openfpga_bits_parser.h
+++ b/libs/libopenfpgautil/src/openfpga_bits_parser.h
@@ -1,0 +1,67 @@
+#pragma once
+
+/********************************************************************
+ * Include header files that are required by data structure declaration
+ *******************************************************************/
+#include <string>
+#include <vector>
+
+/************************************************************************
+ * This file includes parsers for bit data in the architecture XML
+ * language. Note that it is also compatiable to Verilog syntax.
+ * It means we may reuse this for constructing a structural Verilog parser
+ ***********************************************************************/
+
+/* namespace openfpga begins */
+namespace openfpga {
+
+/************************************************************************
+ * Class BitParser:
+ * Supported data format:
+ * - Binary format:
+ *     Native: 11000111
+ *     With splitter: 1100_0111
+ *     Header in big endian: 8B'11000111
+ *     Header in big endian with splitter : 8B'1100_0111
+ *     Header in little endian with splitter:  8b'11100011
+ *     Header in little endian:  8b'1110_0011
+ *   where 
+ *    - 8 represents the number of bits
+ *    - B represent the big endian
+ *    - b represents the little endian
+ * - Hexadecimal format: 8H'A7 or 8h'E3
+ *   where 
+ *    - 8 represents the number of bits
+ *    - H represent the big endian
+ *    - h represents the little endian
+ ***********************************************************************/
+class BitsParser {
+ public: /* Constructors*/
+  BitsParser(const std::string& data);
+
+ public: /* Public Accessors */
+  std::string data() const;
+  bool valid() const;
+  std::vector<size_t> result() const;
+
+ public: /* Public Mutators */
+  void set_data(const std::string& data);
+
+ private: /* Private Mutators */
+  void parse();
+  void parse_bin_format(const std::string& bits_str, const bool& little_endian, const int& expected_len);
+  void parse_hex_format(const std::string& bits_str, const bool& little_endian, const int& expected_len);
+
+ private:            /* Internal data */
+  std::string data_; /* Lines to be splited */
+  char delim_;
+  char splitter_;
+  char bin_format_be_code_;
+  char hex_format_be_code_;
+  char bin_format_le_code_;
+  char hex_format_le_code_;
+  std::vector<size_t> result_;
+  bool valid_;
+};
+
+}  // namespace openfpga

--- a/libs/libopenfpgautil/src/openfpga_bits_parser.h
+++ b/libs/libopenfpgautil/src/openfpga_bits_parser.h
@@ -25,12 +25,12 @@ namespace openfpga {
  *     Header in big endian with splitter : 8B'1100_0111
  *     Header in little endian with splitter:  8b'11100011
  *     Header in little endian:  8b'1110_0011
- *   where 
+ *   where
  *    - 8 represents the number of bits
  *    - B represent the big endian
  *    - b represents the little endian
  * - Hexadecimal format: 8H'A7 or 8h'E3
- *   where 
+ *   where
  *    - 8 represents the number of bits
  *    - H represent the big endian
  *    - h represents the little endian
@@ -49,8 +49,10 @@ class BitsParser {
 
  private: /* Private Mutators */
   void parse();
-  void parse_bin_format(const std::string& bits_str, const bool& little_endian, const int& expected_len);
-  void parse_hex_format(const std::string& bits_str, const bool& little_endian, const int& expected_len);
+  void parse_bin_format(const std::string& bits_str, const bool& little_endian,
+                        const int& expected_len);
+  void parse_hex_format(const std::string& bits_str, const bool& little_endian,
+                        const int& expected_len);
 
  private:            /* Internal data */
   std::string data_; /* Lines to be splited */

--- a/openfpga_flow/openfpga_arch/README.md
+++ b/openfpga_flow/openfpga_arch/README.md
@@ -39,5 +39,6 @@ Note that an OpenFPGA architecture can be applied to multiple VPR architecture f
   * <Pin> When specified, multiple clocks are in separated pins with different names
 - abspath: All the paths in the architecture file are absolute and hardcoded.
 - ecb: *Enhanced Connection Block* where connection blocks includes feedback connections
+- <Hex|Bin>ModeBits: Use hexadecimal or binary format for mode bits
 
 Other features are used in naming should be listed here.

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_BinModeBits_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_BinModeBits_openfpga.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0"?>
+<!-- Architecture annotation for OpenFPGA framework
+     This annotation supports the k6_N10_40nm.xml 
+     - General purpose logic block
+       - K = 6, N = 10, I = 40
+       - Single mode
+     - Routing architecture
+       - L = 4, fc_in = 0.15, fc_out = 0.1
+  -->
+<openfpga_architecture>
+  <technology_library>
+    <device_library>
+      <device_model name="logic" type="transistor">
+        <lib type="industry" corner="TOP_TT" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="0.9" pn_ratio="2"/>
+        <pmos name="pch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+        <nmos name="nch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+      </device_model>
+      <device_model name="io" type="transistor">
+        <lib type="academia" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="2.5" pn_ratio="3"/>
+        <pmos name="pch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+        <nmos name="nch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+      </device_model>
+    </device_library>
+    <variation_library>
+      <variation name="logic_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+      <variation name="io_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+    </variation_library>
+  </technology_library>
+  <circuit_library>
+    <circuit_model type="inv_buf" name="INVTX1" prefix="INVTX1" is_default="true">
+      <design_technology type="cmos" topology="inverter" size="1"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="buf4" prefix="buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="2" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="tap_buf4" prefix="tap_buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="3" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="gate" name="OR2" prefix="OR2" is_default="true">
+      <design_technology type="cmos" topology="OR"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="a" size="1"/>
+      <port type="input" prefix="b" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="a b" out_port="out">
+        10e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="a b" out_port="out">
+        10e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="pass_gate" name="TGATE" prefix="TGATE" is_default="true">
+      <design_technology type="cmos" topology="transmission_gate" nmos_size="1" pmos_size="2"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" lib_name="A" size="1"/>
+      <port type="input" prefix="sel" lib_name="S" size="1"/>
+      <port type="input" prefix="selb" lib_name="SI" size="1"/>
+      <port type="output" prefix="out" lib_name="Y" size="1"/>
+      <delay_matrix type="rise" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="chan_wire" name="chan_segment" prefix="track_seg" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+    </circuit_model>
+    <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level_tapbuf" prefix="mux_2level_tapbuf" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_1level_tapbuf" prefix="mux_1level_tapbuf" is_default="true" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="one_level" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ff" name="MULTI_MODE_DFFNRQ" prefix="MULTI_MODE_DFFNRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dffn.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="R" lib_name="RST" size="1" default_val="0"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="C" lib_name="CK" size="1" default_val="0"/>
+      <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
+    </circuit_model>
+    <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
+      <design_technology type="cmos" fracturable_lut="true"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_inverter exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_buffer exist="true" circuit_model_name="buf4"/>
+      <lut_intermediate_buffer exist="true" circuit_model_name="buf4" location_map="-1-"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="4" tri_state_map="---1" circuit_model_name="OR2"/>
+      <port type="output" prefix="lut3_out" size="2" lut_frac_level="3" lut_output_mask="0,1"/>
+      <port type="output" prefix="lut4_out" size="1" lut_output_mask="0"/>
+      <port type="sram" prefix="sram" size="16"/>
+      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
+    </circuit_model>
+    <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true" is_data_io="true"/>
+      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
+      <port type="input" prefix="outpad" lib_name="A" size="1"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
+  </circuit_library>
+  <configuration_protocol>
+    <organization type="scan_chain" circuit_model_name="DFFR"/>
+  </configuration_protocol>
+  <connection_block>
+    <switch name="ipin_cblock" circuit_model_name="mux_2level_tapbuf"/>
+  </connection_block>
+  <switch_block>
+    <switch name="0" circuit_model_name="mux_2level_tapbuf"/>
+  </switch_block>
+  <routing_segment>
+    <segment name="L4" circuit_model_name="chan_segment"/>
+  </routing_segment>
+  <tile_annotations>
+    <global_port name="op_clk" tile_port="clb.clk" is_clock="true" default_val="0">
+      <tile name="clb" port="clk"/>
+    </global_port>
+    <global_port name="op_reset" is_reset="true" default_val="0">
+      <tile name="clb" port="reset"/>
+    </global_port>
+  </tile_annotations>
+  <pb_type_annotations>
+    <!-- physical pb_type binding in complex block IO -->
+    <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
+    <!-- End physical pb_type binding in complex block IO -->
+    <!-- physical pb_type binding in complex block CLB -->
+    <!-- physical mode will be the default mode if not specified -->
+    <pb_type name="clb">
+      <!-- Binding interconnect to circuit models as their physical implementation, if not defined, we use the default model -->
+      <interconnect name="crossbar" circuit_model_name="mux_2level"/>
+    </pb_type>
+    <pb_type name="clb.fle" physical_mode_name="physical"/>
+    <pb_type name="clb.fle[physical].fabric.frac_logic.frac_lut4" circuit_model_name="frac_lut4" mode_bits="1B'0"/>
+    <pb_type name="clb.fle[physical].fabric.ff" circuit_model_name="MULTI_MODE_DFFNRQ" mode_bits="2B'00"/>
+    <!-- Binding operating pb_type to physical pb_type -->
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.lut3" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="1B'1" physical_pb_type_index_factor="0.5">
+      <!-- Binding the lut3 to the first 3 inputs of fracturable lut4 -->
+      <port name="in" physical_mode_port="in[0:2]"/>
+      <port name="out" physical_mode_port="lut3_out[0:0]" physical_mode_pin_rotate_offset="1"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[latch].latch" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00">
+      <port name="clk" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dff].dff" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00"/>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffn].dffn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'01">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffr].dffr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00"/>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffnr].dffnr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'01">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'10">
+      <port name="RN" physical_mode_port="R"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffnrn].dffnrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'11">
+      <port name="RN" physical_mode_port="R"/>
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.lut4" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="1B'0">
+      <!-- Binding the lut4 to the first 4 inputs of fracturable lut4 -->
+      <port name="in" physical_mode_port="in[0:3]"/>
+      <port name="out" physical_mode_port="lut4_out"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[latch].latch" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="clk" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dff].dff" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffn].dffn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'01" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffr].dffr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffnr].dffnr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'01" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'10" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="RN" physical_mode_port="R"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffnrn].dffnrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'11" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="RN" physical_mode_port="R"/>
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <!-- End physical pb_type binding in complex block IO -->
+  </pb_type_annotations>
+</openfpga_architecture>

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_BinModeBits_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_BinModeBits_openfpga.xml
@@ -240,7 +240,7 @@
     <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffnr].dffnr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'01">
       <port name="CN" physical_mode_port="C"/>
     </pb_type>
-    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'10">
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2b'01">
       <port name="RN" physical_mode_port="R"/>
     </pb_type>
     <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffnrn].dffnrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'11">
@@ -252,18 +252,18 @@
       <port name="in" physical_mode_port="in[0:3]"/>
       <port name="out" physical_mode_port="lut4_out"/>
     </pb_type>
-    <pb_type name="clb.fle[n1_lut4].ble4.ff[latch].latch" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[latch].latch" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'0_0" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
       <port name="clk" physical_mode_port="C"/>
     </pb_type>
     <pb_type name="clb.fle[n1_lut4].ble4.ff[dff].dff" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
-    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffn].dffn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'01" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffn].dffn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'0_1" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
       <port name="CN" physical_mode_port="C"/>
     </pb_type>
     <pb_type name="clb.fle[n1_lut4].ble4.ff[dffr].dffr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'00" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
     <pb_type name="clb.fle[n1_lut4].ble4.ff[dffnr].dffnr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'01" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
       <port name="CN" physical_mode_port="C"/>
     </pb_type>
-    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'10" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2b'01" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
       <port name="RN" physical_mode_port="R"/>
     </pb_type>
     <pb_type name="clb.fle[n1_lut4].ble4.ff[dffnrn].dffnrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2B'11" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_HexModeBits_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_HexModeBits_openfpga.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0"?>
+<!-- Architecture annotation for OpenFPGA framework
+     This annotation supports the k6_N10_40nm.xml 
+     - General purpose logic block
+       - K = 6, N = 10, I = 40
+       - Single mode
+     - Routing architecture
+       - L = 4, fc_in = 0.15, fc_out = 0.1
+  -->
+<openfpga_architecture>
+  <technology_library>
+    <device_library>
+      <device_model name="logic" type="transistor">
+        <lib type="industry" corner="TOP_TT" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="0.9" pn_ratio="2"/>
+        <pmos name="pch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+        <nmos name="nch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+      </device_model>
+      <device_model name="io" type="transistor">
+        <lib type="academia" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="2.5" pn_ratio="3"/>
+        <pmos name="pch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+        <nmos name="nch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+      </device_model>
+    </device_library>
+    <variation_library>
+      <variation name="logic_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+      <variation name="io_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+    </variation_library>
+  </technology_library>
+  <circuit_library>
+    <circuit_model type="inv_buf" name="INVTX1" prefix="INVTX1" is_default="true">
+      <design_technology type="cmos" topology="inverter" size="1"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="buf4" prefix="buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="2" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="tap_buf4" prefix="tap_buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="3" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="gate" name="OR2" prefix="OR2" is_default="true">
+      <design_technology type="cmos" topology="OR"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="a" size="1"/>
+      <port type="input" prefix="b" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="a b" out_port="out">
+        10e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="a b" out_port="out">
+        10e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="pass_gate" name="TGATE" prefix="TGATE" is_default="true">
+      <design_technology type="cmos" topology="transmission_gate" nmos_size="1" pmos_size="2"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" lib_name="A" size="1"/>
+      <port type="input" prefix="sel" lib_name="S" size="1"/>
+      <port type="input" prefix="selb" lib_name="SI" size="1"/>
+      <port type="output" prefix="out" lib_name="Y" size="1"/>
+      <delay_matrix type="rise" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="chan_wire" name="chan_segment" prefix="track_seg" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/>
+      <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+    </circuit_model>
+    <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/>
+      <!-- model_type could be T, res_val cap_val should be defined -->
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level_tapbuf" prefix="mux_2level_tapbuf" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_1level_tapbuf" prefix="mux_1level_tapbuf" is_default="true" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="one_level" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ff" name="MULTI_MODE_DFFNRQ" prefix="MULTI_MODE_DFFNRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dffn.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="input" prefix="R" lib_name="RST" size="1" default_val="0"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="clock" prefix="C" lib_name="CK" size="1" default_val="0"/>
+      <port type="sram" prefix="mode" size="2" mode_select="true" circuit_model_name="DFFR" default_val="0"/>
+    </circuit_model>
+    <circuit_model type="lut" name="frac_lut4" prefix="frac_lut4" dump_structural_verilog="true">
+      <design_technology type="cmos" fracturable_lut="true"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_inverter exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_buffer exist="true" circuit_model_name="buf4"/>
+      <lut_intermediate_buffer exist="true" circuit_model_name="buf4" location_map="-1-"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="4" tri_state_map="---1" circuit_model_name="OR2"/>
+      <port type="output" prefix="lut3_out" size="2" lut_frac_level="3" lut_output_mask="0,1"/>
+      <port type="output" prefix="lut4_out" size="1" lut_output_mask="0"/>
+      <port type="sram" prefix="sram" size="16"/>
+      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
+    </circuit_model>
+    <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+      <port type="input" prefix="D" size="1"/>
+      <port type="output" prefix="Q" size="1"/>
+      <port type="output" prefix="QN" size="1"/>
+      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true" is_data_io="true"/>
+      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
+      <port type="input" prefix="outpad" lib_name="A" size="1"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
+  </circuit_library>
+  <configuration_protocol>
+    <organization type="scan_chain" circuit_model_name="DFFR"/>
+  </configuration_protocol>
+  <connection_block>
+    <switch name="ipin_cblock" circuit_model_name="mux_2level_tapbuf"/>
+  </connection_block>
+  <switch_block>
+    <switch name="0" circuit_model_name="mux_2level_tapbuf"/>
+  </switch_block>
+  <routing_segment>
+    <segment name="L4" circuit_model_name="chan_segment"/>
+  </routing_segment>
+  <tile_annotations>
+    <global_port name="op_clk" tile_port="clb.clk" is_clock="true" default_val="0">
+      <tile name="clb" port="clk"/>
+    </global_port>
+    <global_port name="op_reset" is_reset="true" default_val="0">
+      <tile name="clb" port="reset"/>
+    </global_port>
+  </tile_annotations>
+  <pb_type_annotations>
+    <!-- physical pb_type binding in complex block IO -->
+    <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/>
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/>
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/>
+    <!-- End physical pb_type binding in complex block IO -->
+    <!-- physical pb_type binding in complex block CLB -->
+    <!-- physical mode will be the default mode if not specified -->
+    <pb_type name="clb">
+      <!-- Binding interconnect to circuit models as their physical implementation, if not defined, we use the default model -->
+      <interconnect name="crossbar" circuit_model_name="mux_2level"/>
+    </pb_type>
+    <pb_type name="clb.fle" physical_mode_name="physical"/>
+    <pb_type name="clb.fle[physical].fabric.frac_logic.frac_lut4" circuit_model_name="frac_lut4" mode_bits="2H'0"/>
+    <pb_type name="clb.fle[physical].fabric.ff" circuit_model_name="MULTI_MODE_DFFNRQ" mode_bits="2H'0"/>
+    <!-- Binding operating pb_type to physical pb_type -->
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.lut3" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="1H'1" physical_pb_type_index_factor="0.5">
+      <!-- Binding the lut3 to the first 3 inputs of fracturable lut4 -->
+      <port name="in" physical_mode_port="in[0:2]"/>
+      <port name="out" physical_mode_port="lut3_out[0:0]" physical_mode_pin_rotate_offset="1"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[latch].latch" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'0">
+      <port name="clk" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dff].dff" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'0"/>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffn].dffn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'1">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffr].dffr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'0"/>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffnr].dffnr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'1">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'2">
+      <port name="RN" physical_mode_port="R"/>
+    </pb_type>
+    <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.ff[dffnrn].dffnrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'3">
+      <port name="RN" physical_mode_port="R"/>
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.lut4" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="1H'0">
+      <!-- Binding the lut4 to the first 4 inputs of fracturable lut4 -->
+      <port name="in" physical_mode_port="in[0:3]"/>
+      <port name="out" physical_mode_port="lut4_out"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[latch].latch" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'0" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="clk" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dff].dff" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'0" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffn].dffn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'1" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffr].dffr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'0" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffnr].dffnr" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'1" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffrn].dffrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'2" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="RN" physical_mode_port="R"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff[dffnrn].dffnrn" physical_pb_type_name="clb.fle[physical].fabric.ff" mode_bits="2H'3" physical_pb_type_index_factor="2" physical_pb_type_index_offset="0">
+      <port name="RN" physical_mode_port="R"/>
+      <port name="CN" physical_mode_port="C"/>
+    </pb_type>
+    <!-- End physical pb_type binding in complex block IO -->
+  </pb_type_annotations>
+</openfpga_architecture>

--- a/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_HexModeBits_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_HexModeBits_openfpga.xml
@@ -221,7 +221,7 @@
       <interconnect name="crossbar" circuit_model_name="mux_2level"/>
     </pb_type>
     <pb_type name="clb.fle" physical_mode_name="physical"/>
-    <pb_type name="clb.fle[physical].fabric.frac_logic.frac_lut4" circuit_model_name="frac_lut4" mode_bits="2H'0"/>
+    <pb_type name="clb.fle[physical].fabric.frac_logic.frac_lut4" circuit_model_name="frac_lut4" mode_bits="1H'0"/>
     <pb_type name="clb.fle[physical].fabric.ff" circuit_model_name="MULTI_MODE_DFFNRQ" mode_bits="2H'0"/>
     <!-- Binding operating pb_type to physical pb_type -->
     <pb_type name="clb.fle[n2_lut3].lut3inter.ble3.lut3" physical_pb_type_name="clb.fle[physical].fabric.frac_logic.frac_lut4" mode_bits="1H'1" physical_pb_type_index_factor="0.5">

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -347,6 +347,10 @@ run-task basic_tests/no_time_stamp/dump_waveform $@
 echo -e "Testing report reference to file";
 run-task basic_tests/report_reference $@
 
+echo -e "Testing mode bit format";
+run-task basic_tests/mode_bit_format/bin_format_big_endian $@
+run-task basic_tests/mode_bit_format/hex_format_big_endian $@
+
 # Run git-diff to ensure no changes on the golden netlists
 # Switch to root path in case users are running the tests in another location
 cd ${OPENFPGA_PATH}

--- a/openfpga_flow/tasks/basic_tests/mode_bit_format/bin_format_big_endian/config/pin_constraints_reset.xml
+++ b/openfpga_flow/tasks/basic_tests/mode_bit_format/bin_format_big_endian/config/pin_constraints_reset.xml
@@ -1,0 +1,8 @@
+<pin_constraints>
+  <!-- For a given .blif file, we want to assign 
+       - the reset signal to the op_reset[0] port of the FPGA fabric
+    -->
+  <set_io pin="op_reset[0]" net="reset"/>
+  <set_io pin="clk[0]" net="clkn"/>
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/mode_bit_format/bin_format_big_endian/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/mode_bit_format/bin_format_big_endian/config/task.conf
@@ -1,0 +1,42 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 3*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/example_without_ace_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_BinModeBits_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff2edge_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_8bit_negedge_async_reset/counter.v
+
+[SYNTHESIS_PARAM]
+# Yosys script parameters
+bench_yosys_cell_sim_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_sim.v
+bench_yosys_dff_map_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_map.v
+bench_read_verilog_options_common = -nolatches
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
+bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys
+
+bench0_top = counter
+bench0_openfpga_pin_constraints_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tasks/basic_tests/k4_series/k4n4_fracff2edge/config/pin_constraints_reset.xml
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/openfpga_flow/tasks/basic_tests/mode_bit_format/hex_format_big_endian/config/pin_constraints_reset.xml
+++ b/openfpga_flow/tasks/basic_tests/mode_bit_format/hex_format_big_endian/config/pin_constraints_reset.xml
@@ -1,0 +1,8 @@
+<pin_constraints>
+  <!-- For a given .blif file, we want to assign 
+       - the reset signal to the op_reset[0] port of the FPGA fabric
+    -->
+  <set_io pin="op_reset[0]" net="reset"/>
+  <set_io pin="clk[0]" net="clkn"/>
+</pin_constraints>
+

--- a/openfpga_flow/tasks/basic_tests/mode_bit_format/hex_format_big_endian/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/mode_bit_format/hex_format_big_endian/config/task.conf
@@ -1,0 +1,42 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = false
+spice_output=false
+verilog_output=true
+timeout_each_job = 3*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/example_without_ace_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_fracff2edge_40nm_cc_HexModeBits_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_fracff2edge_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/counters/counter_8bit_negedge_async_reset/counter.v
+
+[SYNTHESIS_PARAM]
+# Yosys script parameters
+bench_yosys_cell_sim_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_sim.v
+bench_yosys_dff_map_verilog_common=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_yosys_techlib/openfpga_dff_map.v
+bench_read_verilog_options_common = -nolatches
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_dff_flow.ys
+bench_yosys_rewrite_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow_with_rewrite.ys;${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_rewrite_flow.ys
+
+bench0_top = counter
+bench0_openfpga_pin_constraints_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tasks/basic_tests/k4_series/k4n4_fracff2edge/config/pin_constraints_reset.xml
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #1979 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 

As stated in #1979 

> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Added a dedicated parser to support various format of string

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
