### PR TITLE
Update openfpga_script.rst

### DIFF
--- a/docs/source/manual/openfpga_shell/openfpga_script.rst
+++ b/docs/source/manual/openfpga_shell/openfpga_script.rst
@@ -59,7 +59,7 @@ The following is an example.
   # Build the bitstream 
   #  - Output the fabric-independent bitstream to a file
   build_architecture_bitstream --verbose \
-                               --file /var/tmp/xtang/openfpga_test_src/fabric_indepenent_bitstream.xml
+                               --write_file /var/tmp/xtang/openfpga_test_src/fabric_indepenent_bitstream.xml
   
   # Build fabric-dependent bitstream
   build_fabric_bitstream --verbose


### PR DESCRIPTION
> ### Describe the technical details
- `--file` is no longer an arg for `build_architecture_bitstream`
- if writing output, then `--write_file` should be used instead
 
#### What does this pull request change?
- Documentation only change (no change in code behavior)

### Which part of the code base require a change
- [ ] Documentation

### Impact of the pull request
- None
