### PR TITLE
Include runtime dependencies for binaries in Installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,7 +505,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S .. -B . -DOPENFPGA_WITH_SWIG=OFF -DWITH_ABC=OFF -DOPENFPGA_WITH_YOSYS=OFF -DWGET="${{ env.CURL_PATH }}" -DOPENFPGA_INSTALL_DOC=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -DCMAKE_INSTALL_RPATH="${{ github.workspace }}/vcpkg" -S .. -B . -DOPENFPGA_WITH_SWIG=OFF -DWITH_ABC=OFF -DOPENFPGA_WITH_YOSYS=OFF -DWGET="${{ env.CURL_PATH }}" -DOPENFPGA_INSTALL_DOC=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build . --config Release --parallel ${{ steps.cpu-cores.outputs.count }}
           cpack --config CPackConfig.cmake -G IFW -DOPENFPGA_WITH_SWIG=OFF -DWITH_ABC=OFF -DOPENFPGA_WITH_YOSYS=OFF -DWGET="${{ env.CURL_PATH }}" -DOPENFPGA_INSTALL_DOC=OFF -C Release
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,12 @@ endif()
 
 # For installer
 if (OPENFPGA_WITH_INSTALLER)
+  # Disable automatic runtime dependency resolution on MSVC
+  # This prevents CPack from trying to include Windows API stub DLLs (api-ms-win-*.dll)
+  if (MSVC)
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS "")
+    set(CMAKE_INSTALL_DEBUG_LIBRARIES FALSE)
+  endif()
   include(OpenfpgaInstaller)
   include(OpenfpgaPackaging)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ include(FilesToDirs)
 include(SwigLib)
 # Auto-enable ccache
 include(SupportCcache)
+# Auto deps 
+include(DeployDependencies)
 
 if (${CMAKE_VERSION} VERSION_GREATER "3.8")
     #For cmake >= 3.9 INTERPROCEDURAL_OPTIMIZATION behaviour we need to explicitly

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,12 +437,6 @@ endif()
 
 # For installer
 if (OPENFPGA_WITH_INSTALLER)
-  # Disable automatic runtime dependency resolution on MSVC
-  # This prevents CPack from trying to include Windows API stub DLLs (api-ms-win-*.dll)
-  if (MSVC)
-    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS "")
-    set(CMAKE_INSTALL_DEBUG_LIBRARIES FALSE)
-  endif()
   include(OpenfpgaInstaller)
   include(OpenfpgaPackaging)
 endif()

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -83,6 +83,9 @@ function(deploy_runtime_dependencies)
         if (MSVC)
             set(DEPLOY_ADDITIONAL_DIRECTORIES
                 ${TCL_BIN_DIR}
+                # Magicsplat Tcl/Tk default installation locations
+                "C:/Program Files/Tcl/bin"
+                "C:/Program Files (x86)/Tcl/bin"
             )
         endif()
     else()

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -50,6 +50,18 @@ function(deploy_runtime_dependencies)
             ".*[Ss]ystem32.*"
             ".*[Ss]ys[Ww][Oo][Ww]64.*"
         )
+        # Fetch paths from environment variables if set, otherwise fallback to defaults
+        if(DEFINED ENV{TCL_ROOT})
+            set(TCL_BIN_DIR "$ENV{TCL_ROOT}/bin")
+        else()
+            set(TCL_BIN_DIR "C:/Tcl/bin")
+        endif()
+        
+        if(DEFINED ENV{MSYSTEM_PREFIX})
+            set(MSYS_BIN_DIR "$ENV{MSYSTEM_PREFIX}/bin")
+        else()
+            set(MSYS_BIN_DIR "C:/msys64/mingw64/bin")
+        endif()
         # Robust check for MSYS2 contexts (MinGW, UCRT64, Clang64)
         if(MINGW OR CYGWIN OR DEFINED ENV{MSYSTEM})
             get_filename_component(MINGW_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
@@ -60,11 +72,18 @@ function(deploy_runtime_dependencies)
             )
             set(DEPLOY_ADDITIONAL_DIRECTORIES
                 ${MINGW_BIN_DIR}
-                "/mingw64/bin"
+                ${MSYS_BIN_DIR}
+                ${TCL_BIN_DIR}      # Adds ActiveTcl (C:/Tcl/bin)
                 "/usr/bin"
             )
-        message(STATUS "DeployDependencies: Added default Mingw64 search directories")
-
+            message(STATUS "DeployDependencies: Added default Mingw64 search directories")
+        endif()
+        # In MSVC build, tcl is installed by ActiveTcl
+        # Adds ActiveTcl (C:/Tcl/bin)
+        if (MSVC)
+            set(DEPLOY_ADDITIONAL_DIRECTORIES
+                ${TCL_BIN_DIR}
+            )
         endif()
     else()
         set(SYSTEM_EXCLUDE_REGEXES

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -37,8 +37,8 @@ function(deploy_runtime_dependencies)
             "^[Aa][Pp][Pp][Dd][Aa][Tt][Aa]"
             "api-ms-win-.*"           # Exclude Windows API forwarder DLLs
             "ext-ms-win-.*"           # Exclude extended Windows API DLLs
-            "^/Windows/"              # Exclude Windows system directories
-            "^/WINDOWS/"
+            "/Windows/"              # Exclude Windows system directories
+            "/WINDOWS/"
             "^kernel32\\.dll"
             "user32\\.dll"
             "msvcrt\\.dll"
@@ -97,8 +97,8 @@ function(deploy_runtime_dependencies)
     install(RUNTIME_DEPENDENCY_SET ${DEPLOY_RUNTIME_SET_NAME}
         DESTINATION ${DEPLOY_DESTINATION}
         COMPONENT ${DEPLOY_COMPONENT}
-        PRE_EXCLUDE_REGEXES "${SYSTEM_EXCLUDE_REGEXES}"
-        POST_EXCLUDE_REGEXES "${SYSTEM_EXCLUDE_REGEXES}"
+        PRE_EXCLUDE_REGEXES ${SYSTEM_EXCLUDE_REGEXES}
+        POST_EXCLUDE_REGEXES ${SYSTEM_EXCLUDE_REGEXES}
         DIRECTORIES ${DEPLOY_ADDITIONAL_DIRECTORIES}
     )
 endfunction()

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -1,0 +1,96 @@
+## This function is the create runtime dependency set for an executable
+# Call the custom module function 
+# Pass multiple targets cleanly to your updated module
+#deploy_runtime_dependencies(
+#    TARGETS app_one app_two
+#    DESTINATION bin
+#    COMPONENT Runtime
+#    RUNTIME_SET_NAME project_shared_deps # Optional customization parameter
+#)
+cmake_minimum_required(VERSION 3.21)
+
+function(deploy_runtime_dependencies)
+    set(options)
+    set(oneValueArgs COMPONENT DESTINATION RUNTIME_SET_NAME)
+    set(multiValueArgs TARGETS ADDITIONAL_DIRECTORIES)
+    cmake_parse_arguments(DEPLOY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Validate mandatory inputs
+    if(NOT DEPLOY_TARGETS)
+        message(FATAL_ERROR "deploy_runtime_dependencies: TARGETS argument is required.")
+    endif()
+    if(NOT DEPLOY_COMPONENT)
+        set(DEPLOY_COMPONENT "Runtime")
+    endif()
+    if(NOT DEPLOY_DESTINATION)
+        set(DEPLOY_DESTINATION "bin")
+    endif()
+    # Define a default namespace for the shared library bucket if none provided
+    if(NOT DEPLOY_RUNTIME_SET_NAME)
+        set(DEPLOY_RUNTIME_SET_NAME "global_runtime_deps")
+    endif()
+
+    # 1. Platform-specific regexes to ignore core Operating System libraries
+    if(WIN32)
+        set(SYSTEM_EXCLUDE_REGEXES
+            "^[Cc]:/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]"
+            "^[Aa][Pp][Pp][Dd][Aa][Tt][Aa]"
+            "api-ms-win"
+            "ext-ms-win"
+            "kernel32\\.dll"
+            "user32\\.dll"
+            "msvcrt\\.dll"
+            "ucrtbase\\.dll"
+            "ntdll\\.dll"
+        )
+        # Robust check for MSYS2 contexts (MinGW, UCRT64, Clang64)
+        if(MINGW OR CYGWIN OR DEFINED ENV{MSYSTEM})
+            list(APPEND SYSTEM_EXCLUDE_REGEXES
+                "^/usr/lib"
+                "^/lib"
+                "msys-.*\\.dll"
+            )
+        endif()
+    else()
+        set(SYSTEM_EXCLUDE_REGEXES
+            "^/usr/lib"
+            "^/lib"
+            "^/lib64"
+        )
+    endif()
+
+    # 2. Iterate through each target to configure RPATH and target installations
+    foreach(current_target ${DEPLOY_TARGETS})
+        if(NOT TARGET ${current_target})
+            message(FATAL_ERROR "deploy_runtime_dependencies: '${current_target}' is not a valid CMake target.")
+        endif()
+
+        # Automatic RPATH handling for Unix-like platforms
+        if(UNIX AND NOT APPLE)
+            set_target_properties(${current_target} PROPERTIES 
+                INSTALL_RPATH "$ORIGIN"
+            )
+        endif()
+
+        # Install target binary and append dependencies to the shared pool
+        install(TARGETS ${current_target}
+            RUNTIME 
+                DESTINATION ${DEPLOY_DESTINATION}
+                COMPONENT ${DEPLOY_COMPONENT}
+            LIBRARY 
+                DESTINATION ${DEPLOY_DESTINATION}
+                COMPONENT ${DEPLOY_COMPONENT}
+            RUNTIME_DEPENDENCY_SET ${DEPLOY_RUNTIME_SET_NAME}
+        )
+    endforeach()
+
+    # 3. Process and install the single unified dependency pool
+    install(RUNTIME_DEPENDENCY_SET ${DEPLOY_RUNTIME_SET_NAME}
+        DESTINATION ${DEPLOY_DESTINATION}
+        COMPONENT ${DEPLOY_COMPONENT}
+        PRE_EXCLUDE_REGEXES "${SYSTEM_EXCLUDE_REGEXES}"
+        POST_EXCLUDE_REGEXES "${SYSTEM_EXCLUDE_REGEXES}"
+        DIRECTORIES ${DEPLOY_ADDITIONAL_DIRECTORIES}
+    )
+endfunction()
+

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -52,17 +52,34 @@ function(deploy_runtime_dependencies)
         )
         # Robust check for MSYS2 contexts (MinGW, UCRT64, Clang64)
         if(MINGW OR CYGWIN OR DEFINED ENV{MSYSTEM})
+            get_filename_component(MINGW_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
             list(APPEND SYSTEM_EXCLUDE_REGEXES
                 "^/usr/lib"
                 "^/lib"
                 "msys-.*"
             )
+            set(DEPLOY_ADDITIONAL_DIRECTORIES
+                ${MINGW_BIN_DIR}
+                "/mingw64/bin"
+                "/usr/bin"
+            )
+        message(STATUS "DeployDependencies: Added default Mingw64 search directories")
+
         endif()
     else()
         set(SYSTEM_EXCLUDE_REGEXES
             "^/usr/lib"
             "^/lib"
             "^/lib64"
+            "libc\\.so.*"
+            "libpthread\\.so.*"
+            "libglib-.*"
+            "libdl\\.so.*"
+            "libm\\.so.*"
+            "librt\\.so.*"
+            "libstdc\\+\\+\\.so.*"
+            "libgcc_s\\.so.*"
+            "libz\\.so.*$"
         )
     endif()
 

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -35,8 +35,10 @@ function(deploy_runtime_dependencies)
         set(SYSTEM_EXCLUDE_REGEXES
             "^[Cc]:/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]"
             "^[Aa][Pp][Pp][Dd][Aa][Tt][Aa]"
-            "^api-ms-.*"
-            "^ext-ms-.*"
+            "api-ms-win-.*"           # Exclude Windows API forwarder DLLs
+            "ext-ms-win-.*"           # Exclude extended Windows API DLLs
+            "^/Windows/"              # Exclude Windows system directories
+            "^/WINDOWS/"
             "^kernel32\\.dll"
             "user32\\.dll"
             "msvcrt\\.dll"
@@ -47,6 +49,8 @@ function(deploy_runtime_dependencies)
             ".*[Pp]dm[Uu]tilities.*\\.dll"
             ".*[Ww][Tt][Dd][Ss][Ee][Nn][Ss][Oo][Rr].*\\.dll"
             "^[Cc]:/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/.*" # Ignores all standard Windows system DLL
+            ".*system32.*"
+            ".*SysWOW64.*"
         )
         # Robust check for MSYS2 contexts (MinGW, UCRT64, Clang64)
         if(MINGW OR CYGWIN OR DEFINED ENV{MSYSTEM})

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -37,27 +37,25 @@ function(deploy_runtime_dependencies)
             "^[Aa][Pp][Pp][Dd][Aa][Tt][Aa]"
             "api-ms-win-.*"           # Exclude Windows API forwarder DLLs
             "ext-ms-win-.*"           # Exclude extended Windows API DLLs
-            "/Windows/"              # Exclude Windows system directories
-            "/WINDOWS/"
-            "^kernel32\\.dll"
-            "user32\\.dll"
-            "msvcrt\\.dll"
-            "ucrtbase\\.dll"
-            "ntdll\\.dll"
-            ".*[Aa]zure[Aa]ttest.*\\.dll"
-            ".*[Hh]vsi[Ff]ile.*\\.dll"
-            ".*[Pp]dm[Uu]tilities.*\\.dll"
-            ".*[Ww][Tt][Dd][Ss][Ee][Nn][Ss][Oo][Rr].*\\.dll"
-            "^[Cc]:/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/.*" # Ignores all standard Windows system DLL
-            ".*system32.*"
-            ".*SysWOW64.*"
+            "/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/"              # Exclude Windows system directories
+            "kernel32"
+            "user32"
+            "msvcrt"
+            "ucrtbase"
+            "ntdll"
+            ".*[Aa]zure[Aa]ttest.*"
+            ".*[Hh]vsi[Ff]ile.*"
+            ".*[Pp]dm[Uu]tilities.*"
+            ".*[Ww][Tt][Dd][Ss][Ee][Nn][Ss][Oo][Rr].*"
+            ".*[Ss]ystem32.*"
+            ".*[Ss]ys[Ww][Oo][Ww]64.*"
         )
         # Robust check for MSYS2 contexts (MinGW, UCRT64, Clang64)
         if(MINGW OR CYGWIN OR DEFINED ENV{MSYSTEM})
             list(APPEND SYSTEM_EXCLUDE_REGEXES
                 "^/usr/lib"
                 "^/lib"
-                "msys-.*\\.dll"
+                "msys-.*"
             )
         endif()
     else()
@@ -72,6 +70,12 @@ function(deploy_runtime_dependencies)
     foreach(current_target ${DEPLOY_TARGETS})
         if(NOT TARGET ${current_target})
             message(FATAL_ERROR "deploy_runtime_dependencies: '${current_target}' is not a valid CMake target.")
+        endif()
+
+        # Skip installation for static libraries as they don't have runtime dependencies
+        get_target_property(target_type ${current_target} TYPE)
+        if(target_type STREQUAL "STATIC_LIBRARY")
+            continue()
         endif()
 
         # Automatic RPATH handling for Unix-like platforms
@@ -102,4 +106,3 @@ function(deploy_runtime_dependencies)
         DIRECTORIES ${DEPLOY_ADDITIONAL_DIRECTORIES}
     )
 endfunction()
-

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -8,9 +8,6 @@
 #    RUNTIME_SET_NAME project_shared_deps # Optional customization parameter
 #)
 cmake_minimum_required(VERSION 3.21)
-# Manually force the behavior in older project structures
-# This can be removed once cmake version requirements is >4.3
-cmake_policy(SET CMP0207 NEW)
 
 function(deploy_runtime_dependencies)
     set(options)

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -74,13 +74,13 @@ function(deploy_runtime_dependencies)
 
         # Install target binary and append dependencies to the shared pool
         install(TARGETS ${current_target}
+            RUNTIME_DEPENDENCY_SET ${DEPLOY_RUNTIME_SET_NAME}
             RUNTIME 
                 DESTINATION ${DEPLOY_DESTINATION}
                 COMPONENT ${DEPLOY_COMPONENT}
             LIBRARY 
                 DESTINATION ${DEPLOY_DESTINATION}
                 COMPONENT ${DEPLOY_COMPONENT}
-            RUNTIME_DEPENDENCY_SET ${DEPLOY_RUNTIME_SET_NAME}
         )
     endforeach()
 

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -35,9 +35,9 @@ function(deploy_runtime_dependencies)
         set(SYSTEM_EXCLUDE_REGEXES
             "^[Cc]:/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]"
             "^[Aa][Pp][Pp][Dd][Aa][Tt][Aa]"
-            "api-ms-win"
-            "ext-ms-win"
-            "kernel32\\.dll"
+            "^api-ms-.*"
+            "^ext-ms-.*"
+            "^kernel32\\.dll"
             "user32\\.dll"
             "msvcrt\\.dll"
             "ucrtbase\\.dll"

--- a/cmake/modules/DeployDependencies.cmake
+++ b/cmake/modules/DeployDependencies.cmake
@@ -8,6 +8,9 @@
 #    RUNTIME_SET_NAME project_shared_deps # Optional customization parameter
 #)
 cmake_minimum_required(VERSION 3.21)
+# Manually force the behavior in older project structures
+# This can be removed once cmake version requirements is >4.3
+cmake_policy(SET CMP0207 NEW)
 
 function(deploy_runtime_dependencies)
     set(options)
@@ -42,6 +45,11 @@ function(deploy_runtime_dependencies)
             "msvcrt\\.dll"
             "ucrtbase\\.dll"
             "ntdll\\.dll"
+            ".*[Aa]zure[Aa]ttest.*\\.dll"
+            ".*[Hh]vsi[Ff]ile.*\\.dll"
+            ".*[Pp]dm[Uu]tilities.*\\.dll"
+            ".*[Ww][Tt][Dd][Ss][Ee][Nn][Ss][Oo][Rr].*\\.dll"
+            "^[Cc]:/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/.*" # Ignores all standard Windows system DLL
         )
         # Robust check for MSYS2 contexts (MinGW, UCRT64, Clang64)
         if(MINGW OR CYGWIN OR DEFINED ENV{MSYSTEM})

--- a/cmake/modules/OpenfpgaPackaging.cmake
+++ b/cmake/modules/OpenfpgaPackaging.cmake
@@ -49,6 +49,17 @@ if (CPACK_GENERATOR STREQUAL "IFW")
   set(CPACK_IFW_PACKAGE_LOGO ${CMAKE_CURRENT_SOURCE_DIR}/docs/source/overview/figures/OpenFPGA_logo.png)
 endif() 
 
+# Skip or exclude system API-sets from runtime dependency resolution
+if(WIN32) 
+  set(CPACK_GET_RUNTIME_DEPENDENCIES_EXCLUDE_REGEX "api-ms-.;ext-ms-.")
+endif()
+# Disable automatic runtime dependency resolution on MSVC
+# This prevents CPack from trying to include Windows API stub DLLs (api-ms-win-*.dll)
+if (MSVC)
+  set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS "")
+  set(CMAKE_INSTALL_DEBUG_LIBRARIES FALSE)
+endif()
+
 # Variables must be defined before including the CPACK module
 set(CPACK_BUILD_CONFIG ${CMAKE_BUILD_TYPE})
 include(CPack)

--- a/openfpga/CMakeLists.txt
+++ b/openfpga/CMakeLists.txt
@@ -78,7 +78,7 @@ if (OPENFPGA_USES_IPO)
 endif()
 
 deploy_runtime_dependencies(
-    TARGET libopenfpga openfpga
+    TARGETS libopenfpga openfpga
     DESTINATION bin
     COMPONENT openfpga_package
     RUNTIME_SET_NAME openfpga_shared_deps

--- a/openfpga/CMakeLists.txt
+++ b/openfpga/CMakeLists.txt
@@ -77,7 +77,9 @@ if (OPENFPGA_USES_IPO)
     set_property(TARGET openfpga APPEND PROPERTY LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
 endif()
 
-install(TARGETS libopenfpga openfpga
-        DESTINATION bin
-        COMPONENT openfpga_package
+deploy_runtime_dependencies(
+    TARGET libopenfpga openfpga
+    DESTINATION bin
+    COMPONENT openfpga_package
+    RUNTIME_SET_NAME openfpga_shared_deps
 )


### PR DESCRIPTION

> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
Currently, OpenFPGA has the following limitations: 

- Shared libraries are headaches for distributing OpenFPGA installer. In some computers, users are not allowed to install required. Therefore, it is strongly needed to include shared libraries in the installer
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
This PR improves in the following aspects:
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

- [x] Add a cmake module to automatically identify, collect and include runtime dependencies for an executable which is an install target.
- [x] The runtime dependency inclusion is applied to Msys2 and Linux installers. 
- [x] Now the runtime dependencies are included for openfpga executable 
- [ ] Now the runtime dependencies are included for all the utility executables

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
