### PR TITLE
repack: create one routing net per primitive output pin

### DIFF
--- a/openfpga/src/repack/lb_router.cpp
+++ b/openfpga/src/repack/lb_router.cpp
@@ -92,6 +92,7 @@ bool LbRouter::is_route_success(const LbRRGraph& lb_rr_graph) const {
   /* Validate if the rr_graph is the one we used to initialize the router */
   VTR_ASSERT(true == matched_lb_rr_graph(lb_rr_graph));
 
+  bool success = true;
   for (const LbRRNodeId& inode : lb_rr_graph.nodes()) {
     if (routing_status_[inode].occ > lb_rr_graph.node_capacity(inode)) {
       VTR_LOGV(lb_rr_graph.node_pb_graph_pin(inode),
@@ -99,11 +100,11 @@ bool LbRouter::is_route_success(const LbRRGraph& lb_rr_graph) const {
                "capacity '%ld'!\n",
                lb_rr_graph.node_pb_graph_pin(inode)->to_string().c_str(),
                routing_status_[inode].occ, lb_rr_graph.node_capacity(inode));
-      return false;
+      success = false;
     }
   }
 
-  return true;
+  return success;
 }
 
 LbRouter::t_trace* LbRouter::find_node_in_rt(t_trace* rt,

--- a/openfpga/src/repack/repack.cpp
+++ b/openfpga/src/repack/repack.cpp
@@ -869,16 +869,11 @@ static void add_lb_router_nets(
         (AtomNetId::INVALID() == pb->pb_route[pin].atom_net_id)) {
       continue;
     }
-    /* Get the driver pb pin id, it must be valid */
-    int source_pb_pin_id = pb->pb_route[pin].driver_pb_pin_id;
-    if (UNDEFINED == source_pb_pin_id) {
-      continue;
-    }
-    VTR_ASSERT(UNDEFINED != source_pb_pin_id &&
-               source_pb_pin_id < pb->pb_graph_node->total_pb_pins);
-    /* Find the corresponding pb_graph_pin and its physical pb_graph_pin */
-    t_pb_graph_pin* source_pb_pin =
-      pb_graph_pin_lookup_from_index[source_pb_pin_id];
+
+    /* Consider this pin as the potential source pin of a net */
+    t_pb_graph_pin* source_pb_pin = pb_graph_pin_lookup_from_index[pin];
+    VTR_ASSERT(nullptr != source_pb_pin);
+
     /* Skip the pin from top-level pb_graph_node, they have been handled already
      */
     if (source_pb_pin->parent_node == pb->pb_graph_node) {
@@ -890,6 +885,20 @@ static void add_lb_router_nets(
       continue;
     }
     if (true != is_primitive_pb_type(source_pb_pin->parent_node->pb_type)) {
+      continue;
+    }
+
+    /* Skip dangling outputs: there is no terminal to route to.
+     * Warn unconditionally: a driven net always reaches at least one terminal,
+     * so an empty sink list points at an inconsistent pb_route rather than at a
+     * legitimately unused output.
+     */
+    if (pb->pb_route[pin].sink_pb_pin_ids.empty()) {
+      VTR_LOG_WARN(
+        "Primitive output pin '%s' carries net '%s' but drives nothing inside "
+        "the cluster. Skip routing it.\n",
+        source_pb_pin->to_string().c_str(),
+        atom_ctx.netlist().net_name(pb->pb_route[pin].atom_net_id).c_str());
       continue;
     }
 


### PR DESCRIPTION
When repack collects the nets to route inside a cluster, it scans every occupied pin and picks up that pin's driver, so a driver pin is visited once per fan-out rather than once per driver — while the terminal list is rebuilt from the driver on every visit. A primitive output that drives two pins directly, such as a DSP accumulator output feeding both the tile output pin and the ALU feedback input, is therefore handed to the intra-tile router twice with an identical source and an identical terminal list. Both copies claim the same nodes, occupancy reaches 2 against a capacity of 1 on every node along the route, and repacking aborts with overuse that rip-up and reroute cannot resolve. This walks the primitive output pins directly so that exactly one net is created per driver, and skips outputs whose pb_route entry carries no sink (unreachable under the old iteration, and an assertion failure in `add_lb_router_net_to_route()` otherwise). A second commit makes `is_route_success()` report every overused pin instead of returning at the first one, which is what made the extent of the problem visible.

Verified on a MAC design that previously failed in repack: the routing nets registered for the affected cluster drop from 315 to 283, the resulting set of nets is identical to the old set with the duplicates removed, and the full flow now completes and writes a bitstream. Also checked against five soft-logic cases that already worked (a LUT feeding two LUTs in the same CLB, a LUT output used both registered and unregistered, and shift-register chains with and without an intermediate tap): net counts and net sets are unchanged in every cluster.