### PR TITLE
Remove quicklogic plugins removal command which only works on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,6 @@ if (OPENFPGA_WITH_YOSYS)
         add_custom_target(
             yosys ALL
             # add step to remove the 'built-in' quicklogic plugins code in yosys
-            COMMAND rm -rf techlibs/quicklogic
             COMMAND $(MAKE) config-gcc
             COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys


### PR DESCRIPTION
Removed command to delete quicklogic plugins from Yosys build process.

> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #2382 
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, OpenFPGA has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Remove Linux-only CMake commands to support Windows build

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
