### PR TITLE
Adding CFGDSDFFR_FB modle to dff.v

### DIFF
--- a/openfpga_flow/openfpga_cell_library/verilog/dff.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dff.v
@@ -508,6 +508,50 @@ assign QN = CFG_DONE ? !Q : 1'b1;
 
 endmodule //End Of Module
 
+//-----------------------------------------------------
+// Function    : D-type flip-flop with 
+//               - asynchronous active high reset
+//               - scan-chain input
+//               - a scan-chain enable 
+//               - a configure enable, when enabled the registered output will
+//               be released to the CFGQ
+//               - a configure done, when enable, the regsitered output will be released to the Q
+//-----------------------------------------------------
+module CFGDSDFFR_FB (
+  input RST, // Reset input
+  input CK, // Clock Input (can be used with a free running programming clock)
+  input SE, // Scan-chain Enable (used to load the data)
+//input D, // Data Input
+  input SI, // Scan-chain input
+  input CFGE, // Configure enable
+  input CFG_DONE, // Configure done
+  output Q, // Regular Q output
+  output CFGQ, // Data Q output which is released when configure enable is activated
+  output CFGQN // Data Qb output which is released when configure enable is activated
+);
+//------------Internal Variables--------
+reg q_reg;
+wire QN;
+
+//-------------Code Starts Here---------
+always @ ( posedge CK or posedge RST)
+if (RST) begin
+  q_reg <= 1'b0;
+end else if (SE) begin
+  q_reg <= SI;
+end else begin
+    // Ignore D when SE=0 and RST=0 --> Hold previous value
+    q_reg <= q_reg;
+//  q_reg <= D;
+end
+
+assign CFGQ = CFGE ? Q : 1'b0;
+assign CFGQN = CFGE ? QN : 1'b1;
+
+assign Q = CFG_DONE ? q_reg : 1'b0;
+assign QN = CFG_DONE ? !Q : 1'b1;
+
+endmodule //End Of Module
 
 //-----------------------------------------------------
 // Function    : D-type flip-flop with 


### PR DESCRIPTION
### Motivate of the pull request
- I need the ability for the `prog_clk` to be free running.

### Describe the technical details
- The existing `CFGDSDFFR` will re-sample the D input if there is a `prog_clk` event and SE=0 and RST=0 
- `CFGDSDFFR_FB` (terrible name, open for a better one) will just feedback the D->Q when  SE=0 and RST=0 + clk event
- This enable the use of flip-flop for the CRAM with a free running `prog_clk`
  - which is a requirement for this particular application that I am working on

```xml
    <circuit_model type="ccff" name="CFGDSDFFR_FB" prefix="CFGDSDFFR_FB" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
      <design_technology type="cmos"/>
      <input_buffer exist="true" circuit_model_name="INVTX1"/>
      <output_buffer exist="true" circuit_model_name="INVTX1"/>
      <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
      <port type="input" prefix="SE" size="1" is_global="true" default_val="0"/>
      <port type="input" prefix="config_enable" lib_name="CFGE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
      <port type="input" prefix="config_done" lib_name="CFG_DONE" size="1" is_global="true" default_val="0" is_config_enable="true"/>
      <port type="input" prefix="SI" size="1"/>
      <port type="output" prefix="Q" size="1"/>
      <port type="output" prefix="CFGQN" size="1"/>
      <port type="output" prefix="CFGQ" size="1"/>
      <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
    </circuit_model>

  <configuration_protocol>
    <organization type="scan_chain" circuit_model_name="CFGDSDFFR_FB"/>
  </configuration_protocol>
```

> #### What does this pull request change?
- Adds a new DFF model to the openfpga_cell_library library

### Which part of the code base require a change
- [X ] Cell library

### Impact of the pull request
- This is back-compatibility and will not break any existing code.
