### PR TITLE
Fix stale contributor guidelines link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ A list of related publications can be found [here](https://openfpga.readthedocs.
 
 ## Contributing to OpenFPGA
 
-Please read the [contributor guidelines](https://openfpga.readthedocs.io/en/master/dev_manual/contributor_guide/) if you would like to contribute to OpenFPGA.
+Please read the [contributor guidelines](https://openfpga.readthedocs.io/en/master/dev_manual/contributor_guidelines/) if you would like to contribute to OpenFPGA.


### PR DESCRIPTION
Fixes #1534

> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: #1534
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> The README links to a stale contributor guidelines URL (`contributor_guide`).
> The correct Read the Docs page is `contributor_guidelines`.

> #### What does this pull request change?
> - Updates the contributor guidelines link in README.md to the correct URL:
>   https://openfpga.readthedocs.io/en/master/dev_manual/contributor_guidelines/

> ### Which part of the code base require a change
> - [ ] VPR
> - [ ] Tileable routing architecture generator
> - [ ] OpenFPGA libraries
> - [ ] FPGA-Verilog
> - [ ] FPGA-Bitstream
> - [ ] FPGA-SDC
> - [ ] FPGA-SPICE
> - [ ] Flow scripts
> - [ ] Architecture library
> - [ ] Cell library
> - [x] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.