### PR TITLE
Add SystemVerilog Frontend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,9 +82,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "Build Compatibility: GCC-10 (Ubuntu 22.04)"
-            cc: gcc-10
-            cxx: g++-10
           - name: "Build Compatibility: GCC-11 (Ubuntu 22.04)"
             cc: gcc-11
             cxx: g++-11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,18 +88,6 @@ jobs:
           - name: "Build Compatibility: GCC-12 (Ubuntu 22.04)"
             cc: gcc-12
             cxx: g++-12
-          - name: "Build Compatibility: Clang-11 (Ubuntu 22.04)"
-            cc: clang-11
-            cxx: clang++-11
-          - name: "Build Compatibility: Clang-12 (Ubuntu 22.04)"
-            cc: clang-12
-            cxx: clang++-12
-          - name: "Build Compatibility: Clang-13 (Ubuntu 22.04)"
-            cc: clang-13
-            cxx: clang++-13
-          - name: "Build Compatibility: Clang-14 (Ubuntu 22.04)"
-            cc: clang-14
-            cxx: clang++-14
     # Define the steps to run the build job
     env:
       CC: ${{ matrix.config.cc }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = vtr-verilog-to-routing
 	url = https://github.com/verilog-to-routing/vtr-verilog-to-routing.git
     branch = openfpga
+[submodule "yosys-slang"]
+	path = yosys-slang
+	url = https://github.com/povik/yosys-slang.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if (OPENFPGA_WITH_YOSYS)
         # yosys-plugins compilation starts
         add_custom_target(
             yosys-slang ALL
-            COMMAND $(MAKE) YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/ CMAKE_FLAGS+="-DPASS_NAME=read_slang"
+            COMMAND $(MAKE) YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
             COMMENT "Compile Yosys-Slang with given Makefile"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,13 +339,13 @@ if (OPENFPGA_WITH_YOSYS)
         # yosys compilation ends
         # yosys-plugins compilation starts
         add_custom_target(
-            yosys-plugins-slang ALL
-            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys EXTRA_FLAGS="-DPASS_NAME=read_slang"
+            yosys-slang ALL
+            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/ EXTRA_FLAGS="-DPASS_NAME=read_slang"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
-            COMMENT "Compile Yosys-plugins-Slang with given Makefile"
+            COMMENT "Compile Yosys-Slang with given Makefile"
         )
-        add_dependencies(yosys-plugins-slang yosys)
+        add_dependencies(yosys-slang yosys)
 
         ## yosys-plugins compilation starts
         #if (OPENFPGA_WITH_YOSYS_PLUGIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,15 @@ if (OPENFPGA_WITH_YOSYS)
             COMMENT "Compile Yosys with given Makefile"
         )
         # yosys compilation ends
+        # yosys-plugins compilation starts
+        add_custom_target(
+            yosys-plugins-slang ALL
+            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys EXTRA_FLAGS="-DPASS_NAME=read_slang"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
+            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
+            COMMENT "Compile Yosys-plugins-Slang with given Makefile"
+        )
+        add_dependencies(yosys-plugins-slang yosys)
 
         ## yosys-plugins compilation starts
         #if (OPENFPGA_WITH_YOSYS_PLUGIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,7 @@ if (OPENFPGA_WITH_YOSYS)
         add_custom_target(
             yosys-plugins-slang ALL
             COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys EXTRA_FLAGS="-DPASS_NAME=read_slang"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
             COMMENT "Compile Yosys-plugins-Slang with given Makefile"
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if (OPENFPGA_WITH_YOSYS)
         # yosys-plugins compilation starts
         add_custom_target(
             yosys-slang ALL
-            COMMAND $(MAKE) YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang"
+            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
             COMMENT "Compile Yosys-Slang with given Makefile"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if (OPENFPGA_WITH_YOSYS)
         # yosys-plugins compilation starts
         add_custom_target(
             yosys-slang ALL
-            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/ EXTRA_FLAGS="-DPASS_NAME=read_slang"
+            COMMAND $(MAKE) YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/ CMAKE_FLAGS+="-DPASS_NAME=read_slang"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
             COMMENT "Compile Yosys-Slang with given Makefile"

--- a/docs/source/tutorials/getting_started/compile.rst
+++ b/docs/source/tutorials/getting_started/compile.rst
@@ -35,7 +35,7 @@ In general, please follow the steps to compile
   cd OpenFPGA
   make all
 
-.. note:: OpenFPGA requires gcc/g++ version > 10 and clang version > 10.
+.. note:: OpenFPGA requires gcc/g++ version >= 11 and clang version >= 17.
 
 .. note:: cmake3.12+ is recommended to compile OpenFPGA with GUI
 

--- a/docs/source/tutorials/getting_started/compile.rst
+++ b/docs/source/tutorials/getting_started/compile.rst
@@ -35,7 +35,7 @@ In general, please follow the steps to compile
   cd OpenFPGA
   make all
 
-.. note:: OpenFPGA requires gcc/g++ version > 9 and clang version > 10.
+.. note:: OpenFPGA requires gcc/g++ version > 10 and clang version > 10.
 
 .. note:: cmake3.12+ is recommended to compile OpenFPGA with GUI
 

--- a/openfpga_flow/benchmarks/micro_benchmark/and2/and2.sv
+++ b/openfpga_flow/benchmarks/micro_benchmark/and2/and2.sv
@@ -1,0 +1,13 @@
+/////////////////////////////////////////
+//  Functionality: 2-input AND 
+//  Author:        Xifan Tang
+////////////////////////////////////////
+module and2 (
+    input  logic a,    // First input
+    input  logic b,    // Second input
+    output logic y     // Output: a AND b
+);
+
+    assign y = a & b;
+
+endmodule

--- a/openfpga_flow/benchmarks/micro_benchmark/and2_latch/and2_latch.sv
+++ b/openfpga_flow/benchmarks/micro_benchmark/and2_latch/and2_latch.sv
@@ -1,0 +1,22 @@
+/////////////////////////////////////////
+//  Functionality: 2-input AND with clocked 
+//                 and combinational outputs 
+//  Author:        Xifan Tang
+////////////////////////////////////////
+
+`timescale 1ns / 1ps
+
+module and2_latch(
+  input logic a,
+  input logic b,
+  input logic clk,
+  output logic c,
+  output logic d);
+
+assign c = a & b;
+
+always_ff @(posedge clk) begin
+  d <= c;
+end
+
+endmodule

--- a/openfpga_flow/misc/ys_tmpl_yosys_sv_vpr_flow.ys
+++ b/openfpga_flow/misc/ys_tmpl_yosys_sv_vpr_flow.ys
@@ -1,0 +1,40 @@
+# Yosys synthesis script for ${TOP_MODULE}
+# Read verilog files
+plugin -i slang
+read_slang ${READ_VERILOG_OPTIONS} ${VERILOG_FILES}
+
+# Technology mapping
+hierarchy -top ${TOP_MODULE}
+proc
+techmap -D NO_LUT -map +/adff2dff.v
+
+# Synthesis
+flatten
+opt_expr
+opt_clean
+check
+opt -nodffe -nosdff
+fsm
+opt -nodffe -nosdff
+wreduce
+peepopt
+opt_clean
+opt -nodffe -nosdff
+memory -nomap
+opt_clean
+opt -fast -full -nodffe -nosdff
+memory_map
+opt -full -nodffe -nosdff
+techmap
+opt -fast -nodffe -nosdff
+clean
+
+# LUT mapping
+abc -lut ${LUT_SIZE}
+
+# Check
+synth -run check
+
+# Clean and output blif
+opt_clean -purge
+write_blif ${OUTPUT_BLIF}

--- a/openfpga_flow/regression_test_scripts/basic_reg_test.sh
+++ b/openfpga_flow/regression_test_scripts/basic_reg_test.sh
@@ -27,6 +27,8 @@ run-task basic_tests/preload_unique_blocks/write_bin_unique_blocks_full_flow $@
 run-task basic_tests/preload_unique_blocks/read_unique_blocks_bin    $@
 run-task basic_tests/preload_unique_blocks/read_bin_write_xml $@
 
+echo -e "Testing SystemVerilog-to-Bitstream Flow"
+run-task basic_tests/systemverilog $@
 
 echo -e "Testing testbenches using fpga core wrapper"
 run-task basic_tests/full_testbench/fpga_core_wrapper $@

--- a/openfpga_flow/tasks/basic_tests/systemverilog/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/systemverilog/config/task.conf
@@ -1,0 +1,40 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/write_full_testbench_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_cc_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=
+openfpga_fast_configuration=
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.sv
+bench1=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2_latch/and2_latch.sv
+
+[SYNTHESIS_PARAM]
+bench_read_verilog_options_common = 
+bench_yosys_common=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/ys_tmpl_yosys_sv_vpr_flow.ys
+
+bench0_top = and2
+bench1_top = and2_latch
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA only supports Verilog-2005 due to Yosys's limited support.
Recently, the Yosys-slang comes to the stage as an optional plug-in, offering good SystemVerilog support.

https://github.com/povik/yosys-slang

https://github.com/open-source-eda-birds-of-a-feather/open-source-eda-birds-of-a-feather.github.io/blob/main/doc/slides_2025/yosys-slang-dac-bof.pdf



>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Add the yosys-slang as a submodule. Integrated it into the build system
- [x] Added a new Yosys template script to show how to use it in OpenFPGA
- [x] Added SV benchmarks for basic regression purpose  

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [x] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [x] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [x] Break back-compatibility. If so, please list who may be influenced.

Dropped GCC-10 support as Yosys-slang requires gcc > 11
Dropped all the clang support on Ubuntu 22.04 as Yosys-slang requires clang > 17
The clang support should be back when we support Ubuntu 24.04 or later version
