### PR TITLE
Enable Ccache in CI and Yosys by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -664,10 +664,10 @@ jobs:
             cc: gcc-11
             cxx: g++-11
             cmake_flags: "-DOPENFPGA_WITH_YOSYS=OFF"
-          - name: "Build w/o Yosys plugin (Ubuntu 22.04)"
+          - name: "Build w/o Yosys Slang (Ubuntu 22.04)"
             cc: gcc-11
             cxx: g++-11
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS_PLUGIN=OFF"
+            cmake_flags: "-DOPENFPGA_WITH_SLANG=OFF"
           - name: "Build w/o test (Ubuntu 22.04)"
             cc: gcc-11
             cxx: g++-11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             cxx: g++
             os: MINGW64
             prefix: mingw64
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=ON -DOPENFPGA_WITH_SLANG=OFF"
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=OFF -DOPENFPGA_WITH_SLANG=OFF"
     defaults:
       run:
         # This ensures all 'run' steps use the MSYS2 bash shell by default
@@ -208,7 +208,7 @@ jobs:
             cxx: g++
             os: MINGW64
             prefix: mingw64
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS=OFF -DWITH_ABC=OFF"
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=OFF -DOPENFPGA_WITH_SLANG=OFF"
     defaults:
       run:
         # This ensures all 'run' steps use the MSYS2 bash shell by default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             cxx: g++
             os: MINGW64
             prefix: mingw64
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=ON -OPENFPGA_WITH_SLANG=OFF"
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=ON -DOPENFPGA_WITH_SLANG=OFF"
     defaults:
       run:
         # This ensures all 'run' steps use the MSYS2 bash shell by default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             cxx: g++
             os: MINGW64
             prefix: mingw64
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS=OFF -DWITH_ABC=OFF"
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=ON"
     defaults:
       run:
         # This ensures all 'run' steps use the MSYS2 bash shell by default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             cxx: g++
             os: MINGW64
             prefix: mingw64
-            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=ON"
+            cmake_flags: "-DOPENFPGA_WITH_YOSYS=ON -DWITH_ABC=ON -OPENFPGA_WITH_SLANG=OFF"
     defaults:
       run:
         # This ensures all 'run' steps use the MSYS2 bash shell by default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ concurrency:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
-  MAKEFLAGS: "-j8"
   DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
   # (Boolean) Setting this value to True, will force linux tet always
   IGNORE_DOCKER_TEST: ${{ secrets.IGNORE_DOCKER_TEST }}
@@ -606,11 +605,18 @@ jobs:
           ${CXX} --version
 
       - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
 
       - name: Build
         shell: bash
         run: |
-          make all BUILD_TYPE=$BUILD_TYPE
+           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+           make all BUILD_TYPE=$BUILD_TYPE -j${{ steps.cpu-cores.outputs.count}}
 
       - name: Clear error log
         if: ${{ failure() }}
@@ -701,11 +707,18 @@ jobs:
           ${CXX} --version
 
       - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
 
       - name: Build
         shell: bash
         run: |
-          make all BUILD_TYPE=$BUILD_TYPE CMAKE_FLAGS="${{ matrix.config.cmake_flags }}"
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          make all BUILD_TYPE=$BUILD_TYPE CMAKE_FLAGS="${{ matrix.config.cmake_flags }}" -j${{ steps.cpu-cores.outputs.count}}
 
   centos_support:
     needs: change_detect
@@ -740,12 +753,19 @@ jobs:
           ${CXX} --version
 
       - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
 
       - name: Build
         shell: bash
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           git config --global --add safe.directory '*'
-          make all BUILD_TYPE=$BUILD_TYPE 
+          make all BUILD_TYPE=$BUILD_TYPE  -j${{ steps.cpu-cores.outputs.count}}
 
   # Support 24.04
   ubuntu_support:
@@ -787,11 +807,18 @@ jobs:
           python3 --version
   
       - uses: hendrikmuhs/ccache-action@v1.2
-  
+        with:
+          key: ${{ github.job }}
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
+
       - name: Build
         shell: bash
         run: |
-          make all BUILD_TYPE=$BUILD_TYPE 
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          make all BUILD_TYPE=$BUILD_TYPE -j${{ steps.cpu-cores.outputs.count}} 
 
       - name: Quick Test
         shell: bash
@@ -813,7 +840,6 @@ jobs:
             cc: gcc-13
             cxx: g++-13
             build_type: debug
-            cores: 4
     # Define the steps to run the build job
     env:
       CC: ${{ matrix.config.cc }}
@@ -841,11 +867,18 @@ jobs:
           python3 --version
 
       - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
 
       - name: Build
         shell: bash
         run: |
-          make all BUILD_TYPE=${{ matrix.config.build_type }} -j ${{ matrix.config.cores }}
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          make all BUILD_TYPE=${{ matrix.config.build_type }} -j${{ steps.cpu-cores.outputs.count}}
 
       - name: Quick Test
         shell: bash
@@ -865,7 +898,6 @@ jobs:
             cc: gcc-11
             cxx: g++-11
             build_type: release
-            cores: 4
     # Define the steps to run the build job
     env:
       CC: ${{ matrix.config.cc }}
@@ -892,11 +924,18 @@ jobs:
           ${CXX} --version
 
       - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
 
       - name: Build
         shell: bash
         run: |
-          make all BUILD_TYPE=${{ matrix.config.build_type }} -j ${{ matrix.config.cores }} CMAKE_FLAGS="-DOPENFPGA_ENABLE_STRICT_COMPILE=ON"
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          make all BUILD_TYPE=${{ matrix.config.build_type }} -j${{ steps.cpu-cores.outputs.count}} CMAKE_FLAGS="-DOPENFPGA_ENABLE_STRICT_COMPILE=ON"
 
       - name: Quick Test
         shell: bash
@@ -942,13 +981,20 @@ jobs:
           ${CXX} --version
 
       - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v3
+        id: cpu-cores
 
       - name: Build
         shell: bash
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make checkout
-          make prebuild BUILD_TYPE=$BUILD_TYPE INSTALL_DOC=OFF
-          make installer BUILD_TYPE=$BUILD_TYPE INSTALL_DOC=OFF
+          make prebuild BUILD_TYPE=$BUILD_TYPE INSTALL_DOC=OFF -j${{ steps.cpu-cores.outputs.count}}
+          make installer BUILD_TYPE=$BUILD_TYPE INSTALL_DOC=OFF -j${{ steps.cpu-cores.outputs.count}}
 
   docker_distribution:
     name: Build docker image for distribution

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,41 @@ if(CXX_COMPILER_SUPPORTS_-Wimplicit-fallthrough=0)
     target_compile_options(libpugixml PRIVATE "-Wimplicit-fallthrough=0")
 endif()
 
+# Only patch abc makefile on Msys2 where linker complains
+# Find the Python 3 interpreter
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+if (DEFINED ENV{MSYSTEM})
+    set(PY_PATCH_ABC_MAKEFILE "${CMAKE_CURRENT_SOURCE_DIR}/dev/patch_abc_makefile.py")
+    set(ABC_MAKEFILE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/yosys/abc")
+    set(ABC_MAKEFILE_FPATH "Makefile")
+    set(ABC_MAKEFILE_PATCH_FPATH "Makefile.patched")
+    message(STATUS "Patching ${ABC_MAKEFILE_DIR}/${ABC_MAKEFILE_FPATH}")
+    add_custom_command(
+        OUTPUT ${ABC_MAKEFILE_PATCH_FPATH}
+        COMMAND "${Python3_EXECUTABLE}" "${PY_PATCH_ABC_MAKEFILE}" "${ABC_MAKEFILE_FPATH}"
+        COMMAND ${CMAKE_COMMAND} -E touch ${ABC_MAKEFILE_PATCH_FPATH}
+        COMMENT "Apply sed patch to ${ABC_MAKEFILE_DIR}/${ABC_MAKEFILE_FPATH} for long linker command fix"
+        DEPENDS "${PY_PATCH_ABC_MAKEFILE}"
+        VERBATIM
+        WORKING_DIRECTORY "${ABC_MAKEFILE_DIR}"
+    )
+    add_custom_target(patch_abc_makefile ALL DEPENDS ${ABC_MAKEFILE_PATCH_FPATH})
+endif()
+
+# Once Yosys adapts to CMake. This will be much simplified
+# Yosys build options
+set(YOSYS_CONFIG_OPTION "config-gcc" CACHE STRING "Yosys configuration on environment") 
+set(YOSYS_BUILD_OPTION "ENABLE_CCACHE=1" CACHE STRING "Yosys build options") 
+set(SLANG_BUILD_CONFIG "" CACHE STRING "Slang build configuration on environment") 
+set(SLANG_CMAKE_CONFIG "" CACHE STRING "Slang cmake configuration on environment") 
+if (DEFINED ENV{MSYSTEM})
+    message(STATUS "Build Yosys in an MSYS2 MinGW-w64 environment")
+    set(YOSYS_CONFIG_OPTION "config-msys2-64" CACHE STRING "Yosys configuration on environment" FORCE) 
+    set(YOSYS_BUILD_OPTION "ENABLE_THREADS=0 ENABLE_CCACHE=1" CACHE STRING "Yosys build options on environment" FORCE) 
+    set(SLANG_BUILD_CONFIG "-Wl,--exclude-all-symbols" CACHE STRING "Slang build configuration on environment" FORCE) 
+    set(SLANG_CMAKE_CONFIG "" CACHE STRING "Slang cmake configuration on environment") 
+endif() 
+
 # we will check if yosys already exist. if not then build it
 if (OPENFPGA_WITH_YOSYS STREQUAL "ON")
     if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys)
@@ -358,16 +393,20 @@ if (OPENFPGA_WITH_YOSYS STREQUAL "ON")
         add_custom_target(
             yosys ALL
             # add step to remove the 'built-in' quicklogic plugins code in yosys
-            COMMAND $(MAKE) config-gcc
-            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/
+            COMMAND $(MAKE) ${YOSYS_CONFIG_OPTION}
+            COMMAND $(MAKE) install PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/ ${YOSYS_BUILD_OPTION}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys
             COMMENT "Compile Yosys with given Makefile"
         )
+        # Add dependency on patched Makefile if on MinGW
+        if (DEFINED ENV{MSYSTEM})
+            add_dependencies(aa_yosys patch_abc_makefile)
+        endif()  
         # yosys compilation ends
         # yosys-plugins compilation starts
         add_custom_target(
             yosys-slang ALL
-            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang"
+            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang" ${SLANG_CMAKE_CONFIG}" LDFLAGS+="${SLANG_BUILD_CONFIG}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
             COMMENT "Compile Yosys-Slang with given Makefile"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,37 +406,14 @@ if (OPENFPGA_WITH_YOSYS STREQUAL "ON")
         # yosys-plugins compilation starts
         add_custom_target(
             yosys-slang ALL
-            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang" ${SLANG_CMAKE_CONFIG}" LDFLAGS+="${SLANG_BUILD_CONFIG}"
+            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang ${SLANG_CMAKE_CONFIG}" LDFLAGS+="${SLANG_BUILD_CONFIG}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
             COMMENT "Compile Yosys-Slang with given Makefile"
         )
         add_dependencies(yosys-slang yosys)
-
-        ## yosys-plugins compilation starts
-        #if (OPENFPGA_WITH_YOSYS_PLUGIN)
-        #    add_custom_target(
-        #        yosys-plugins ALL
-        #        COMMAND $(MAKE) install_ql-qlf YOSYS_PATH=${CMAKE_CURRENT_BINARY_DIR}/yosys EXTRA_FLAGS="-DPASS_NAME=synth_ql"
-        #        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-plugins
-        #        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
-        #        COMMENT "Compile Yosys-plugins with given Makefile"
-        #    )
-        #    add_dependencies(yosys-plugins yosys)
-        #endif()
     endif()
 endif()
-
-# run make to extract compiler options, linker options and list of source files
-#add_custom_target(
-#  yosys
-#  COMMAND make run
-#  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys
-#)
-
-# Add extra compilation flags to suppress warnings from some libraries/tools
-# Note that target_compile_options() *appends* to the current compilation options of
-# the specified target
 
 # For installer
 if (OPENFPGA_WITH_INSTALLER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,7 +379,7 @@ set(SLANG_CMAKE_CONFIG "" CACHE STRING "Slang cmake configuration on environment
 if (DEFINED ENV{MSYSTEM})
     message(STATUS "Build Yosys in an MSYS2 MinGW-w64 environment")
     set(YOSYS_CONFIG_OPTION "config-msys2-64" CACHE STRING "Yosys configuration on environment" FORCE) 
-    set(YOSYS_BUILD_OPTION "ENABLE_THREADS=0 ENABLE_CCACHE=1" CACHE STRING "Yosys build options on environment" FORCE) 
+    set(YOSYS_BUILD_OPTION "DISABLE_ABC_THREADS=1 ENABLE_CCACHE=1" CACHE STRING "Yosys build options on environment" FORCE) 
     set(SLANG_BUILD_CONFIG "-Wl,--exclude-all-symbols" CACHE STRING "Slang build configuration on environment" FORCE) 
     set(SLANG_CMAKE_CONFIG "" CACHE STRING "Slang cmake configuration on environment") 
 endif() 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ include(CheckCXXCompilerFlag)
 # Options
 ## General options
 option(OPENFPGA_WITH_YOSYS "Enable building Yosys" ON)
-option(OPENFPGA_WITH_YOSYS_PLUGIN "Enable building Yosys plugin" ON)
+option(OPENFPGA_WITH_SLANG "Enable building Yosys Slang plugin" ON)
 option(OPENFPGA_WITH_TEST "Enable testing build for codebase. Once enabled, make test can be run" ON)
 option(OPENFPGA_WITH_VERSION "Enable version always-up-to-date when building codebase. Disable only when you do not care an accurate version number" ON)
 option(OPENFPGA_WITH_SWIG "Enable SWIG interface when building codebase. Disable when you do not need high-level interfaces, such as Tcl/Python" ON)
@@ -380,7 +380,7 @@ if (DEFINED ENV{MSYSTEM})
     message(STATUS "Build Yosys in an MSYS2 MinGW-w64 environment")
     set(YOSYS_CONFIG_OPTION "config-msys2-64" CACHE STRING "Yosys configuration on environment" FORCE) 
     set(YOSYS_BUILD_OPTION "DISABLE_ABC_THREADS=1 ENABLE_CCACHE=1" CACHE STRING "Yosys build options on environment" FORCE) 
-#    set(SLANG_BUILD_CONFIG "-Wl,--exclude-all-symbols" CACHE STRING "Slang build configuration on environment" FORCE) 
+    set(SLANG_BUILD_CONFIG "-Wl,--exclude-all-symbols" CACHE STRING "Slang build configuration on environment" FORCE) 
     set(SLANG_CMAKE_CONFIG "" CACHE STRING "Slang cmake configuration on environment") 
 endif() 
 
@@ -400,18 +400,20 @@ if (OPENFPGA_WITH_YOSYS STREQUAL "ON")
         )
         # Add dependency on patched Makefile if on MinGW
         if (DEFINED ENV{MSYSTEM})
-            add_dependencies(yosys patch_abc_makefile)
+          add_dependencies(yosys patch_abc_makefile)
         endif()  
         # yosys compilation ends
         # yosys-plugins compilation starts
-        add_custom_target(
-            yosys-slang ALL
-            COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang ${SLANG_CMAKE_CONFIG}" LDFLAGS+="${SLANG_BUILD_CONFIG}"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
-            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
-            COMMENT "Compile Yosys-Slang with given Makefile"
-        )
-        add_dependencies(yosys-slang yosys)
+        if (OPENFPGA_WITH_SLANG)
+          add_custom_target(
+              yosys-slang ALL
+              COMMAND $(MAKE) install YOSYS_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/ CMAKE_FLAGS+="-DPASS_NAME=read_slang ${SLANG_CMAKE_CONFIG}" LDFLAGS+="${SLANG_BUILD_CONFIG}"
+              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/yosys-slang
+              DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/yosys/bin/yosys
+              COMMENT "Compile Yosys-Slang with given Makefile"
+          )
+          add_dependencies(yosys-slang yosys)
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,7 @@ if (DEFINED ENV{MSYSTEM})
     message(STATUS "Build Yosys in an MSYS2 MinGW-w64 environment")
     set(YOSYS_CONFIG_OPTION "config-msys2-64" CACHE STRING "Yosys configuration on environment" FORCE) 
     set(YOSYS_BUILD_OPTION "DISABLE_ABC_THREADS=1 ENABLE_CCACHE=1" CACHE STRING "Yosys build options on environment" FORCE) 
-    set(SLANG_BUILD_CONFIG "-Wl,--exclude-all-symbols" CACHE STRING "Slang build configuration on environment" FORCE) 
+#    set(SLANG_BUILD_CONFIG "-Wl,--exclude-all-symbols" CACHE STRING "Slang build configuration on environment" FORCE) 
     set(SLANG_CMAKE_CONFIG "" CACHE STRING "Slang cmake configuration on environment") 
 endif() 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,7 +400,7 @@ if (OPENFPGA_WITH_YOSYS STREQUAL "ON")
         )
         # Add dependency on patched Makefile if on MinGW
         if (DEFINED ENV{MSYSTEM})
-            add_dependencies(aa_yosys patch_abc_makefile)
+            add_dependencies(yosys patch_abc_makefile)
         endif()  
         # yosys compilation ends
         # yosys-plugins compilation starts

--- a/dev/patch_abc_makefile.py
+++ b/dev/patch_abc_makefile.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Python equivalent of the CMake add_custom_command that patches the ABC Makefile
+for the long linker command fix.
+
+CMake context resolved:
+  MAKEFILE_INSERT_LINE = "@echo $(OBJ) > abc_objs.rsp"
+  ABC_MAKEFILE_PATCH_FPATH = "Makefile.patched" (sentinel, same dir as Makefile)
+
+Patches applied:
+  1. Find the two-line anchor block:
+         $(PROG): $(OBJ)
+         \t@echo "$(MSG_PREFIX)`...
+     and insert "\t@echo $(OBJ) > abc_objs.rsp" immediately after it.
+  2. On the next line after the insertion, replace '$^' with '@abc_objs.rsp'.
+  3. Touch Makefile.patched as a sentinel so CMake knows the patch was applied.
+
+Usage:
+  python3 patch_abc_makefile.py <path/to/Makefile>
+"""
+
+import sys
+import pathlib
+
+
+# ---------------------------------------------------------------------------
+# CMake variable values (resolved from CMake escape sequences)
+# ---------------------------------------------------------------------------
+MAKEFILE_INSERT_LINE = "@echo $(OBJ) > abc_objs.rsp"
+ABC_MAKEFILE_PATCH_FPATH = "Makefile.patched"
+
+# Two-line anchor after which the new line is inserted.
+# Trailing whitespace is ignored when matching.
+ANCHOR_LINES = (
+    "$(PROG): $(OBJ)",
+    '\t@echo "$(MSG_PREFIX)\`\` Building binary:" $(notdir $@)',
+)
+
+
+def find_anchor(lines: list[str]) -> int:
+    """
+    Return the 0-based index of the LAST line of the anchor block,
+    or -1 if the anchor is not found.
+    """
+    for i in range(len(lines) - 1):
+        if (
+            lines[i].rstrip() == ANCHOR_LINES[0]
+            and lines[i + 1].rstrip() == ANCHOR_LINES[1]
+        ):
+            return i + 1  # index of the second anchor line
+    return -1
+
+
+def apply_patch(makefile_path: str) -> None:
+    makefile = pathlib.Path(makefile_path).resolve()
+
+    if not makefile.exists():
+        print(f"Error: Makefile not found: {makefile}", file=sys.stderr)
+        sys.exit(1)
+
+    if not makefile.is_file():
+        print(f"Error: Path is not a file: {makefile}", file=sys.stderr)
+        sys.exit(1)
+
+    sentinel = makefile.parent / ABC_MAKEFILE_PATCH_FPATH
+    lines = makefile.read_text().splitlines(keepends=True)
+
+    # ------------------------------------------------------------------
+    # Command 1: insert MAKEFILE_INSERT_LINE after the anchor block
+    # ------------------------------------------------------------------
+    anchor_idx = find_anchor(lines)
+    if anchor_idx == -1:
+        print(
+            "Error: anchor block not found in Makefile:\n"
+            f"  {ANCHOR_LINES[0]!r}\n"
+            f"  {ANCHOR_LINES[1]!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    insert_at = anchor_idx + 1  # insert immediately after the anchor
+    lines.insert(insert_at, f"\t{MAKEFILE_INSERT_LINE}\n")
+    print(f"Inserted '{MAKEFILE_INSERT_LINE}' after line {anchor_idx + 1} (1-based)")
+
+    # ------------------------------------------------------------------
+    # Command 2: replace '$^' with '@abc_objs.rsp' on the line that now
+    # follows the newly inserted line (i.e. insert_at + 1, 0-based)
+    # ------------------------------------------------------------------
+    replace_idx = insert_at + 1
+    if replace_idx >= len(lines):
+        print(
+            f"Error: no line exists after insertion point (index {replace_idx}).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    original = lines[replace_idx]
+    patched = original.replace("$^", "@abc_objs.rsp")
+    if patched == original:
+        print(
+            f"Warning: '$^' not found on line {replace_idx + 1} (1-based); "
+            "no substitution made.",
+            file=sys.stderr,
+        )
+    lines[replace_idx] = patched
+
+    makefile.write_text("".join(lines))
+    print(f"Patched:  {makefile}")
+
+    # ------------------------------------------------------------------
+    # Command 3: touch sentinel so CMake sees OUTPUT as satisfied
+    # ------------------------------------------------------------------
+    sentinel.touch()
+    print(f"Sentinel: {sentinel}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(
+            f"Usage: {sys.argv[0]} <path/to/Makefile>\n"
+            f"  e.g. {sys.argv[0]} path/to/yosys/abc/Makefile",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    apply_patch(sys.argv[1])

--- a/docs/source/tutorials/getting_started/compile.rst
+++ b/docs/source/tutorials/getting_started/compile.rst
@@ -102,7 +102,7 @@ The following options are available for a custom build
 
   - ``DOPENFPGA_WITH_TEST=[ON|OFF]``: Enable/Disable the test build
   - ``DOPENFPGA_WITH_YOSYS=[ON|OFF]``: Enable/Disable the build of yosys. Note that when disabled, the build of yosys-plugin is also disabled
-  - ``DOPENFPGA_WITH_YOSYS_PLUGIN=[ON|OFF]``: Enable/Disable the build of yosys-plugin.
+  - ``DOPENFPGA_WITH_SLANG=[ON|OFF]``: Enable/Disable the build of yosys-plugin Slang. If disabled, system verilog will not be supported. By default, it is enabled.
   - ``DOPENFPGA_WITH_VERSION=[ON|OFF]``: Enable/Disable the build of version number. When disabled, version number will be displayed as an empty string.
   - ``DOPENFPGA_WITH_SWIG=[ON|OFF]``: Enable/Disable the build of SWIG, which is required for integrating to high-level interface.
   - ``OPENFPGA_ENABLE_STRICT_COMPILE=[ON|OFF]``: Specifies whether compiler warnings should be treated as errors (e.g. -Werror)
@@ -177,11 +177,11 @@ If your OS is Msys2 in Windows, we offer the script to install all the dependenc
 .. include:: win_msys2_mingw64.sh
   :code: shell
 
-Yosys build is not supported yet on Msys2. Please disable it during the build by adding to cmake flags (See details in :ref:`tutorial_compile_build_options`)
+Yosys Slang build is not supported yet on Msys2. Please disable it during the build by adding to cmake flags (See details in :ref:`tutorial_compile_build_options`)
 
 .. code-block::
 
-  make all CMAKE_FLAGS="-DOPENFPGA_WITH_YOSYS=OFF -DWITH_ABC=OFF"
+  make all CMAKE_FLAGS="-DOPENFPGA_WITH_SLANG=OFF"
 
 Instead, please use the prebuilt version of Yosys at 
 `mingw-w64-x86_64-yosys <https://packages.msys2.org/packages/mingw-w64-x86_64-yosys>`_.


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
- ccache is added to CI but may not be configured to work. It causes long build time on CI.
- Yosys has a ccache option but not yet enabled by default.This causes Yosys to be built from fresh each time.

>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:

- [x] Enable ccache on CI 
- [x] Now CI workflow auto detect the number of CPU cores for each machine and assign to make options
- [x] Enable ccache for Yosys build options
- [x] Now Msys2 build will automatically patch ABC makefile  
- [x] Enable ABC and Yosys in Msys2 build on CI

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [x] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
