### PR TITLE
Fix code and CMake for Windows/macOS cross-platform builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,10 @@ set(WITH_PARMYS OFF CACHE BOOL "Enable Yosys as elaborator and parmys-plugin as 
 # TCL file/lib required to link with SWIG generated wrapper
 if (OPENFPGA_WITH_SWIG)
 #Find Tcl
-  find_package(TCL REQUIRED)
+  find_package(TCL)
+  if(NOT TCL_FOUND)
+    message(FATAL_ERROR "TCL not found. Please install TCL development headers (e.g. tcl8.6-dev).")
+  endif()
   message(STATUS "TCL_INCLUDE_PATH: ${TCL_INCLUDE_PATH}")
   message(STATUS "TCL_LIBRARY: ${TCL_LIBRARY}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,9 @@ set(WITH_PARMYS OFF CACHE BOOL "Enable Yosys as elaborator and parmys-plugin as 
 # TCL file/lib required to link with SWIG generated wrapper
 if (OPENFPGA_WITH_SWIG)
 #Find Tcl
-  include(FindTCL)
-  message(STATUS "tcl.h path is : ${TCL_INCLUDE_PATH}")
-  message(STATUS "libtcl.so path is : ${TCL_LIBRARY}") 
+  find_package(TCL REQUIRED)
+  message(STATUS "TCL_INCLUDE_PATH: ${TCL_INCLUDE_PATH}")
+  message(STATUS "TCL_LIBRARY: ${TCL_LIBRARY}")
 
 #Find SWIG
   find_package(SWIG 3.0 REQUIRED)

--- a/libs/libini/CMakeLists.txt
+++ b/libs/libini/CMakeLists.txt
@@ -6,12 +6,15 @@ file(GLOB_RECURSE LIB_HEADERS src/*.h)
 files_to_dirs(LIB_HEADERS LIB_INCLUDE_DIRS)
 
 #Create the library
-add_library(libini STATIC
-            ${LIB_HEADERS})
-target_link_libraries(libini)
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
+    add_library(libini INTERFACE
+                ${LIB_HEADERS})
+else()
+    add_library(libini INTERFACE)
+endif()
 
-target_include_directories(libini PUBLIC ${LIB_INCLUDE_DIRS})
-set_target_properties(libini PROPERTIES PREFIX "" LINKER_LANGUAGE CXX)
+target_include_directories(libini INTERFACE ${LIB_INCLUDE_DIRS})
+set_target_properties(libini PROPERTIES PREFIX "")
 
 install(TARGETS libini
         DESTINATION bin

--- a/libs/libopenfpgashell/src/base/shell.tpp
+++ b/libs/libopenfpgashell/src/base/shell.tpp
@@ -3,6 +3,7 @@
  ********************************************************************/
 #include <fstream>
 #include <algorithm>
+#include <cstring>
 
 /* Headers from vtrutil library */
 #include "vtr_log.h"

--- a/openfpga/src/base/openfpga_basic.cpp
+++ b/openfpga/src/base/openfpga_basic.cpp
@@ -18,10 +18,10 @@
  */
 #if defined(_WIN32) || defined(WIN32)
 #ifndef WIFEXITED
-#define WIFEXITED(status) (((status) & 0x7f) == 0)
+#define WIFEXITED(status) (((status)&0x7f) == 0)
 #endif
 #ifndef WEXITSTATUS
-#define WEXITSTATUS(status) (((status) & 0xff00) >> 8)
+#define WEXITSTATUS(status) (((status)&0xff00) >> 8)
 #endif
 #endif
 

--- a/openfpga/src/base/openfpga_basic.cpp
+++ b/openfpga/src/base/openfpga_basic.cpp
@@ -9,6 +9,22 @@
 #include "command_exit_codes.h"
 #include "openfpga_title.h"
 
+/*
+ * WIFEXITED and WEXITSTATUS are POSIX macros from <sys/wait.h> used to
+ * interpret the return value of system(). They are not available on Windows.
+ * On Windows, system() returns the exit code directly from cmd.exe,
+ * so we provide equivalent shims here.
+ * See: https://pubs.opengroup.org/onlinepubs/009695399/functions/waitpid.html
+ */
+#if defined(_WIN32) || defined(WIN32)
+#ifndef WIFEXITED
+#define WIFEXITED(status) (((status) & 0x7f) == 0)
+#endif
+#ifndef WEXITSTATUS
+#define WEXITSTATUS(status) (((status) & 0xff00) >> 8)
+#endif
+#endif
+
 /* begin namespace openfpga */
 namespace openfpga {
 


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: Continuation of PR #2437 by coolbreeze413 (split into code-only changes as requested by reviewer @tangxifan)
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
PR #2437 introduced Windows and macOS build support but was requested to be split into two PRs:
1. **PR1 (this PR)**: Code and CMake fixes that enable cross-platform compilation
2. PR2 (to follow): CI workflow and VTR submodule changes

> #### What does this pull request change?

**1. `CMakeLists.txt` — Fix TCL discovery**
- Replace `include(FindTCL)` with `find_package(TCL REQUIRED)` for proper cross-platform TCL discovery
- Clean up status messages to use consistent variable names (`TCL_INCLUDE_PATH`, `TCL_LIBRARY`) instead of hardcoded references to `tcl.h` and `libtcl.so`

**2. `libs/libini/CMakeLists.txt` — Fix header-only library type**
- Change `libini` from `STATIC` to `INTERFACE` library (it contains only `ini.h`, no source files)
- Add cmake version check: `INTERFACE` libraries support source files only in cmake >= 3.19
- Remove unnecessary `target_link_libraries()` and `LINKER_LANGUAGE CXX` (not applicable to INTERFACE targets)
- Change `PUBLIC` to `INTERFACE` for include directories (required for INTERFACE libraries)

**3. `libs/libopenfpgashell/src/base/shell.tpp` — Add missing include**
- Add `#include <cstring>` needed for string functions (`strcmp`, `memcpy`, etc.)
- Required by MSVC and some strict GCC configurations where `<cstring>` is not transitively included

**4. `openfpga/src/base/openfpga_basic.cpp` — Add Windows POSIX macro shims**
- Add `WIFEXITED` and `WEXITSTATUS` macro definitions guarded by `#if defined(_WIN32) || defined(WIN32)`
- These are POSIX macros from `<sys/wait.h>` used to interpret the return value of `system()`, not available on Windows
- Guard uses both `_WIN32` (MinGW/GCC) and `WIN32` (MSVC) for broad compiler coverage
- Inner `#ifndef` guards prevent redefinition if provided by a platform header
- Reference: https://pubs.opengroup.org/onlinepubs/009695399/functions/waitpid.html

> ### Which part of the code base require a change
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.

### Testing performed
- CMake configure verified on macOS (cmake 4.3.1) — TCL discovered correctly
- CMake configure + full build verified on Windows (MSYS2 MinGW64, GCC 14.2.0) — all 4 changes compile successfully
- No changes to Linux behavior (all Windows guards are `#if defined(_WIN32)`, INTERFACE library is backward compatible)

### Attribution
Based on code changes from PR #2437 by @coolbreeze413. Split as suggested by reviewer @tangxifan: this PR contains only code/CMake fixes. CI workflow and VTR submodule changes will follow in a separate PR.