### PR TITLE
update vtr to latest

### DIFF
--- a/openfpga/src/annotation/annotate_rr_graph.cpp
+++ b/openfpga/src/annotation/annotate_rr_graph.cpp
@@ -25,52 +25,53 @@ namespace openfpga {
 /*********************************************************************
  * Find a list of rr_nodes that locate at a side of a grid
  **********************************************************************/
-static std::vector<RRNodeId> openfpga_find_rr_graph_grid_nodes(const RRGraphView& rr_graph,
-                                               const DeviceGrid& device_grid,
-                                               const size_t& layer,
-                                               const int& x,
-                                               const int& y,
-                                               const e_rr_type& rr_type,
-                                               const e_side& side,
-                                               bool include_ignored_global_pins) {
-    std::vector<RRNodeId> indices;
+static std::vector<RRNodeId> openfpga_find_rr_graph_grid_nodes(
+  const RRGraphView& rr_graph, const DeviceGrid& device_grid,
+  const size_t& layer, const int& x, const int& y, const e_rr_type& rr_type,
+  const e_side& side, bool include_ignored_global_pins) {
+  std::vector<RRNodeId> indices;
 
-    VTR_ASSERT(rr_type == e_rr_type::IPIN || rr_type == e_rr_type::OPIN);
+  VTR_ASSERT(rr_type == e_rr_type::IPIN || rr_type == e_rr_type::OPIN);
 
-    /* Ensure that (x, y) is a valid location in grids */
-    if (size_t(x) > device_grid.width() - 1 || size_t(y) > device_grid.height() - 1) {
-        return indices;
-    }
-
-    /* Ensure we have a valid side */
-    VTR_ASSERT(side != NUM_2D_SIDES);
-
-    /* Find all the pins on the side of the grid */
-    t_physical_tile_loc tile_loc(x, y, layer);
-    int width_offset = device_grid.get_width_offset(tile_loc);
-    int height_offset = device_grid.get_height_offset(tile_loc);
-
-    for (int pin = 0; pin < device_grid.get_physical_type(tile_loc)->num_pins; ++pin) {
-        /* Skip those pins have been ignored during rr_graph build-up */
-        if (device_grid.get_physical_type(tile_loc)->is_ignored_pin[pin] && device_grid.get_physical_type(tile_loc)->is_pin_global[pin]) {
-            /* If specified, force to include all the ignored pins */
-            if (!include_ignored_global_pins) {
-                continue;
-            }
-        }
-        if (false == device_grid.get_physical_type(tile_loc)->pinloc[width_offset][height_offset][side][pin]) {
-            /* Not the pin on this side, we skip */
-            continue;
-        }
-
-        /* Try to find the rr node */
-        RRNodeId rr_node_index = rr_graph.node_lookup().find_node(layer, x, y, rr_type, pin, side);
-        if (rr_node_index != RRNodeId::INVALID()) {
-            indices.push_back(rr_node_index);
-        }
-    }
-
+  /* Ensure that (x, y) is a valid location in grids */
+  if (size_t(x) > device_grid.width() - 1 ||
+      size_t(y) > device_grid.height() - 1) {
     return indices;
+  }
+
+  /* Ensure we have a valid side */
+  VTR_ASSERT(side != NUM_2D_SIDES);
+
+  /* Find all the pins on the side of the grid */
+  t_physical_tile_loc tile_loc(x, y, layer);
+  int width_offset = device_grid.get_width_offset(tile_loc);
+  int height_offset = device_grid.get_height_offset(tile_loc);
+
+  for (int pin = 0; pin < device_grid.get_physical_type(tile_loc)->num_pins;
+       ++pin) {
+    /* Skip those pins have been ignored during rr_graph build-up */
+    if (device_grid.get_physical_type(tile_loc)->is_ignored_pin[pin] &&
+        device_grid.get_physical_type(tile_loc)->is_pin_global[pin]) {
+      /* If specified, force to include all the ignored pins */
+      if (!include_ignored_global_pins) {
+        continue;
+      }
+    }
+    if (false == device_grid.get_physical_type(tile_loc)
+                   ->pinloc[width_offset][height_offset][side][pin]) {
+      /* Not the pin on this side, we skip */
+      continue;
+    }
+
+    /* Try to find the rr node */
+    RRNodeId rr_node_index =
+      rr_graph.node_lookup().find_node(layer, x, y, rr_type, pin, side);
+    if (rr_node_index != RRNodeId::INVALID()) {
+      indices.push_back(rr_node_index);
+    }
+  }
+
+  return indices;
 }
 
 /* Returns true if the given OPIN node drives at least one CHANX/Y wire that

--- a/openfpga/src/annotation/annotate_rr_graph.cpp
+++ b/openfpga/src/annotation/annotate_rr_graph.cpp
@@ -22,6 +22,57 @@
 /* begin namespace openfpga */
 namespace openfpga {
 
+/*********************************************************************
+ * Find a list of rr_nodes that locate at a side of a grid
+ **********************************************************************/
+static std::vector<RRNodeId> openfpga_find_rr_graph_grid_nodes(const RRGraphView& rr_graph,
+                                               const DeviceGrid& device_grid,
+                                               const size_t& layer,
+                                               const int& x,
+                                               const int& y,
+                                               const e_rr_type& rr_type,
+                                               const e_side& side,
+                                               bool include_ignored_global_pins) {
+    std::vector<RRNodeId> indices;
+
+    VTR_ASSERT(rr_type == e_rr_type::IPIN || rr_type == e_rr_type::OPIN);
+
+    /* Ensure that (x, y) is a valid location in grids */
+    if (size_t(x) > device_grid.width() - 1 || size_t(y) > device_grid.height() - 1) {
+        return indices;
+    }
+
+    /* Ensure we have a valid side */
+    VTR_ASSERT(side != NUM_2D_SIDES);
+
+    /* Find all the pins on the side of the grid */
+    t_physical_tile_loc tile_loc(x, y, layer);
+    int width_offset = device_grid.get_width_offset(tile_loc);
+    int height_offset = device_grid.get_height_offset(tile_loc);
+
+    for (int pin = 0; pin < device_grid.get_physical_type(tile_loc)->num_pins; ++pin) {
+        /* Skip those pins have been ignored during rr_graph build-up */
+        if (device_grid.get_physical_type(tile_loc)->is_ignored_pin[pin] && device_grid.get_physical_type(tile_loc)->is_pin_global[pin]) {
+            /* If specified, force to include all the ignored pins */
+            if (!include_ignored_global_pins) {
+                continue;
+            }
+        }
+        if (false == device_grid.get_physical_type(tile_loc)->pinloc[width_offset][height_offset][side][pin]) {
+            /* Not the pin on this side, we skip */
+            continue;
+        }
+
+        /* Try to find the rr node */
+        RRNodeId rr_node_index = rr_graph.node_lookup().find_node(layer, x, y, rr_type, pin, side);
+        if (rr_node_index != RRNodeId::INVALID()) {
+            indices.push_back(rr_node_index);
+        }
+    }
+
+    return indices;
+}
+
 /* Returns true if the given OPIN node drives at least one CHANX/Y wire that
  * is a valid (non-passing) output track in the switch block. */
 static bool is_rr_opin_drive_gsb_track(const RRGraphView& rr_graph,
@@ -427,7 +478,7 @@ static RRGSB build_rr_gsb(const DeviceContext& vpr_device_ctx,
       continue;
     }
     /* Collect IPIN rr_nodes*/
-    temp_ipin_rr_nodes = find_rr_graph_grid_nodes(
+    temp_ipin_rr_nodes = openfpga_find_rr_graph_grid_nodes(
       vpr_device_ctx.rr_graph, vpr_device_ctx.grid, layer, ix, iy,
       e_rr_type::IPIN, ipin_rr_node_grid_side, include_clock);
     /* Fill the ipin nodes of RRGSB */


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
The API in rr_graph_view_util.cpp now exclude reset pins when include_clock is enabled. But it is required by the programmable clock architecture.

https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/3ac8a833409df847af086ceb747f7c78451dd97e/vpr/src/route/rr_graph_generation/tileable_rr_graph/rr_graph_view_util.cpp#L88-L139


>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
- [x] Added an improved version of the API in openfpga. Will update it in the VTR once validated in OpenFPGA's regression tests.



> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [x] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
