### PR TITLE
Now create_directory() API has an option to disable verbose mode

### DIFF
--- a/libs/libopenfpgautil/src/openfpga_digest.cpp
+++ b/libs/libopenfpgautil/src/openfpga_digest.cpp
@@ -166,7 +166,8 @@ static bool create_dir_path(const std::string& dir_path, const bool& verbose) {
  * This function will try to create all the parent directory before
  * creating the last level.
  ********************************************************************/
-static bool rec_create_dir_path(const std::string& dir_path, const bool& verbose) {
+static bool rec_create_dir_path(const std::string& dir_path,
+                                const bool& verbose) {
   /* Give up if the path is empty */
   if (true == dir_path.empty()) {
     VTR_LOG_WARN("Directory path is empty and nothing will be created.\n");
@@ -202,7 +203,8 @@ static bool rec_create_dir_path(const std::string& dir_path, const bool& verbose
     std::string sub_dir = dir_path.substr(0, pos);
 
     /* Turn on verbose output only for the last position: the leaf directory */
-    if (false == create_dir_path(sub_dir, (&pos == &slash_pos.back()) && verbose)) {
+    if (false ==
+        create_dir_path(sub_dir, (&pos == &slash_pos.back()) && verbose)) {
       return false;
     }
   }
@@ -217,8 +219,7 @@ static bool rec_create_dir_path(const std::string& dir_path, const bool& verbose
  * Strongly recommend to use the recursive way, as it can maximum
  * guarantee the success in creation of directories
  ********************************************************************/
-void create_directory(const std::string& dir_path,
-                      const bool& recursive,
+void create_directory(const std::string& dir_path, const bool& recursive,
                       const bool& verbose) {
   std::string formatted_dir_path = format_dir_path(dir_path);
   bool status = false;

--- a/libs/libopenfpgautil/src/openfpga_digest.h
+++ b/libs/libopenfpgautil/src/openfpga_digest.h
@@ -22,8 +22,7 @@ std::string find_path_file_name(const std::string& file_name);
 
 std::string find_path_dir_name(const std::string& file_name);
 
-void create_directory(const std::string& dir_path,
-                      const bool& recursive = true,
+void create_directory(const std::string& dir_path, const bool& recursive = true,
                       const bool& verbose = true);
 
 bool write_space_to_file(std::fstream& fp, const size_t& num_space);


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations:
- The create_directory() API is widely use in OpenFPGA and related projects. It can recursively create directories as ``mkdir -p``. In addition, it throws warning when the directory path already exists.  See an example,

```
Warning 92: Directory 'home/path1' already exists. Will overwrite content
```

This could be annoying when the developers are expecting the overwriting behavior. It causes the log file of openfpga to be very long.

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:

The API ``create_directory()`` now have two default arguments

```
// Now the two default arguments are set to true if not specified. But developers can choose to disable them in their context
void create_directory(const std::string& dir_path,
                                  const bool& recursive = true,
                                  const bool& verbose = true);
```

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
