### PR TITLE
Update documentation about clock modeling option when mapping global signals on custom network

### DIFF
--- a/docs/source/manual/arch_lang/annotate_vpr_arch.rst
+++ b/docs/source/manual/arch_lang/annotate_vpr_arch.rst
@@ -94,7 +94,7 @@ For subtile port merge support (see an illustrative example in :numref:`fig_subt
 
 For global port support:
 
-.. note:: If you choose to route the global signal through the global port network, you should set the ``--clock_modeling ideal`` when running VPR.
+.. note:: If you choose to route the global signal through the global port network, you should set the ``--clock_modeling ideal`` when running VPR. In such case, VPR will still reserve an I/O for the global signals without any routing traces. If you are minimize the I/O for your FPGA, please take the number of reserved I/Os into account!
 
 - ``name="<string>"`` is the port name to appear in the top-level FPGA fabric.
 

--- a/docs/source/manual/file_formats/clock_network.rst
+++ b/docs/source/manual/file_formats/clock_network.rst
@@ -3,7 +3,7 @@
 Clock Network (.xml)
 --------------------
 
-.. note:: If you choose to route the global signal through the programmable network, you should set the ``--clock_modeling ideal`` when running VPR.
+.. note:: If you choose to route the global signal through the programmable network, you should set the ``--clock_modeling ideal`` when running VPR. In such case, VPR will still reserve an I/O for the global signals without any routing traces. If you are minimize the I/O for your FPGA, please take the number of reserved I/Os into account!
 
 The XML-based clock network description language is used to describe 
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
Suggested by @ruck314 , add notes about the ``clock_modeling`` option in VPR to guide users when mapping global signals.
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
